### PR TITLE
Enable verifier tab on Draft namespace in addition to Article

### DIFF
--- a/main.js
+++ b/main.js
@@ -488,7 +488,7 @@
         }
         
         createVerifierTab() {
-            if (typeof mw !== 'undefined' && mw.config.get('wgNamespaceNumber') === 0) {
+            if (typeof mw !== 'undefined' && [0, 118].includes(mw.config.get('wgNamespaceNumber'))) {
                 const skin = mw.config.get('skin');
                 let portletId;
                 
@@ -1359,7 +1359,7 @@ ${sourceText}`;
         }
     }
     
-    if (typeof mw !== 'undefined' && mw.config.get('wgNamespaceNumber') === 0) {
+    if (typeof mw !== 'undefined' && [0, 118].includes(mw.config.get('wgNamespaceNumber'))) {
         mw.loader.using(['mediawiki.util', 'mediawiki.api', 'oojs-ui-core', 'oojs-ui-widgets', 'oojs-ui-windows']).then(function() {
             $(function() {
                 new WikipediaSourceVerifier();


### PR DESCRIPTION
## Summary
Updated the namespace check logic to enable the Wikipedia Source Verifier tool on both the Article namespace (0) and Draft namespace (118), expanding its availability beyond just main article pages.

## Key Changes
- Modified the namespace validation in `createVerifierTab()` method to check if the current namespace is either 0 (Article) or 118 (Draft) using an array inclusion check
- Updated the initialization condition at the module level to use the same expanded namespace check, ensuring the verifier tool loads on Draft pages

## Implementation Details
Changed the namespace check from a strict equality comparison (`=== 0`) to an array-based inclusion check (`[0, 118].includes()`), allowing the verifier functionality to work on both article and draft pages. This change was applied consistently in two locations where namespace validation occurs.

https://claude.ai/code/session_015h8VvtKg3Qmry454dj2DGV