### PR TITLE
Fix Verify tab placement and alignment across skins

### DIFF
--- a/main.js
+++ b/main.js
@@ -342,6 +342,17 @@
                 .verifier-sidebar-hidden #t-verifier {
                     display: list-item !important;
                 }
+                .skin-vector-2022 #p-associated-pages #t-verifier {
+                    font-size: inherit;
+                    margin: 0;
+                    padding: 0;
+                }
+                .skin-vector-2022 #p-associated-pages #t-verifier a {
+                    font-size: inherit !important;
+                    padding: 0 !important;
+                    margin: 0;
+                    display: inline-block;
+                }
                 .reference:hover {
                     background-color: #e6f3ff;
                     cursor: pointer;
@@ -498,7 +509,7 @@
                         portletId = 'p-associated-pages';
                         break;
                     case 'vector':
-                        portletId = 'p-cactions';
+                        portletId = 'p-namespaces';
                         break;
                     case 'monobook':
                         portletId = 'p-cactions';


### PR DESCRIPTION
- Move Vector 2010 tab from p-cactions (More menu) to p-namespaces so it appears next to Article and Talk tabs, matching the intent for Vector 2022's p-associated-pages placement
- Add Vector 2022-specific CSS to align the Verify tab properly with the Article and Talk tabs in p-associated-pages

https://claude.ai/code/session_01LmogBXyDndbm1G2TKZfpTT