### PR TITLE
Fix CSS selectors so Verify tab actually becomes visible

### DIFF
--- a/main.js
+++ b/main.js
@@ -331,14 +331,14 @@
                     padding: 8px;
                     border-radius: 4px;
                 }
-                .verifier-sidebar-hidden body {
+                body.verifier-sidebar-hidden {
                     margin-right: 0 !important;
                 }
-                .verifier-sidebar-hidden #source-verifier-sidebar {
+                body.verifier-sidebar-hidden #source-verifier-sidebar {
                     display: none;
                 }
-                .verifier-sidebar-hidden #ca-verifier,
-                .verifier-sidebar-hidden #t-verifier {
+                body.verifier-sidebar-hidden #ca-verifier,
+                body.verifier-sidebar-hidden #t-verifier {
                     display: block !important;
                 }
                 .reference:hover {


### PR DESCRIPTION
The selectors used `.verifier-sidebar-hidden body` (descendant) but the class is added to document.body itself. Changed to `body.verifier-sidebar-hidden` so the rules match when the class is on the body element directly.

https://claude.ai/code/session_01LmogBXyDndbm1G2TKZfpTT