### PR TITLE
Add revision tracking to citation verification reports

### DIFF
--- a/main.js
+++ b/main.js
@@ -66,6 +66,7 @@
             this.sourceCache = new Map();
             this.reportTokenUsage = { input: 0, output: 0 };
             this.hasReport = false;
+            this.reportRevisionId = null;
 
             this.init();
         }
@@ -2227,6 +2228,7 @@ ${sourceText}`;
                 <div style="margin-top:6px;font-size:11px;color:#888;">
                     ${total} citations checked${this.reportTokenUsage.input + this.reportTokenUsage.output > 0 ? ` · ${this.reportTokenUsage.input.toLocaleString()} input + ${this.reportTokenUsage.output.toLocaleString()} output tokens` : ''}
                 </div>
+                ${this.reportRevisionId ? `<div style="margin-top:4px;font-size:11px;color:#888;">Revision: <a href="${this.escapeHtml(this.getRevisionPermalinkUrl(this.reportRevisionId) || '#')}" target="_blank" rel="noopener">${this.reportRevisionId}</a></div>` : ''}
             `;
         }
 
@@ -2312,10 +2314,27 @@ ${sourceText}`;
             actionsEl.appendChild(copyTextBtn.$element[0]);
         }
 
+        getRevisionPermalinkUrl(revId) {
+            if (!revId || typeof mw === 'undefined') return null;
+            try {
+                let server = mw.config.get('wgServer') || '';
+                if (server.startsWith('//')) server = 'https:' + server;
+                const script = mw.config.get('wgScript') || '/w/index.php';
+                const title = mw.config.get('wgPageName') || '';
+                return `${server}${script}?title=${encodeURIComponent(title)}&oldid=${revId}`;
+            } catch (e) {
+                return null;
+            }
+        }
+
         generateWikitextReport() {
             const articleTitle = typeof mw !== 'undefined' ? mw.config.get('wgTitle') : document.title;
+            const revId = this.reportRevisionId;
             let wikitext = `== Citation verification report ==\n`;
             wikitext += `This is an experimental check of the article sources by [[User:Alaexis/AI_Source_Verification|Citation Verifier]]. Treat it with caution, be aware of its [[User:Alaexis/AI_Source_Verification#Limitations|limitations]] and feel free to leave feedback at [[User_talk:Alaexis/AI_Source_Verification|the talk page]].\n\n`;
+            if (revId) {
+                wikitext += `Revision checked: [[Special:PermanentLink/${revId}|${revId}]]\n\n`;
+            }
             wikitext += `{| class="wikitable sortable"\n`;
             wikitext += `|-\n! # !! Verdict !! Confidence !! Source !! Comments\n`;
 
@@ -2363,8 +2382,13 @@ ${sourceText}`;
 
         generatePlainTextReport() {
             const articleTitle = typeof mw !== 'undefined' ? mw.config.get('wgTitle') : document.title;
+            const revId = this.reportRevisionId;
             let text = `Citation Verification Report: ${articleTitle}\n`;
             text += `Provider: ${this.providers[this.currentProvider].name}\n`;
+            if (revId) {
+                const permalink = this.getRevisionPermalinkUrl(revId);
+                text += `Revision: ${revId}${permalink ? ` (${permalink})` : ''}\n`;
+            }
             text += `${'='.repeat(60)}\n\n`;
 
             for (const r of this.reportResults) {
@@ -2437,6 +2461,7 @@ ${sourceText}`;
             this.sourceCache = new Map();
             this.reportTokenUsage = { input: 0, output: 0 };
             this.hasReport = true;
+            this.reportRevisionId = mw.config.get('wgCurRevisionId') || null;
 
             this.showReportView();
             document.getElementById('verifier-report-results').innerHTML = '';


### PR DESCRIPTION
## Summary
This PR adds revision tracking functionality to the citation verification reports, allowing users to see which article revision was checked and providing a permalink to that specific revision.

## Key Changes
- **Initialize revision tracking**: Added `reportRevisionId` property to store the revision ID of the checked article
- **Capture revision ID**: Automatically capture the current revision ID (`wgCurRevisionId`) when generating a report
- **Display revision in HTML report**: Added a new section in the HTML report footer showing the revision ID with a clickable permalink
- **Include revision in Wikitext export**: Added revision information to the Wikitext-formatted report with a link to the permanent revision
- **Include revision in plain text export**: Added revision information and permalink to the plain text report format
- **Add helper method**: Implemented `getRevisionPermalinkUrl()` to construct proper Wikipedia revision permalinks using MediaWiki configuration

## Implementation Details
- The revision ID is captured from `mw.config.get('wgCurRevisionId')` when a report is generated
- The permalink URL is constructed using MediaWiki's standard parameters: `?title=...&oldid=...`
- The helper method includes error handling for cases where MediaWiki is not available
- The revision information is displayed consistently across all three report formats (HTML, Wikitext, and plain text)
- HTML display uses the same styling as other report metadata (small gray text)

https://claude.ai/code/session_01Q2gpjPcpBTpZyotnWn6k7f