### PR TITLE
Strip Wikipedia maintenance markers from extracted claim text

### DIFF
--- a/benchmark/extract_dataset.js
+++ b/benchmark/extract_dataset.js
@@ -17,6 +17,12 @@ const path = require('path');
 const https = require('https');
 const { JSDOM } = require('jsdom');
 
+// Wikipedia inline maintenance markers that the article renders as bracketed
+// superscript text (e.g. "[failed verification]"). These leak into claim text
+// when the surrounding ref is the one we're testing — strip them so they
+// don't bias the LLM verdict.
+const MAINTENANCE_MARKER_RE = /\[(failed verification|verification needed|citation needed|better source[^\]]*|dubious[^\]]*|unreliable source[^\]]*|clarification needed|disputed[^\]]*|page needed|when\??|where\??|who\??|why\??|by whom\??|according to whom\??|original research[^\]]*|specify[^\]]*|vague|opinion|fact)\]/gi;
+
 // Configuration
 const INPUT_CSV = path.join(__dirname, '..', 'Benchmarking_data_Citations.csv');
 const OUTPUT_JSON = path.join(__dirname, 'dataset.json');
@@ -223,6 +229,7 @@ function extractClaimText(document, citationNumber) {
         // Clean up
         text = text
             .replace(/\[\d+\]/g, '')
+            .replace(MAINTENANCE_MARKER_RE, '')
             .replace(/\s+/g, ' ')
             .trim();
 
@@ -230,6 +237,7 @@ function extractClaimText(document, citationNumber) {
         if (!text || text.length < 10) {
             text = container.textContent
                 .replace(/\[\d+\]/g, '')
+                .replace(MAINTENANCE_MARKER_RE, '')
                 .replace(/\s+/g, ' ')
                 .trim();
         }

--- a/main.js
+++ b/main.js
@@ -4,7 +4,13 @@
 
 (function() {
     'use strict';
-    
+
+    // Wikipedia inline maintenance markers that the article renders as bracketed
+    // superscript text (e.g. "[failed verification]"). Strip them from extracted
+    // claim text so they don't bias the LLM verdict toward the editor's own
+    // tagging.
+    const MAINTENANCE_MARKER_RE = /\[(failed verification|verification needed|citation needed|better source[^\]]*|dubious[^\]]*|unreliable source[^\]]*|clarification needed|disputed[^\]]*|page needed|when\??|where\??|who\??|why\??|by whom\??|according to whom\??|original research[^\]]*|specify[^\]]*|vague|opinion|fact)\]/gi;
+
     class WikipediaSourceVerifier {
         constructor() {
             this.providers = {
@@ -1487,18 +1493,20 @@
             
             // Clean up the text
             claimText = claimText
-                .replace(/\[\d+\]/g, '')           // Remove reference numbers like [1], [2]
-                .replace(/\s+/g, ' ')              // Normalize whitespace
+                .replace(/\[\d+\]/g, '')                 // Remove reference numbers like [1], [2]
+                .replace(MAINTENANCE_MARKER_RE, '')      // Remove maintenance markers like [failed verification]
+                .replace(/\s+/g, ' ')                    // Normalize whitespace
                 .trim();
-            
+
             // If we got nothing meaningful, fall back to the container text
             if (!claimText || claimText.length < 10) {
                 claimText = container.textContent
                     .replace(/\[\d+\]/g, '')
+                    .replace(MAINTENANCE_MARKER_RE, '')
                     .replace(/\s+/g, ' ')
                     .trim();
             }
-            
+
             return claimText;
         }
         


### PR DESCRIPTION
## Summary

When the user script (or the offline benchmark dataset builder) extracts the sentence(s) attached to a citation, it strips inline reference numbers like `[1]` but at least sometimes leaves editor-applied inline maintenance markers in place. Tags like `[failed verification]`, `[citation needed]`, and `[better source needed]` were therefore being passed verbatim into the claim text the LLM verifies, which presumably will taint the verdict.

## Fix

Add a shared `MAINTENANCE_MARKER_RE` covering the common Wikipedia inline markers, and apply it in the same cleanup chain as the existing `[\d+]` strip — in both:

- `main.js` — the runtime claim extractor in `WikipediaSourceVerifier.extractClaimText()`
- `benchmark/extract_dataset.js` — the offline dataset builder used to construct the benchmark fixtures

The two files keep their own copy of the regex deliberately: `main.js` is loaded directly into Wikipedia as a single user script (no build step), so it cannot share a module with the benchmark code. They are kept identical by inspection; if a third call site appears, this would be a candidate to extract.

## Markers covered

`failed verification`, `verification needed`, `citation needed`, `better source*`, `dubious*`, `unreliable source*`, `clarification needed`, `disputed*`, `page needed`, `when?`, `where?`, `who?`, `why?`, `by whom?`, `according to whom?`, `original research*`, `specify*`, `vague`, `opinion`, `fact`. Match is case-insensitive; the `*` markers use a `[^\]]*` tail so variants like `[better source needed]` or `[disputed – discuss]` are caught.

## How this was found

Surfaced while reviewing rows in PR #116 (benchmark expansion): `row_203`'s extracted claim contained the literal string `failed verification` because the row was mined from the very revision that added the tag, and the surrounding article text rendered the marker inline.

## Test plan

- [x] Manual: re-extracted affected benchmark rows; markers no longer appear in `claim_text`
- [ ] Smoke: run the user script in a browser against an article with a `{{Failed verification}}` tag and confirm the rendered claim text in the verifier UI no longer includes the bracketed marker

🤖 Generated with [Claude Code](https://claude.com/claude-code)