### PR TITLE
Add action buttons to verification report cards for failed claims

### DIFF
--- a/main.js
+++ b/main.js
@@ -511,6 +511,13 @@
                     font-size: 11px;
                     font-style: italic;
                 }
+                .report-card-action {
+                    margin-top: 4px;
+                }
+                .report-card-action .oo-ui-buttonElement-button {
+                    font-size: 11px;
+                    padding: 2px 4px;
+                }
                 #verifier-report-actions {
                     display: flex;
                     flex-direction: column;
@@ -2239,12 +2246,28 @@ ${sourceText}`;
             `;
 
             if (result.refElement) {
-                card.addEventListener('click', () => {
+                card.addEventListener('click', (e) => {
+                    if (e.target.closest('.report-card-action')) return;
                     result.refElement.scrollIntoView({ behavior: 'smooth', block: 'center' });
                     this.clearHighlights();
                     const parentRef = result.refElement.closest('.reference');
                     if (parentRef) parentRef.classList.add('verifier-active');
                 });
+            }
+
+            if (result.refElement && (result.verdict === 'NOT SUPPORTED' || result.verdict === 'PARTIALLY SUPPORTED' || result.verdict === 'SOURCE UNAVAILABLE')) {
+                const actionDiv = document.createElement('div');
+                actionDiv.className = 'report-card-action';
+                const editBtn = new OO.ui.ButtonWidget({
+                    label: 'Add {{Failed verification}}',
+                    flags: ['progressive'],
+                    icon: 'edit',
+                    href: this.buildEditUrl(result.refElement),
+                    target: '_blank',
+                    framed: false
+                });
+                actionDiv.appendChild(editBtn.$element[0]);
+                card.appendChild(actionDiv);
             }
 
             resultsEl.appendChild(card);
@@ -2563,8 +2586,9 @@ ${sourceText}`;
             this.updateButtonVisibility();
         }
 
-        findSectionNumber() {
-            if (!this.activeRefElement) return 0;
+        findSectionNumber(refElement) {
+            const el = refElement || this.activeRefElement;
+            if (!el) return 0;
 
             const content = document.getElementById('mw-content-text');
             if (!content) return 0;
@@ -2573,7 +2597,7 @@ ${sourceText}`;
             let sectionNumber = 0;
 
             for (const heading of headings) {
-                const position = heading.compareDocumentPosition(this.activeRefElement);
+                const position = heading.compareDocumentPosition(el);
                 if (position & Node.DOCUMENT_POSITION_FOLLOWING) {
                     sectionNumber++;
                 } else {
@@ -2584,9 +2608,9 @@ ${sourceText}`;
             return sectionNumber;
         }
 
-        buildEditUrl() {
+        buildEditUrl(refElement) {
             const title = mw.config.get('wgPageName');
-            const section = this.findSectionNumber();
+            const section = this.findSectionNumber(refElement);
             const summary = 'source does not support claim (checked with [[User:Alaexis/AI_Source_Verification|Source Verifier]])';
 
             const params = { action: 'edit', summary: summary };


### PR DESCRIPTION
## Summary
This PR enhances the verification report UI by adding contextual action buttons to report cards for claims with unsupported or unavailable sources. It also refactors the edit URL building logic to support per-reference operations.

## Key Changes
- **New report card actions UI**: Added styling for `.report-card-action` class with appropriately sized buttons
- **Action button for failed verifications**: When a reference has a verdict of "NOT SUPPORTED", "PARTIALLY SUPPORTED", or "SOURCE UNAVAILABLE", an "Add {{Failed verification}}" button is now displayed on the report card
- **Click event handling**: Modified the card click listener to prevent navigation when clicking on action buttons within the card
- **Refactored edit URL building**: 
  - `buildEditUrl()` now accepts an optional `refElement` parameter to support building URLs for specific references
  - `findSectionNumber()` now accepts an optional `refElement` parameter instead of relying solely on `this.activeRefElement`
  - This allows the edit URL to be correctly generated for any reference, not just the currently active one

## Implementation Details
- The action button uses OOUI's `ButtonWidget` with progressive styling and an edit icon
- The button opens the edit page in a new tab with a pre-filled summary indicating the source verification check
- Event delegation prevents the card's scroll-to-reference behavior from triggering when users click the action button
- The refactoring maintains backward compatibility by making the new parameters optional

https://claude.ai/code/session_019TLmiJmEQzQR3bFnjdmd74