### PR TITLE
claude/clarify-support-warning-vJnlB

### DIFF
--- a/main.js
+++ b/main.js
@@ -2499,7 +2499,7 @@ ${sourceText}`;
             card.className = `verifier-report-card verdict-${verdictClass}`;
             const claimExcerpt = result.claimText.length > 80 ? result.claimText.substring(0, 80) + '…' : result.claimText;
             const confidenceStr = result.confidence !== null ? ` (${result.confidence}%)` : '';
-            const truncationHtml = result.truncated
+            const truncationHtml = (result.truncated && result.verdict !== 'SUPPORTED')
                 ? '<div class="report-card-truncated">⚠ Source is long, only partially checked.</div>'
                 : '';
             card.innerHTML = `
@@ -2604,7 +2604,7 @@ ${sourceText}`;
                 const confStr = r.confidence !== null ? `${r.confidence}%` : '—';
                 const sourceStr = r.url ? `[${r.url} source]` : '—';
                 let commentsClean = (r.comments || '').replace(/\n/g, ' ');
-                if (r.truncated) {
+                if (r.truncated && r.verdict !== 'SUPPORTED') {
                     commentsClean += (commentsClean ? ' ' : '') + "''(Source is long, only partially checked.)''";
                 }
                 // Link the citation number to the footnote anchor on the analyzed revision,
@@ -2663,7 +2663,7 @@ ${sourceText}`;
                 text += `  Claim: ${r.claimText.substring(0, 100)}${r.claimText.length > 100 ? '...' : ''}\n`;
                 if (r.url) text += `  Source: ${r.url}\n`;
                 if (r.comments) text += `  Comments: ${r.comments}\n`;
-                if (r.truncated) text += `  Note: Source is long, only partially checked.\n`;
+                if (r.truncated && r.verdict !== 'SUPPORTED') text += `  Note: Source is long, only partially checked.\n`;
                 text += `\n`;
             }
 


### PR DESCRIPTION
When the verdict is "Supported" the source evidently contained enough
evidence to support the claim, so the "Source is long, only partially
checked" warning is confusing rather than informative. Suppress it in
the report card UI, wikitext report, and plain-text report.