### PR TITLE
Update Claude model from sonnet-4-20250514 to sonnet-4-6

### DIFF
--- a/main.js
+++ b/main.js
@@ -19,7 +19,7 @@
                     name: 'Claude',
                     storageKey: 'claude_api_key',
                     color: '#0645ad',
-                    model: 'claude-sonnet-4-20250514',
+                    model: 'claude-sonnet-4-6',
                     requiresKey: true
                 },
                 gemini: {


### PR DESCRIPTION
## Summary
Updated the default Claude model configuration to use an earlier version of the Sonnet 4 model.

## Changes
- Changed Claude model identifier from `claude-sonnet-4-20250514` to `claude-sonnet-4-6` in the AI provider configuration

## Details
This change updates the model version used for Claude API interactions. The model field in the Claude provider configuration has been modified to reference a different Sonnet 4 model variant.

https://claude.ai/code/session_01KspzN4xHbrofzSQPgr33WJ