### PR TITLE
Add Google Books URL detection and skip fetching

### DIFF
--- a/main.js
+++ b/main.js
@@ -1232,7 +1232,13 @@
                     this.updateStatus('No URL found in reference. Please paste the source text below.');
                     return;
                 }
-                
+
+                if (this.isGoogleBooksUrl(refUrl)) {
+                    this.showSourceTextInput();
+                    this.updateStatus('Google Books sources cannot be fetched. Please paste the source text below.');
+                    return;
+                }
+
                 this.hideSourceTextInput();
                 this.activeSource = null;
                 this.updateButtonVisibility();
@@ -1452,8 +1458,17 @@
             }
             return null;
         }
-        
+
+        isGoogleBooksUrl(url) {
+            return /books\.google\./.test(url);
+        }
+
         async fetchSourceContent(url, pageNum) {
+            if (this.isGoogleBooksUrl(url)) {
+                console.log('[CitationVerifier] Skipping Google Books URL:', url);
+                return null;
+            }
+
             try {
                 let proxyUrl = `https://publicai-proxy.alaexis.workers.dev/?fetch=${encodeURIComponent(url)}`;
                 if (pageNum) {


### PR DESCRIPTION
## Summary
Added detection and handling for Google Books URLs to prevent failed fetch attempts. When a Google Books source is detected, the application now prompts users to manually paste the source text instead of attempting to fetch content.

## Key Changes
- Added `isGoogleBooksUrl()` method that detects Google Books URLs using regex pattern matching (`/books\.google\./`)
- Added validation in the reference URL processing flow to detect Google Books URLs and show the source text input prompt with an appropriate message
- Added early return in `fetchSourceContent()` to skip fetch attempts for Google Books URLs and log the action
- Cleaned up trailing whitespace in affected code sections

## Implementation Details
- The Google Books detection uses a simple regex test against the URL to identify any Google Books domain
- When a Google Books URL is detected, the UI shows the source text input field and displays a user-friendly message explaining that Google Books sources cannot be automatically fetched
- The `fetchSourceContent()` method returns `null` for Google Books URLs, preventing unnecessary network requests

https://claude.ai/code/session_01SzsBfmbVjixUrqwv6ZA5jM