### PR TITLE
Improve report mode reference navigation with smooth scrolling

### DIFF
--- a/main.js
+++ b/main.js
@@ -1161,8 +1161,21 @@
         
         async handleReferenceClick(refElement) {
             try {
+                // When in report mode, don't switch to single-citation view.
+                // Instead, scroll to the matching report card if one exists.
                 if (this.reportMode) {
-                    this.showSingleCitationView();
+                    const matchIndex = this.reportResults.findIndex(r => r.refElement === refElement);
+                    if (matchIndex !== -1) {
+                        const cards = document.querySelectorAll('#verifier-report-results .report-card');
+                        const card = cards[matchIndex];
+                        if (card) {
+                            card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                            card.style.transition = 'box-shadow 0.3s';
+                            card.style.boxShadow = '0 0 0 3px #36c';
+                            setTimeout(() => { card.style.boxShadow = ''; }, 1500);
+                        }
+                    }
+                    return;
                 }
                 this.clearHighlights();
                 this.showSidebar();


### PR DESCRIPTION
## Summary
Modified the reference click handler to improve user experience in report mode by scrolling to and highlighting the corresponding report card instead of switching to single-citation view.

## Key Changes
- Changed report mode behavior to scroll to the matching report card instead of showing single-citation view
- Added smooth scrolling with centered positioning to the matching report card
- Implemented visual feedback with a temporary blue highlight (box-shadow) on the target card that fades after 1.5 seconds
- Added early return to prevent further processing when in report mode

## Implementation Details
- Uses `findIndex()` to locate the report result matching the clicked reference element
- Queries for report cards and scrolls the matching card into view with `scrollIntoView({ behavior: 'smooth', block: 'center' })`
- Applies a 3px blue box-shadow (`#36c`) as visual feedback
- Uses `setTimeout()` to automatically remove the highlight after 1500ms, providing a non-intrusive visual cue

https://claude.ai/code/session_01Dk2psSE5mP4NyALv2WEBE2