### PR TITLE
Update button labels from 'Add {{Failed verification}}' to 'Edit Section'

### DIFF
--- a/main.js
+++ b/main.js
@@ -2526,7 +2526,7 @@ ${sourceText}`;
                 const actionDiv = document.createElement('div');
                 actionDiv.className = 'report-card-action';
                 const editBtn = new OO.ui.ButtonWidget({
-                    label: 'Add {{Failed verification}}',
+                    label: 'Edit in Wikipedia',
                     flags: ['progressive'],
                     icon: 'edit',
                     href: this.buildEditUrl(result.refElement),
@@ -2942,7 +2942,7 @@ ${sourceText}`;
             if (verdict !== 'NOT SUPPORTED' && verdict !== 'PARTIALLY SUPPORTED' && verdict !== 'SOURCE UNAVAILABLE') return;
 
             const btn = new OO.ui.ButtonWidget({
-                label: 'Add {{Failed verification}}',
+                label: 'Edit in Wikipedia',
                 flags: ['progressive'],
                 icon: 'edit',
                 href: this.buildEditUrl(),

--- a/main.js
+++ b/main.js
@@ -2526,7 +2526,7 @@ ${sourceText}`;
                 const actionDiv = document.createElement('div');
                 actionDiv.className = 'report-card-action';
                 const editBtn = new OO.ui.ButtonWidget({
-                    label: 'Edit in Wikipedia',
+                    label: 'Edit Section',
                     flags: ['progressive'],
                     icon: 'edit',
                     href: this.buildEditUrl(result.refElement),
@@ -2942,7 +2942,7 @@ ${sourceText}`;
             if (verdict !== 'NOT SUPPORTED' && verdict !== 'PARTIALLY SUPPORTED' && verdict !== 'SOURCE UNAVAILABLE') return;
 
             const btn = new OO.ui.ButtonWidget({
-                label: 'Edit in Wikipedia',
+                label: 'Edit Section',
                 flags: ['progressive'],
                 icon: 'edit',
                 href: this.buildEditUrl(),


### PR DESCRIPTION
## Summary
Updated button labels in the report card interface to use more generic and user-friendly text that better describes the action being performed.

## Changes
- Changed button label from `'Add {{Failed verification}}'` to `'Edit Section'` in the report card action button (line 2529)
- Changed button label from `'Add {{Failed verification}}'` to `'Edit Section'` in the verdict-based button (line 2945)

## Details
Both button instances maintain their existing functionality (progressive flag, edit icon, and href behavior) - only the displayed label text has been updated to be more descriptive of the actual user action (editing a section) rather than the specific wiki template being added.

https://claude.ai/code/session_01H6tKnmu6gBkmfwP1cffxXp