### PR TITLE
Add page number extraction for PDF source content fetching

### DIFF
--- a/main.js
+++ b/main.js
@@ -902,7 +902,8 @@
                 this.updateButtonVisibility();
                 this.updateStatus('Fetching source content...');
                 const fetchId = ++this.currentFetchId;
-                const sourceInfo = await this.fetchSourceContent(refUrl);
+                const pageNum = this.extractPageNumber(refElement);
+                const sourceInfo = await this.fetchSourceContent(refUrl, pageNum);
 
                 if (fetchId !== this.currentFetchId) {
                     return;
@@ -916,22 +917,33 @@
 
                 this.activeSource = sourceInfo;
                 const sourceElement = document.getElementById('verifier-source-text');
-                
+
                 const urlMatch = sourceInfo.match(/Source URL: (https?:\/\/[^\s\n]+)/);
                 const contentFetched = sourceInfo.includes('Source Content:');
-                
+                const pdfMatch = sourceInfo.match(/PDF: (\d+) pages/);
+                const pageMatch = sourceInfo.match(/\(extracted page (\d+)\)/);
+
                 if (urlMatch) {
+                    let statusHtml;
+                    if (contentFetched && pdfMatch) {
+                        const pageInfo = pageMatch
+                            ? ` (page ${pageMatch[1]} of ${pdfMatch[1]})`
+                            : ` (${pdfMatch[1]} pages)`;
+                        statusHtml = `<span style="color: #2e7d32;">✓ PDF content extracted${pageInfo}</span>`;
+                    } else if (contentFetched) {
+                        statusHtml = '<span style="color: #2e7d32;">✓ Content fetched successfully</span>';
+                    } else {
+                        statusHtml = '<em>Content will be fetched by AI during verification.</em>';
+                    }
                     sourceElement.innerHTML = `
                         <strong>Source URL:</strong><br>
                         <a href="${urlMatch[1]}" target="_blank" style="word-break: break-all;">${urlMatch[1]}</a><br><br>
-                        ${contentFetched 
-                            ? '<span style="color: #2e7d32;">✓ Content fetched successfully</span>' 
-                            : '<em>Content will be fetched by AI during verification.</em>'}
+                        ${statusHtml}
                     `;
                 } else {
                     sourceElement.textContent = sourceInfo;
                 }
-                
+
                 this.updateButtonVisibility();
                 this.updateStatus(contentFetched ? 'Source fetched. Ready to verify.' : 'Ready to verify claim against source');
                 
@@ -1082,15 +1094,53 @@
             }
             return links[0].href;
         }
+
+        extractPageNumber(refElement) {
+            const href = refElement.getAttribute('href');
+            if (!href || !href.startsWith('#')) return null;
+
+            const refTarget = document.getElementById(href.substring(1));
+            if (!refTarget) return null;
+
+            const text = refTarget.textContent;
+            // Match patterns like "p. 42", "pp. 42-43", "p.42", "page 42", "pages 42–43"
+            const match = text.match(/\bp(?:p|ages?)?\.?\s*(\d+)/i);
+            if (match) {
+                console.log('[CitationVerifier] Extracted page number:', match[1]);
+                return parseInt(match[1], 10);
+            }
+            return null;
+        }
         
-        async fetchSourceContent(url) {
+        async fetchSourceContent(url, pageNum) {
             try {
-                const proxyUrl = `https://publicai-proxy.alaexis.workers.dev/?fetch=${encodeURIComponent(url)}`;
+                let proxyUrl = `https://publicai-proxy.alaexis.workers.dev/?fetch=${encodeURIComponent(url)}`;
+                if (pageNum) {
+                    proxyUrl += `&page=${pageNum}`;
+                }
                 const response = await fetch(proxyUrl);
                 const data = await response.json();
-                
+
+                if (data.error) {
+                    console.warn('[CitationVerifier] Proxy error:', data.error);
+                    return null;
+                }
+
                 if (data.content && data.content.length > 100) {
-                    return `Source URL: ${url}\n\nSource Content:\n${data.content}`;
+                    let meta = `Source URL: ${url}`;
+                    if (data.pdf) {
+                        meta += `\nPDF: ${data.totalPages} pages`;
+                        if (data.page) {
+                            meta += ` (extracted page ${data.page})`;
+                        }
+                    }
+                    return `${meta}\n\nSource Content:\n${data.content}`;
+                }
+
+                // If PDF was large and we didn't request a specific page, retry
+                // with the citation page if available
+                if (data.pdf && !pageNum && data.totalPages > 15) {
+                    console.log('[CitationVerifier] Large PDF without page param, content may be truncated');
                 }
             } catch (error) {
                 console.error('Proxy fetch failed:', error);


### PR DESCRIPTION
## Summary
Enhanced the source content fetching functionality to extract and utilize page numbers from citation references, enabling more precise PDF content retrieval and improved status reporting.

## Key Changes
- **Page number extraction**: Added `extractPageNumber()` method that parses reference elements to extract page numbers using regex patterns (supports "p. 42", "pp. 42-43", "page 42", etc.)
- **Enhanced PDF fetching**: Modified `fetchSourceContent()` to accept an optional `pageNum` parameter and pass it to the proxy API for targeted page extraction
- **Improved status reporting**: Enhanced the source element display to show:
  - PDF page count and extracted page number when available
  - Fallback messages for different content states
  - Better visual feedback with color-coded success indicators
- **Error handling**: Added error checking for proxy responses and logging for large PDFs without page parameters
- **Metadata enrichment**: Extended the source info response to include PDF metadata (total pages, extracted page number)

## Implementation Details
- The page number extraction uses a case-insensitive regex pattern to match common citation formats
- The proxy URL is conditionally extended with a `page` parameter when a page number is available
- Status HTML is dynamically constructed based on content type (PDF vs. regular content) and availability
- Added console logging for debugging page extraction and large PDF handling
- Includes graceful fallback behavior when page extraction fails or content is unavailable

https://claude.ai/code/session_01XB9MKug7wThkgh5fK5vKrM