### PR TITLE
Replace direct button state with updateButtonVisibility method

### DIFF
--- a/main.js
+++ b/main.js
@@ -1869,7 +1869,7 @@ ${sourceText}`;
                 if (verifyId === this.currentVerifyId) {
                     this.buttons.verify.setLabel('Verify Claim');
                     this.buttons.verify.setIcon('check');
-                    this.buttons.verify.setDisabled(false);
+                    this.updateButtonVisibility();
                 }
             }
         }


### PR DESCRIPTION
## Summary
Refactored the verify button state management to use a centralized visibility update method instead of directly manipulating the disabled state.

## Key Changes
- Replaced `this.buttons.verify.setDisabled(false)` with `this.updateButtonVisibility()` call in the claim verification completion handler
- This change consolidates button state logic into a single method, improving maintainability and consistency

## Implementation Details
The change occurs in the verification completion flow when `verifyId` matches the current verification ID. Instead of directly setting the disabled state to false, the code now delegates to `updateButtonVisibility()`, which likely handles all button state updates in a coordinated manner. This approach reduces duplication and makes future button state changes easier to manage from a single location.

https://claude.ai/code/session_01DQ4nuUahhZ8uBX6XprcgiR