### PR TITLE
Fix Verify tab not appearing on first visit or after clearing storage

### DIFF
--- a/main.js
+++ b/main.js
@@ -46,7 +46,7 @@
             }
             this.currentProvider = storedProvider || 'publicai';
             this.sidebarWidth = localStorage.getItem('verifier_sidebar_width') || '400px';
-            this.isVisible = localStorage.getItem('verifier_sidebar_visible') !== 'false';
+            this.isVisible = localStorage.getItem('verifier_sidebar_visible') === 'true';
             this.buttons = {};
             this.activeClaim = null;
             this.activeSource = null;


### PR DESCRIPTION
The default for isVisible was true (null !== 'false') which meant hideSidebar() never ran on init, so the verifier-sidebar-hidden class was never added to body, and the tab stayed permanently display:none. Change to === 'true' so it defaults to false, ensuring hideSidebar() runs and the tab becomes visible.

https://claude.ai/code/session_01LmogBXyDndbm1G2TKZfpTT