### PR TITLE
Add guidance on transliteration variants in fact-checking rules

### DIFF
--- a/main.js
+++ b/main.js
@@ -1689,6 +1689,7 @@ Rules:
 - First identify what the claim asserts, then look for information that supports or contradicts it.
 - Accept paraphrasing and straightforward implications, but not speculative inferences or logical leaps.
 - Distinguish between definitive statements and uncertain/hedged language. Claims stated as facts require sources that make definitive statements, not speculation or tentative assertions.
+- Names from languages using non-Latin scripts (Arabic, Chinese, Japanese, Korean, Russian, Hindi, etc.) may have multiple valid romanizations/transliterations. For example, "Yasmin" and "Yazmeen," or "Chekhov" and "Tchekhov," are variant spellings of the same name. Do not treat transliteration differences as factual errors.
 
 Source text evaluation:
 Before analyzing, check if the provided "source text" is actually usable content.


### PR DESCRIPTION
## Summary
Updated the fact-checking rules to clarify how transliteration and romanization variants should be handled when evaluating claims about names from non-Latin script languages.

## Changes
- Added a new rule clarifying that names from languages using non-Latin scripts (Arabic, Chinese, Japanese, Korean, Russian, Hindi, etc.) may have multiple valid romanizations/transliterations
- Provided examples of variant spellings (e.g., "Yasmin"/"Yazmeen", "Chekhov"/"Tchekhov") to illustrate the concept
- Specified that transliteration differences should not be treated as factual errors

## Details
This addition helps fact-checkers avoid false negatives when verifying claims about individuals whose names originate from non-Latin writing systems. Different romanization systems and conventions can produce legitimate spelling variations, and these should be recognized as equivalent rather than contradictory information.

https://claude.ai/code/session_01Sezv4p3BFHRYaVy4GZSoLV