### PR TITLE
Add verifier support for Vector skin and fix sidebar toggle

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-// {{Wikipedia:USync |repo=https://github.com/alex-o-748/citation-checker-script |ref=refs/heads/main|path=main.js}}
+// {{Wikipedia:USync |repo=https://github.com/alex-o-748/citation-checker-script |ref=refs/heads/fix-verify-sidebar-option-Vw3lV|path=main.js}}
 //Inspired by  User:Polygnotus/Scripts/AI_Source_Verification.js
 //Inspired by  User:Phlsph7/SourceVerificationAIAssistant.js
 

--- a/main.js
+++ b/main.js
@@ -310,7 +310,7 @@
                     background: ${this.getCurrentColor()};
                     opacity: 0.5;
                 }
-                #ca-verifier {
+                #ca-verifier, #t-verifier {
                     display: none;
                 }
                 #ca-verifier a, #t-verifier a {
@@ -338,7 +338,8 @@
                 .verifier-sidebar-hidden #source-verifier-sidebar {
                     display: none;
                 }
-                .verifier-sidebar-hidden #ca-verifier {
+                .verifier-sidebar-hidden #ca-verifier,
+                .verifier-sidebar-hidden #t-verifier {
                     display: list-item !important;
                 }
                 .reference:hover {
@@ -495,6 +496,9 @@
                 switch(skin) {
                     case 'vector-2022':
                         portletId = 'p-associated-pages';
+                        break;
+                    case 'vector':
+                        portletId = 'p-cactions';
                         break;
                     case 'monobook':
                         portletId = 'p-cactions';


### PR DESCRIPTION
## Summary
This PR extends verifier functionality to support the Vector skin and improves the sidebar toggle behavior by ensuring both CA and T verifier elements are properly hidden/shown together.

## Key Changes
- **Sidebar CSS selectors**: Updated `#ca-verifier` selector to include `#t-verifier` in both the default hidden state and the sidebar-hidden visible state, ensuring both verifier elements are toggled consistently
- **Vector skin support**: Added a new case for the 'vector' skin to use the 'p-cactions' portlet ID, matching the behavior already implemented for 'monobook'

## Implementation Details
- The CSS changes ensure that when the verifier sidebar is toggled, both the CA verifier and T verifier elements are shown/hidden together as a unit
- The Vector skin now properly maps to the correct portlet location ('p-cactions') for verifier placement, bringing feature parity with other supported skins

https://claude.ai/code/session_01BHRxRNSWh9LsvBfdDttvGv