### PR TITLE
Fix dark theme selector: use single-dash skin-theme-clientpref-os

### DIFF
--- a/main.js
+++ b/main.js
@@ -492,134 +492,134 @@
 
                 /* Support auto dark mode via OS preference */
                 @media (prefers-color-scheme: dark) {
-                    html.skin-theme-clientpref--os #source-verifier-sidebar {
+                    html.skin-theme-clientpref-os #source-verifier-sidebar {
                         background: #1a1a2e !important;
                         color: #e0e0e0 !important;
                         border-left-color: ${this.getCurrentColor()} !important;
                         box-shadow: -2px 0 8px rgba(0,0,0,0.4) !important;
                     }
-                    html.skin-theme-clientpref--os #source-verifier-sidebar * {
+                    html.skin-theme-clientpref-os #source-verifier-sidebar * {
                         color: inherit;
                     }
-                    html.skin-theme-clientpref--os #verifier-sidebar-header {
+                    html.skin-theme-clientpref-os #verifier-sidebar-header {
                         background: ${this.getCurrentColor()} !important;
                         color: white !important;
                     }
-                    html.skin-theme-clientpref--os #verifier-sidebar-header * {
+                    html.skin-theme-clientpref-os #verifier-sidebar-header * {
                         color: white !important;
                     }
-                    html.skin-theme-clientpref--os #verifier-sidebar-content {
+                    html.skin-theme-clientpref-os #verifier-sidebar-content {
                         background: #1a1a2e !important;
                         color: #e0e0e0 !important;
                     }
-                    html.skin-theme-clientpref--os #verifier-provider-info {
+                    html.skin-theme-clientpref-os #verifier-provider-info {
                         background: #2a2a3e !important;
                         color: #b0b0c0 !important;
                         border-color: #3a3a4e !important;
                     }
-                    html.skin-theme-clientpref--os #verifier-provider-info.free-provider {
+                    html.skin-theme-clientpref-os #verifier-provider-info.free-provider {
                         background: #1a2e1a !important;
                         color: #6ecf6e !important;
                     }
-                    html.skin-theme-clientpref--os #verifier-claim-section h4,
-                    html.skin-theme-clientpref--os #verifier-source-section h4,
-                    html.skin-theme-clientpref--os #verifier-results h4 {
+                    html.skin-theme-clientpref-os #verifier-claim-section h4,
+                    html.skin-theme-clientpref-os #verifier-source-section h4,
+                    html.skin-theme-clientpref-os #verifier-results h4 {
                         color: ${this.getCurrentColor()} !important;
                         filter: brightness(1.3);
                     }
-                    html.skin-theme-clientpref--os #verifier-claim-text,
-                    html.skin-theme-clientpref--os #verifier-source-text {
+                    html.skin-theme-clientpref-os #verifier-claim-text,
+                    html.skin-theme-clientpref-os #verifier-source-text {
                         background: #2a2a3e !important;
                         border-color: #3a3a4e !important;
                         color: #e0e0e0 !important;
                     }
-                    html.skin-theme-clientpref--os #verifier-verdict {
+                    html.skin-theme-clientpref-os #verifier-verdict {
                         color: #e0e0e0 !important;
                     }
-                    html.skin-theme-clientpref--os #verifier-verdict.supported {
+                    html.skin-theme-clientpref-os #verifier-verdict.supported {
                         background: #1a3a1a !important;
                         color: #6ecf6e !important;
                         border-color: #2a5a2a !important;
                     }
-                    html.skin-theme-clientpref--os #verifier-verdict.partially-supported {
+                    html.skin-theme-clientpref-os #verifier-verdict.partially-supported {
                         background: #3a3a1a !important;
                         color: #e0c060 !important;
                         border-color: #5a5a2a !important;
                     }
-                    html.skin-theme-clientpref--os #verifier-verdict.not-supported {
+                    html.skin-theme-clientpref-os #verifier-verdict.not-supported {
                         background: #3a1a1a !important;
                         color: #e06060 !important;
                         border-color: #5a2a2a !important;
                     }
-                    html.skin-theme-clientpref--os #verifier-verdict.source-unavailable {
+                    html.skin-theme-clientpref-os #verifier-verdict.source-unavailable {
                         background: #2a2a2e !important;
                         color: #a0a0a8 !important;
                         border-color: #3a3a3e !important;
                     }
-                    html.skin-theme-clientpref--os #verifier-comments {
+                    html.skin-theme-clientpref-os #verifier-comments {
                         background: #2a2a3e !important;
                         border-color: #3a3a4e !important;
                         color: #e0e0e0 !important;
                     }
