### PR TITLE
Link citation numbers to permanent revision anchors in reports

### DIFF
--- a/main.js
+++ b/main.js
@@ -2607,7 +2607,16 @@ ${sourceText}`;
                 if (r.truncated) {
                     commentsClean += (commentsClean ? ' ' : '') + "''(Source is long, only partially checked.)''";
                 }
-                wikitext += `|-\n| [${r.citationNumber}] || ${verdictWiki} || ${confStr} || ${sourceStr} || ${commentsClean}\n`;
+                // Link the citation number to the footnote anchor on the analyzed revision,
+                // so clicks from the report jump to the original citation even after later edits
+                // have shifted citation numbering. HTML entities are used for the square brackets
+                // in the display text so they don't confuse MediaWiki's wikilink parser.
+                const refHref = r.refElement && r.refElement.getAttribute('href');
+                const refAnchor = refHref && refHref.startsWith('#') ? refHref.substring(1) : null;
+                const citationCell = (revId && refAnchor)
+                    ? `[[Special:PermanentLink/${revId}#${refAnchor}|&#91;${r.citationNumber}&#93;]]`
+                    : `[${r.citationNumber}]`;
+                wikitext += `|-\n| ${citationCell} || ${verdictWiki} || ${confStr} || ${sourceStr} || ${commentsClean}\n`;
             }
 
             wikitext += `|}\n\n`;


### PR DESCRIPTION
## Summary
Modified the citation number display in report tables to link directly to the original footnote anchors on the analyzed revision, ensuring that report links remain valid even after subsequent edits change citation numbering.

## Key Changes
- Extract the reference element's href attribute to identify the footnote anchor
- Generate permanent links using `Special:PermanentLink` with the revision ID and anchor fragment
- Use HTML entities (`&#91;` and `&#93;`) for square brackets in the display text to prevent MediaWiki wikilink parser confusion
- Fall back to plain citation numbers when revision ID or anchor information is unavailable

## Implementation Details
- The citation cell now conditionally renders as either a permanent wikilink (when both `revId` and `refAnchor` are available) or a plain bracketed number
- The anchor is extracted from the reference element's href by removing the leading `#` character
- This approach preserves backward compatibility by gracefully degrading to the original format when necessary information is missing

https://claude.ai/code/session_019aTXJJXhMY5Q3hdfELoZev