### PR TITLE
Add Harvard/sfn citation support with URL extraction refactoring

### DIFF
--- a/main.js
+++ b/main.js
@@ -1408,6 +1408,18 @@
             return claimText;
         }
         
+        extractHttpUrl(element) {
+            if (!element) return null;
+            // First look for archive links (prioritize these)
+            const archiveLink = element.querySelector('a[href*="web.archive.org"], a[href*="archive.today"], a[href*="archive.is"], a[href*="archive.ph"], a[href*="webcitation.org"]');
+            if (archiveLink) return archiveLink.href;
+
+            // Fall back to any http link
+            const links = element.querySelectorAll('a[href^="http"]');
+            if (links.length === 0) return null;
+            return links[0].href;
+        }
+
         extractReferenceUrl(refElement) {
             const href = refElement.getAttribute('href');
             if (!href || !href.startsWith('#')) {
@@ -1423,17 +1435,40 @@
                 return null;
             }
 
-            // First look for archive links (prioritize these)
-            const archiveLink = refTarget.querySelector('a[href*="web.archive.org"], a[href*="archive.today"], a[href*="archive.is"], a[href*="archive.ph"], a[href*="webcitation.org"]');
-            if (archiveLink) return archiveLink.href;
+            // Try to extract a direct HTTP URL from the footnote
+            const directUrl = this.extractHttpUrl(refTarget);
+            if (directUrl) return directUrl;
 
-            // Fall back to any http link
-            const links = refTarget.querySelectorAll('a[href^="http"]');
-            if (links.length === 0) {
-                console.log('[CitationVerifier] No http links in refTarget. innerHTML:', refTarget.innerHTML.substring(0, 500));
+            // Harvard/sfn citation support: the footnote may contain only a
+            // short-cite linking to the full citation via a #CITEREF anchor.
+            // Follow that link to resolve the actual source URL.
+            const citerefLink = refTarget.querySelector('a[href^="#CITEREF"]');
+            if (citerefLink) {
+                const citerefId = citerefLink.getAttribute('href').substring(1);
+                const fullCitation = document.getElementById(citerefId);
+                if (fullCitation) {
+                    const resolvedUrl = this.extractHttpUrl(fullCitation);
+                    if (resolvedUrl) {
+                        console.log('[CitationVerifier] Resolved Harvard/sfn citation via', citerefId);
+                        return resolvedUrl;
+                    }
+                }
+                // Also try the parent <li> or <cite> element in case the anchor
+                // is on a child element within the full citation list item
+                const fullCitationLi = fullCitation && fullCitation.closest('li');
+                if (fullCitationLi && fullCitationLi !== fullCitation) {
+                    const resolvedUrl = this.extractHttpUrl(fullCitationLi);
+                    if (resolvedUrl) {
+                        console.log('[CitationVerifier] Resolved Harvard/sfn citation via parent li of', citerefId);
+                        return resolvedUrl;
+                    }
+                }
+                console.log('[CitationVerifier] Harvard/sfn citation found but no URL in full citation:', citerefId);
                 return null;
             }
-            return links[0].href;
+
+            console.log('[CitationVerifier] No http links in refTarget. innerHTML:', refTarget.innerHTML.substring(0, 500));
+            return null;
         }
 
         extractPageNumber(refElement) {


### PR DESCRIPTION
## Summary
This PR refactors URL extraction logic and adds support for Harvard/sfn citation formats, which use anchor links to reference full citations elsewhere in the document.

## Key Changes
- **Extracted `extractHttpUrl()` method**: Refactored duplicate URL extraction logic into a reusable helper method that:
  - Prioritizes archive links (web.archive.org, archive.today, archive.is, archive.ph, webcitation.org)
  - Falls back to any HTTP link if no archive link is found
  
- **Enhanced `extractReferenceUrl()` with Harvard/sfn support**: Added logic to follow `#CITEREF` anchor links to resolve full citations:
  - Attempts direct URL extraction from the footnote first
  - If a `#CITEREF` anchor is found, follows it to the full citation element
  - Searches both the target element and its parent `<li>` element for URLs
  - Includes appropriate logging for debugging citation resolution

## Implementation Details
- The new `extractHttpUrl()` method centralizes the archive link prioritization logic, reducing code duplication
- Harvard/sfn citation resolution handles cases where the anchor may be on a child element within the full citation list item by checking the parent `<li>` element
- Enhanced logging provides visibility into citation resolution paths for debugging purposes

https://claude.ai/code/session_01R3feSeAkz1JsPjeHLubkXp