-                    html.skin-theme-clientpref--os .verifier-error {
+                    html.skin-theme-clientpref-os .verifier-error {
                         color: #ff8080 !important;
                         background: #3a1a1a !important;
                         border-color: #5a2a2a !important;
                     }
-                    html.skin-theme-clientpref--os .reference:hover {
+                    html.skin-theme-clientpref-os .reference:hover {
                         background-color: rgba(100, 149, 237, 0.15) !important;
                     }
-                    html.skin-theme-clientpref--os .claim-highlight {
+                    html.skin-theme-clientpref-os .claim-highlight {
                         background-color: #3a3a1a !important;
                     }
-                    html.skin-theme-clientpref--os #verifier-source-textarea-container textarea {
+                    html.skin-theme-clientpref-os #verifier-source-textarea-container textarea {
                         background: #2a2a3e !important;
                         color: #e0e0e0 !important;
                         border-color: #3a3a4e !important;
                     }
-                    html.skin-theme-clientpref--os #source-verifier-sidebar .oo-ui-dropdownWidget {
+                    html.skin-theme-clientpref-os #source-verifier-sidebar .oo-ui-dropdownWidget {
                         background: #2a2a3e !important;
                         border-color: #3a3a4e !important;
                     }
-                    html.skin-theme-clientpref--os #source-verifier-sidebar .oo-ui-dropdownWidget .oo-ui-labelElement-label {
+                    html.skin-theme-clientpref-os #source-verifier-sidebar .oo-ui-dropdownWidget .oo-ui-labelElement-label {
                         color: #e0e0e0 !important;
                     }
-                    html.skin-theme-clientpref--os #source-verifier-sidebar .oo-ui-buttonElement-button {
+                    html.skin-theme-clientpref-os #source-verifier-sidebar .oo-ui-buttonElement-button {
                         background: #2a2a3e !important;
                         color: #e0e0e0 !important;
                         border-color: #3a3a4e !important;
                     }
-                    html.skin-theme-clientpref--os #source-verifier-sidebar .oo-ui-buttonElement-button .oo-ui-labelElement-label {
+                    html.skin-theme-clientpref-os #source-verifier-sidebar .oo-ui-buttonElement-button .oo-ui-labelElement-label {
                         color: #e0e0e0 !important;
                     }
-                    html.skin-theme-clientpref--os #source-verifier-sidebar .oo-ui-flaggedElement-primary.oo-ui-flaggedElement-progressive .oo-ui-buttonElement-button {
+                    html.skin-theme-clientpref-os #source-verifier-sidebar .oo-ui-flaggedElement-primary.oo-ui-flaggedElement-progressive .oo-ui-buttonElement-button {
                         background: ${this.getCurrentColor()} !important;
                         color: white !important;
                         border-color: ${this.getCurrentColor()} !important;
                     }
-                    html.skin-theme-clientpref--os #source-verifier-sidebar .oo-ui-flaggedElement-primary.oo-ui-flaggedElement-progressive .oo-ui-labelElement-label {
+                    html.skin-theme-clientpref-os #source-verifier-sidebar .oo-ui-flaggedElement-primary.oo-ui-flaggedElement-progressive .oo-ui-labelElement-label {
                         color: white !important;
                     }
-                    html.skin-theme-clientpref--os #source-verifier-sidebar .oo-ui-flaggedElement-destructive .oo-ui-buttonElement-button {
+                    html.skin-theme-clientpref-os #source-verifier-sidebar .oo-ui-flaggedElement-destructive .oo-ui-buttonElement-button {
                         color: #e06060 !important;
                     }
-                    html.skin-theme-clientpref--os #source-verifier-sidebar .oo-ui-iconElement-icon {
+                    html.skin-theme-clientpref-os #source-verifier-sidebar .oo-ui-iconElement-icon {
                         filter: invert(0.8);
                     }
-                    html.skin-theme-clientpref--os #source-verifier-sidebar .oo-ui-indicatorElement-indicator {
+                    html.skin-theme-clientpref-os #source-verifier-sidebar .oo-ui-indicatorElement-indicator {
                         filter: invert(0.8);
                     }
-                    html.skin-theme-clientpref--os #source-verifier-sidebar .oo-ui-menuSelectWidget {
+                    html.skin-theme-clientpref-os #source-verifier-sidebar .oo-ui-menuSelectWidget {
                         background: #2a2a3e !important;
                         border-color: #3a3a4e !important;
                     }
-                    html.skin-theme-clientpref--os #source-verifier-sidebar .oo-ui-optionWidget {
+                    html.skin-theme-clientpref-os #source-verifier-sidebar .oo-ui-optionWidget {
                         color: #e0e0e0 !important;
                     }
-                    html.skin-theme-clientpref--os #source-verifier-sidebar .oo-ui-optionWidget-highlighted {
+                    html.skin-theme-clientpref-os #source-verifier-sidebar .oo-ui-optionWidget-highlighted {
                         background: #3a3a5e !important;
                     }
-                    html.skin-theme-clientpref--os #source-verifier-sidebar .oo-ui-optionWidget-selected {
+                    html.skin-theme-clientpref-os #source-verifier-sidebar .oo-ui-optionWidget-selected {
                         background: ${this.getCurrentColor()} !important;
                         color: white !important;
                     }


### PR DESCRIPTION
The CSS selectors used skin-theme-clientpref--os (double dash) but Wikipedia's actual class name is skin-theme-clientpref-os (single dash), so none of the @media dark mode rules were matching.

https://claude.ai/code/session_01Mmr9U8jRxmUJevKzp7KMzb