### PR TITLE
Add dark mode styling for report card verdict elements

### DIFF
--- a/main.js
+++ b/main.js
@@ -648,6 +648,26 @@
                 html.skin-theme-clientpref-night .report-card-comment {
                     color: #a0a0b0 !important;
                 }
+                html.skin-theme-clientpref-night .report-card-verdict.supported {
+                    background: #1a3a1a !important;
+                    color: #6ecf6e !important;
+                }
+                html.skin-theme-clientpref-night .report-card-verdict.partial {
+                    background: #3a3a1a !important;
+                    color: #e0c060 !important;
+                }
+                html.skin-theme-clientpref-night .report-card-verdict.not-supported {
+                    background: #3a1a1a !important;
+                    color: #e06060 !important;
+                }
+                html.skin-theme-clientpref-night .report-card-verdict.unavailable {
+                    background: #2a2a2e !important;
+                    color: #a0a0a8 !important;
+                }
+                html.skin-theme-clientpref-night .report-card-verdict.error {
+                    background: #2a2a2e !important;
+                    color: #a0a0a8 !important;
+                }
                 html.skin-theme-clientpref-night #verifier-source-textarea-container textarea {
                     background: #2a2a3e !important;
                     color: #e0e0e0 !important;
@@ -815,6 +835,26 @@
                     }
                     html.skin-theme-clientpref-os .report-card-comment {
                         color: #a0a0b0 !important;
+                    }
+                    html.skin-theme-clientpref-os .report-card-verdict.supported {
+                        background: #1a3a1a !important;
+                        color: #6ecf6e !important;
+                    }
+                    html.skin-theme-clientpref-os .report-card-verdict.partial {
+                        background: #3a3a1a !important;
+                        color: #e0c060 !important;
+                    }
+                    html.skin-theme-clientpref-os .report-card-verdict.not-supported {
+                        background: #3a1a1a !important;
+                        color: #e06060 !important;
+                    }
+                    html.skin-theme-clientpref-os .report-card-verdict.unavailable {
+                        background: #2a2a2e !important;
+                        color: #a0a0a8 !important;
+                    }
+                    html.skin-theme-clientpref-os .report-card-verdict.error {
+                        background: #2a2a2e !important;
+                        color: #a0a0a8 !important;
                     }
                     html.skin-theme-clientpref-os #verifier-source-textarea-container textarea {
                         background: #2a2a3e !important;


### PR DESCRIPTION
## Summary
This PR adds dark mode theme styling for report card verdict elements across both the night and OS preference dark themes.

## Key Changes
- Added dark mode color schemes for `.report-card-verdict` elements with five verdict states:
  - **supported**: Green background (#1a3a1a) with bright green text (#6ecf6e)
  - **partial**: Yellow/gold background (#3a3a1a) with gold text (#e0c060)
  - **not-supported**: Red background (#3a1a1a) with red text (#e06060)
  - **unavailable**: Gray background (#2a2a2e) with gray text (#a0a0a8)
  - **error**: Gray background (#2a2a2e) with gray text (#a0a0a8)
- Applied styling to both `skin-theme-clientpref-night` and `skin-theme-clientpref-os` themes for consistency

## Implementation Details
- Maintains visual hierarchy and accessibility by using contrasting colors for each verdict state
- Uses `!important` flags to ensure styles override any conflicting rules
- Mirrors the same color palette across both dark theme variants to provide a consistent user experience

https://claude.ai/code/session_01RU4gLb7V8VtaLhGQSESXWD