### PR TITLE
Pass claim to proxy so that proxy can pull most-appropriate sections of source text, not just first 12K chars

### DIFF
--- a/benchmark/extract_dataset.js
+++ b/benchmark/extract_dataset.js
@@ -145,13 +145,20 @@ function fetchURL(url) {
 }
 
 /**
- * Fetch source content via proxy, with direct fetch fallback
+ * Fetch source content via proxy, with direct fetch fallback.
+ *
+ * When `claim` is supplied, it is forwarded as `&query=<encoded>` so the
+ * proxy can return claim-relevant excerpts from long sources instead of
+ * head-of-page truncation. Mirrors the userscript-side change in
+ * core/worker.js so the benchmark exercises the same fetch contract as
+ * the deployed userscript.
  */
-async function fetchSourceContent(url) {
+async function fetchSourceContent(url, claim) {
     // Try proxy first
     try {
         log(`    Trying proxy fetch...`);
-        const proxyUrl = `${PROXY_URL}?fetch=${encodeURIComponent(url)}`;
+        const queryParam = claim ? `&query=${encodeURIComponent(claim)}` : '';
+        const proxyUrl = `${PROXY_URL}?fetch=${encodeURIComponent(url)}${queryParam}`;
         const response = await fetchWithRetry(proxyUrl);
         const data = JSON.parse(response);
 
@@ -445,7 +452,7 @@ async function main() {
             let sourceText = '';
             if (sourceUrl && !DRY_RUN) {
                 console.log(`    Fetching source: ${sourceUrl.substring(0, 60)}...`);
-                sourceText = await fetchSourceContent(sourceUrl) || '';
+                sourceText = await fetchSourceContent(sourceUrl, claimText) || '';
                 await sleep(500); // Rate limiting
             }
 

--- a/core/prompts.js
+++ b/core/prompts.js
@@ -29,7 +29,12 @@ It is NOT usable if it's:
 
 IMPORTANT: If the source text contains actual article content (paragraphs of text, quotes, factual statements), it IS usable even if it also contains archive navigation, headers, footers, or other page chrome. Only return SOURCE UNAVAILABLE when there is genuinely no article content to analyze.
 
-Note on excerpts: long sources may be delivered as a lead plus claim-relevant excerpts drawn from later in the page, within a fixed size budget. This is expected and is not a signal of unreliability — gaps between paragraphs, missing middle sections, or text that appears to end abruptly mean "this part was not shown", not "this source failed to load". Judge based on what IS present. Only return SOURCE UNAVAILABLE when the actual content is missing (login wall, 404, metadata-only catalog page), not when the page text appears to be a partial slice.
+Note on excerpts and chrome: long sources are delivered through a CORS proxy that returns a fixed-size text budget. For pages that exceed the budget, the proxy may:
+- Include page-header navigation, archive-wrapper chrome (like Wayback Machine capture metadata), share/nav widgets, and footer links — ignore these and focus on the article prose.
+- Include only a lead paragraph plus claim-relevant excerpts drawn from later in the page — gaps between paragraphs, blank-line stacks, text ending mid-sentence, or excerpts separated by "..." are NORMAL and mean "this part was not shown", not "the source failed to load."
+- Deliver a shorter-than-budget excerpt when few paragraphs matched the claim — brevity alone is NOT a source-unavailability signal.
+
+SOURCE UNAVAILABLE is reserved for cases where ZERO article prose is present: login wall, paywall, 404 error page, empty search results page, Google Books preview with only bibliographic metadata, or pages showing only "access denied." If ANY paragraph of article prose is visible — even if surrounded by chrome or separated by gaps — evaluate based on that paragraph.
 
 If the source text is not usable, you MUST return verdict SOURCE UNAVAILABLE with confidence 0. Do not attempt to verify the claim - if you cannot find actual article or book content to quote, the source is unavailable.
 

--- a/core/prompts.js
+++ b/core/prompts.js
@@ -29,6 +29,8 @@ It is NOT usable if it's:
 
 IMPORTANT: If the source text contains actual article content (paragraphs of text, quotes, factual statements), it IS usable even if it also contains archive navigation, headers, footers, or other page chrome. Only return SOURCE UNAVAILABLE when there is genuinely no article content to analyze.
 
+Note on excerpts: long sources may be delivered as a lead plus claim-relevant excerpts drawn from later in the page, within a fixed size budget. This is expected and is not a signal of unreliability — gaps between paragraphs, missing middle sections, or text that appears to end abruptly mean "this part was not shown", not "this source failed to load". Judge based on what IS present. Only return SOURCE UNAVAILABLE when the actual content is missing (login wall, 404, metadata-only catalog page), not when the page text appears to be a partial slice.
+
 If the source text is not usable, you MUST return verdict SOURCE UNAVAILABLE with confidence 0. Do not attempt to verify the claim - if you cannot find actual article or book content to quote, the source is unavailable.
 
 Respond in JSON format:

--- a/core/worker.js
+++ b/core/worker.js
@@ -2,7 +2,12 @@
 
 import { isGoogleBooksUrl } from './urls.js';
 
-export async function fetchSourceContent(url, pageNum, { workerBase = 'https://publicai-proxy.alaexis.workers.dev' } = {}) {
+// claim is optional. When supplied, the proxy may use it to extract
+// claim-relevant excerpts from long sources instead of returning
+// only the first ~12k chars. The proxy MUST gracefully ignore the
+// `query` param if it does not yet support it, so this is safe to
+// ship before the Worker is updated.
+export async function fetchSourceContent(url, pageNum, { claim, workerBase = 'https://publicai-proxy.alaexis.workers.dev' } = {}) {
     if (isGoogleBooksUrl(url)) {
         console.log('[CitationVerifier] Skipping Google Books URL:', url);
         return null;
@@ -12,6 +17,9 @@ export async function fetchSourceContent(url, pageNum, { workerBase = 'https://p
         let proxyUrl = `${workerBase}/?fetch=${encodeURIComponent(url)}`;
         if (pageNum) {
             proxyUrl += `&page=${pageNum}`;
+        }
+        if (claim) {
+            proxyUrl += `&query=${encodeURIComponent(claim)}`;
         }
         const response = await fetch(proxyUrl);
         const data = await response.json();

--- a/main.js
+++ b/main.js
@@ -38,6 +38,8 @@ It is NOT usable if it's:
 
 IMPORTANT: If the source text contains actual article content (paragraphs of text, quotes, factual statements), it IS usable even if it also contains archive navigation, headers, footers, or other page chrome. Only return SOURCE UNAVAILABLE when there is genuinely no article content to analyze.
 
+Note on excerpts: long sources may be delivered as a lead plus claim-relevant excerpts drawn from later in the page, within a fixed size budget. This is expected and is not a signal of unreliability — gaps between paragraphs, missing middle sections, or text that appears to end abruptly mean "this part was not shown", not "this source failed to load". Judge based on what IS present. Only return SOURCE UNAVAILABLE when the actual content is missing (login wall, 404, metadata-only catalog page), not when the page text appears to be a partial slice.
+
 If the source text is not usable, you MUST return verdict SOURCE UNAVAILABLE with confidence 0. Do not attempt to verify the claim - if you cannot find actual article or book content to quote, the source is unavailable.
 
 Respond in JSON format:

--- a/main.js
+++ b/main.js
@@ -38,7 +38,12 @@ It is NOT usable if it's:
 
 IMPORTANT: If the source text contains actual article content (paragraphs of text, quotes, factual statements), it IS usable even if it also contains archive navigation, headers, footers, or other page chrome. Only return SOURCE UNAVAILABLE when there is genuinely no article content to analyze.
 
-Note on excerpts: long sources may be delivered as a lead plus claim-relevant excerpts drawn from later in the page, within a fixed size budget. This is expected and is not a signal of unreliability — gaps between paragraphs, missing middle sections, or text that appears to end abruptly mean "this part was not shown", not "this source failed to load". Judge based on what IS present. Only return SOURCE UNAVAILABLE when the actual content is missing (login wall, 404, metadata-only catalog page), not when the page text appears to be a partial slice.
+Note on excerpts and chrome: long sources are delivered through a CORS proxy that returns a fixed-size text budget. For pages that exceed the budget, the proxy may:
+- Include page-header navigation, archive-wrapper chrome (like Wayback Machine capture metadata), share/nav widgets, and footer links — ignore these and focus on the article prose.
+- Include only a lead paragraph plus claim-relevant excerpts drawn from later in the page — gaps between paragraphs, blank-line stacks, text ending mid-sentence, or excerpts separated by "..." are NORMAL and mean "this part was not shown", not "the source failed to load."
+- Deliver a shorter-than-budget excerpt when few paragraphs matched the claim — brevity alone is NOT a source-unavailability signal.
+
+SOURCE UNAVAILABLE is reserved for cases where ZERO article prose is present: login wall, paywall, 404 error page, empty search results page, Google Books preview with only bibliographic metadata, or pages showing only "access denied." If ANY paragraph of article prose is visible — even if surrounded by chrome or separated by gaps — evaluate based on that paragraph.
 
 If the source text is not usable, you MUST return verdict SOURCE UNAVAILABLE with confidence 0. Do not attempt to verify the claim - if you cannot find actual article or book content to quote, the source is unavailable.
 

--- a/main.js
+++ b/main.js
@@ -537,7 +537,12 @@ async function callProviderAPI(name, config) {
 // Calls to the Cloudflare Worker proxy: source fetching and verification logging.
 
 
-async function fetchSourceContent(url, pageNum, { workerBase = 'https://publicai-proxy.alaexis.workers.dev' } = {}) {
+// claim is optional. When supplied, the proxy may use it to extract
+// claim-relevant excerpts from long sources instead of returning
+// only the first ~12k chars. The proxy MUST gracefully ignore the
+// `query` param if it does not yet support it, so this is safe to
+// ship before the Worker is updated.
+async function fetchSourceContent(url, pageNum, { claim, workerBase = 'https://publicai-proxy.alaexis.workers.dev' } = {}) {
     if (isGoogleBooksUrl(url)) {
         console.log('[CitationVerifier] Skipping Google Books URL:', url);
         return null;
@@ -547,6 +552,9 @@ async function fetchSourceContent(url, pageNum, { workerBase = 'https://publicai
         let proxyUrl = `${workerBase}/?fetch=${encodeURIComponent(url)}`;
         if (pageNum) {
             proxyUrl += `&page=${pageNum}`;
+        }
+        if (claim) {
+            proxyUrl += `&query=${encodeURIComponent(claim)}`;
         }
         const response = await fetch(proxyUrl);
         const data = await response.json();
@@ -1979,7 +1987,7 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
                 this.updateStatus('Fetching source content...');
                 const fetchId = ++this.currentFetchId;
                 const pageNum = this.extractPageNumber(refElement);
-                const sourceInfo = await this.fetchSourceContent(refUrl, pageNum);
+                const sourceInfo = await this.fetchSourceContent(refUrl, pageNum, claim);
 
                 if (fetchId !== this.currentFetchId) {
                     return;
@@ -2119,8 +2127,8 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
             return isGoogleBooksUrl(url);
         }
 
-        async fetchSourceContent(url, pageNum) {
-            return fetchSourceContent(url, pageNum);
+        async fetchSourceContent(url, pageNum, claim) {
+            return fetchSourceContent(url, pageNum, { claim });
         }
         
         highlightClaim(refElement, claim) {
@@ -2955,7 +2963,7 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
                     if (!this.sourceCache.has(cacheKey)) {
                         this.updateReportProgress(i, citations.length, `Fetching source for [${citation.citationNumber}]`, startTime);
                         try {
-                            const sourceContent = await this.fetchSourceContent(citation.url, citation.pageNum);
+                            const sourceContent = await this.fetchSourceContent(citation.url, citation.pageNum, citation.claimText);
                             this.sourceCache.set(cacheKey, sourceContent);
                         } catch (e) {
                             this.sourceCache.set(cacheKey, null);

--- a/tests/worker.test.js
+++ b/tests/worker.test.js
@@ -38,6 +38,66 @@ test('fetchSourceContent returns formatted source text on success', async () => 
   }
 });
 
+test('fetchSourceContent forwards claim as URL-encoded &query=', async () => {
+  const mock = mockFetch(async () => ({
+    ok: true,
+    json: async () => ({ content: 'a'.repeat(500), truncated: false }),
+  }));
+  try {
+    await fetchSourceContent('https://example.com/doc', null, {
+      claim: 'foo & bar = baz?',
+    });
+    const url = mock.calls[0].url;
+    assert.ok(url.includes('&query=foo%20%26%20bar%20%3D%20baz%3F'),
+      `expected URL-encoded &query=, got: ${url}`);
+  } finally {
+    mock.restore();
+  }
+});
+
+test('fetchSourceContent omits &query= when no claim is supplied', async () => {
+  const mock = mockFetch(async () => ({
+    ok: true,
+    json: async () => ({ content: 'a'.repeat(500), truncated: false }),
+  }));
+  try {
+    await fetchSourceContent('https://example.com/doc', null);
+    assert.ok(!mock.calls[0].url.includes('query='),
+      `did not expect &query=, got: ${mock.calls[0].url}`);
+  } finally {
+    mock.restore();
+  }
+});
+
+test('fetchSourceContent combines &page= and &query= when both supplied', async () => {
+  const mock = mockFetch(async () => ({
+    ok: true,
+    json: async () => ({ content: 'a'.repeat(500), truncated: false }),
+  }));
+  try {
+    await fetchSourceContent('https://example.com/doc', 7, { claim: 'hello' });
+    const url = mock.calls[0].url;
+    assert.ok(url.includes('&page=7'), `missing &page=7: ${url}`);
+    assert.ok(url.includes('&query=hello'), `missing &query=hello: ${url}`);
+  } finally {
+    mock.restore();
+  }
+});
+
+test('fetchSourceContent omits &query= for empty-string claim', async () => {
+  const mock = mockFetch(async () => ({
+    ok: true,
+    json: async () => ({ content: 'a'.repeat(500), truncated: false }),
+  }));
+  try {
+    await fetchSourceContent('https://example.com/doc', null, { claim: '' });
+    assert.ok(!mock.calls[0].url.includes('query='),
+      `expected empty claim to be skipped: ${mock.calls[0].url}`);
+  } finally {
+    mock.restore();
+  }
+});
+
 test('logVerification posts payload and swallows failures', async () => {
   const mock = mockFetch(async () => ({ ok: true, json: async () => ({}) }));
   try {


### PR DESCRIPTION
> **Update 2026-05-14:** I still think the instinct here is correct but the benchmarking results continue to be neutral-to-negative. Will continue to experiment but marking this draft for now.

> **Update 2026-05-02:** Rebased onto current `main` (post #155 + #165) and added a 4th commit aligning the benchmark's source-fetch path with the userscript-side change (see commit 4 below). Fresh post-#165 benchmark numbers will follow as a comment once the eval run completes.

(This is a companion to https://github.com/alex-o-748/public-ai-proxy/pull/8 which implements the other side of this slightly tweaked API.)

In my own experimentation on wikidata claim verification, it really helped the bots to feed them specific fragments of the cited source (filtered based on the claim to be tested) instead of just the first N tokens from the source. So I implemented that here. 

On the v3 benchmark data, this gives clean wins on every tested provider. Exact matches on the benchmark improve between +0.7pp (Gemini) to +10.3pp (Qwen). On v2's smaller set it is slightly more ambiguous, and uncovers some other problems (eg #156).

## Summary

The patch adds an optional `claim` argument to `fetchSourceContent` and forwards it to the Worker as `&query=<encoded claim>`. When the Worker's companion patch (PAP #8) is deployed, the Worker then searches for, and returns, claim-relevant excerpts instead of just the first-12,000-character. So, for example, if a claim is about X, and X is discussed in the 13,000th character, then this will surface that information, which wasn’t previously available.

It also mildly updates the system prompt in two ways:
-  tells the model that excerpted sources are expected. In my first tests of this without a prompt change, the models saw fragmentary content and decided the source was not reliable.
- enumerates what does vs. does not warrant `SOURCE UNAVAILABLE`. Again, before the prompt change, smoketesting revealed that the models tended to see fragmentary chunks and decided that was a problem with source availability.

Closes #55 .
Addresses #88 (client side; companion Worker PR at alex-o-748/public-ai-proxy#8).

## What this PR does, detailed version:

Four changes:

1. **`Pass claim text as query param to source-content proxy`** — threads the claim through the two call sites of `fetchSourceContent` (single-citation verify and the batch report generator) and URL-encodes it as `&query=…`. No other behavior change. Comes with 4 unit tests in `tests/worker.test.js` covering URL encoding (special characters), the combination of `&page=` and `&query=`, and the case where no claim (or an empty one) is supplied.

2. **`Tell the model to treat excerpts as partial views, not failures`** — adds a short paragraph to `generateSystemPrompt()` explaining that long sources may arrive as a lead + excerpts within a fixed budget, and that gaps / partial views are not unreliability signals.

3. **`Strengthen SOURCE UNAVAILABLE prompt guidance`** — replaces the single-paragraph excerpt note with a structured three-bullet list enumerating the chrome/excerpt/brevity patterns the model should ignore, followed by an explicit enumeration of what DOES warrant `SOURCE UNAVAILABLE` (login wall, 404, metadata-only catalog page, "access denied"). The key anchor sentence: "If ANY paragraph of article prose is visible — even if surrounded by chrome or separated by gaps — evaluate based on that paragraph." Added after per-entry diff-view analysis showed Claude still over-triggering `SOURCE UNAVAILABLE` on excerpt views despite the prior milder tweak.

4. **`benchmark: pass claim as query param when extracting source content`** — mirrors change #1 in `benchmark/extract_dataset.js` so the benchmark's source-fetch path exercises the same `&query=` contract as the deployed userscript. Pre-#165 (which unified `run_benchmark.js`'s prompt with `core/prompts.js`), the benchmark and userscript fetch paths could drift independently; now that the prompt is unified across both, fetch behavior should match too. This commit was added 2026-05-02 after rebasing onto post-#155 + #165 main.

The two prompt commits exist because the chunked-output format introduced by the worker side (PAP #8) caused models to over-trigger `SOURCE UNAVAILABLE` on excerpts that are shorter than full articles or that have visible structural gaps. They are functionally paired with the proxy/worker change rather than being a separate prompt-tuning effort.

## Backward compatibility

- **Old Worker + new client**: the Worker silently ignores unknown query params, so this PR is safe to ship before the Worker patch is deployed.
- **New Worker + old client**: the Worker receives no `query` param, falls back to the first-N-chars path. Also no regression.
- **Old Worker + old client**: unchanged.

## Testing

Replication run against the benchmark set in #151. The data below is from a run using a locally patched version of the proxy worker.

### Per-provider accuracy (intersection-matched, valid rows, scored against post-audit GT)

| Provider | N | Δ exact | Δ lenient | Δ binary |
|---|---:|---:|---:|---:|
| Apertus 70B | 28 | **+7.1** | +3.6 | +3.6 |
| Claude Sonnet 4.5 | 142 | +3.5 | +4.9 | +2.1 |
| Gemini 2.5 Flash | 142 | +0.7 | +1.4 | +2.1 |
| Qwen SEA-LION v4 | 29 | **+10.3** | **+13.8** | **+13.8** |

### Narrowed subset — rows where the proxy actually changes what the LLM sees

Of the 156 rows, 37 (24%) trigger a non-passthrough extraction strategy (`lead+matches`, `lead+matches+backfill`, or `fallback`). The remaining 119 use `short` strategy and pass through identically to baseline (105 rows are below the 12k budget; 14 had fetch errors). Accuracy deltas on the narrowed subset:

| Provider | N | Δ exact | Δ lenient | Δ binary |
|---|---:|---:|---:|---:|
| Apertus 70B | 9 | +11.1 | +11.1 | +11.1 |
| Claude Sonnet 4.5 | 37 | +2.7 | +5.4 | 0.0 |
| Gemini 2.5 Flash | 37 | −2.7 | +2.7 | +2.7 |
| Qwen SEA-LION v4 | 10 | +30.0 | +30.0 | +30.0 |

### v2 slice — additional benchmarking

After PR #155 added the 34 v2 rows to `dataset.json`, I ran the same comparison on the v2 subset alone (Claude Sonnet 4.5 and Gemini 2.5 Flash only — my PublicAI account "ran out of credit", so Apertus and Qwen weren't tested on v2):

| Provider | N | exact: baseline → PR #114 | binary: baseline → PR #114 | SOURCE UNAVAILABLE rate: baseline → PR #114 |
|---|---:|---|---|---|
| Claude Sonnet 4.5 | 32 | 21.9% → 12.5% (−9.4) | 31.2% → 28.1% (−3.1) | 47% → 41% |
| Gemini 2.5 Flash | 32 | 75.0% → 75.0% | 78.1% → 81.2% (+3.1) | 0% → 0% |

Two things to know about this slice:

1. **The `SOURCE UNAVAILABLE` rate dropping for Claude is the prompt patch working as intended** (from 47% down to 41%). But on the v2 slice, ground truth is heavily skewed toward "Not supported" (76% of rows, vs about 52% on the broader 156-row corpus). The rows that previously bailed with `SOURCE UNAVAILABLE` are now answering "Supported" — which is wrong on a slice where the right answer is mostly "Not supported." So Claude's exact-match score goes down on v2 even though the prompt patch is doing what it's designed to do.
2. **Three rows go in the unintended direction** under the patched prompt — they move *toward* `SOURCE UNAVAILABLE`. Manual review (row_93, row_100, row_105) found that on all three the source content is fully present in the fetched text, and the model's free-text comments correctly diagnose "source is on-topic but doesn't address this specific claim" — and label that `SOURCE UNAVAILABLE` instead of `Not supported`. This is a verdict-classification confusion at the `SOURCE UNAVAILABLE` / `Not supported` boundary that prompt-tuning can move around but cannot fix.

The structural followup is filed as #156 — moving the `SOURCE UNAVAILABLE` decision out of the prompt and into deterministic code that runs before the model is called. That issue covers the architectural fix; this PR ships as the prompt-side improvement that makes the broader corpus better today.

## Known regressions

Identified one repeating regression pattern: **row_3** (Migration Policy Institute article, 65k chars, claim about U.S. share of international migrants). I’ll file a bug about this separately - the improved numbers are without a fix for this.

## Open followups (separate issues)

- **Structural / cross-cutting:** #156 — make `SOURCE UNAVAILABLE` a deterministic check that runs before the main prompt. Once that lands, the prompt patches in this PR (commits 2 and 3) become unnecessary on availability classification, since the model would only ever see content the fetcher has already classified as available.
- **Worker-side:** tokenizer/scoring refinement for the row_3 pattern.
- **Worker-side:** the `fallback` strategy fires on 16/156 rows (10%) — when the worker's claim tokenizer can't match into the source. Further tokenizer work could shrink this.
- **Userscript-side:** investigate Gemini's narrowed-subset exact-metric regression (3 won / 4 lost). It downgrades Supported → Partially-Supported more readily than other providers when seeing chunked output.

## Attribution

Written with Claude; author is the model, committer is me.

