### PR TITLE
benchmark: migrate to ESM and dedup extractClaimText via core/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ benchmark/
   run_benchmark.js               # Run LLM verification on dataset
   analyze_results.js             # Calculate metrics and confusion matrices
   generate_comparison.js         # Generate comparison CSV
-  dataset.json                   # 76 claim-citation pairs (ground truth)
+  dataset.json                   # 77 claim-citation pairs (ground truth)
   results.json                   # Raw benchmark results
   analysis.json                  # Calculated metrics
 Benchmarking_data_Citations.csv  # Source ground truth data
@@ -72,6 +72,10 @@ npm run benchmark:publicai  # Run specific provider
 npm run analyze        # Analyze results
 npm run report         # Generate markdown report
 ```
+
+### Module system and shared logic
+
+`benchmark/` is ESM (`"type": "module"` in `benchmark/package.json`) and imports `extractClaimText` from `../core/claim.js`. Editing claim-extraction logic in `core/` automatically affects both the userscript (`main.js`, via the sync script) and the benchmark — no second copy to keep in sync.
 
 **Required environment variables:**
 - `ANTHROPIC_API_KEY` - Claude

--- a/benchmark/analyze_results.js
+++ b/benchmark/analyze_results.js
@@ -12,8 +12,13 @@
  *   - analysis.json: Detailed metrics in JSON format
  */
 
-const fs = require('fs');
-const path = require('path');
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 // Configuration
 const RESULTS_PATH = path.join(__dirname, 'results.json');

--- a/benchmark/extract_dataset.js
+++ b/benchmark/extract_dataset.js
@@ -12,10 +12,16 @@
  *   - dataset_review.csv: CSV for manual review before benchmarking
  */
 
-const fs = require('fs');
-const path = require('path');
-const https = require('https');
-const { JSDOM } = require('jsdom');
+import fs from 'fs';
+import path from 'path';
+import https from 'https';
+import http from 'http';
+import { JSDOM } from 'jsdom';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 // Configuration
 const INPUT_CSV = path.join(__dirname, '..', 'Benchmarking_data_Citations.csv');
@@ -96,7 +102,7 @@ async function fetchWithRetry(url, maxRetries = 3) {
  */
 function fetchURL(url) {
     return new Promise((resolve, reject) => {
-        const protocol = url.startsWith('https') ? https : require('http');
+        const protocol = url.startsWith('https') ? https : http;
 
         const request = protocol.get(url, {
             headers: { 'User-Agent': 'Mozilla/5.0 (compatible; BenchmarkBot/1.0)' }

--- a/benchmark/extract_dataset.js
+++ b/benchmark/extract_dataset.js
@@ -19,6 +19,7 @@ import http from 'http';
 import { JSDOM } from 'jsdom';
 import { fileURLToPath } from 'url';
 import { dirname } from 'path';
+import { extractClaimText as extractClaimTextFromRef } from '../core/claim.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -185,125 +186,39 @@ async function fetchSourceContent(url) {
 }
 
 /**
- * Extract claim text for a specific citation from Wikipedia HTML
+ * For a given citation number, find every `.reference` element on the page
+ * that displays as `[N]` and extract the prose claim text bearing each one.
+ *
+ * Returns an array of `{occurrence, text, containerText}` so the caller can
+ * pick a specific occurrence (Wikipedia reuses citation numbers — the same
+ * `[5]` can appear several times in different paragraphs).
+ *
+ * Per-element extraction delegates to core/claim.js so the maintenance-marker
+ * stripping (PR #117) and the Range-based extraction stay in one place.
  */
-function extractClaimText(document, citationNumber) {
-    // Find all references with this citation number
-    const allRefs = document.querySelectorAll('.reference');
+export function extractClaimsForCitation(document, citationNumber) {
     const matchingRefs = [];
-
-    allRefs.forEach(ref => {
+    document.querySelectorAll('.reference').forEach(ref => {
         const link = ref.querySelector('a');
-        if (link) {
-            const text = link.textContent.trim();
-            // Match [N] pattern
-            const match = text.match(/^\[(\d+)\]$/);
-            if (match && parseInt(match[1], 10) === citationNumber) {
-                matchingRefs.push(ref);
-            }
+        if (!link) return;
+        const m = link.textContent.trim().match(/^\[(\d+)\]$/);
+        if (m && parseInt(m[1], 10) === citationNumber) {
+            matchingRefs.push(ref);
         }
     });
 
-    return matchingRefs.map((ref, occurrenceIndex) => {
+    return matchingRefs.map((ref, i) => {
+        const text = extractClaimTextFromRef(ref);
         const container = ref.closest('p, li, td, th, dd');
-        if (!container) {
-            return { occurrence: occurrenceIndex + 1, text: '', container: null };
-        }
-
-        // Get all references in this container
-        const refsInContainer = Array.from(container.querySelectorAll('.reference'));
-        const currentIndex = refsInContainer.indexOf(ref);
-
-        // Simple extraction: get text before this reference
-        let text = '';
-
-        if (currentIndex === 0) {
-            // First reference in container - get all text up to this ref
-            text = getTextBeforeElement(container, ref);
-        } else {
-            // Get text between previous ref and this one
-            const prevRef = refsInContainer[currentIndex - 1];
-            text = getTextBetweenElements(container, prevRef, ref);
-        }
-
-        // Clean up
-        text = text
-            .replace(/\[\d+\]/g, '')
-            .replace(/\s+/g, ' ')
-            .trim();
-
-        // Fallback to container text if extraction failed
-        if (!text || text.length < 10) {
-            text = container.textContent
-                .replace(/\[\d+\]/g, '')
-                .replace(/\s+/g, ' ')
-                .trim();
-        }
-
+        const containerText = container
+            ? container.textContent.replace(/\s+/g, ' ').trim()
+            : '';
         return {
-            occurrence: occurrenceIndex + 1,
-            text: text,
-            containerText: container.textContent.replace(/\s+/g, ' ').trim()
+            occurrence: i + 1,
+            text,
+            containerText,
         };
     });
-}
-
-/**
- * Get text content before a specific element within a container
- */
-function getTextBeforeElement(container, element) {
-    let text = '';
-    const walker = container.ownerDocument.createTreeWalker(
-        container,
-        4, // NodeFilter.SHOW_TEXT
-        null
-    );
-
-    let node;
-    while ((node = walker.nextNode())) {
-        if (element.contains(node) || isAfterElement(node, element)) {
-            break;
-        }
-        text += node.textContent;
-    }
-    return text;
-}
-
-/**
- * Get text content between two elements
- */
-function getTextBetweenElements(container, startElement, endElement) {
-    let text = '';
-    let capturing = false;
-
-    const walker = container.ownerDocument.createTreeWalker(
-        container,
-        4, // NodeFilter.SHOW_TEXT
-        null
-    );
-
-    let node;
-    while ((node = walker.nextNode())) {
-        if (startElement.contains(node)) {
-            capturing = true;
-            continue;
-        }
-        if (endElement.contains(node)) {
-            break;
-        }
-        if (capturing) {
-            text += node.textContent;
-        }
-    }
-    return text;
-}
-
-/**
- * Check if node comes after element in document order
- */
-function isAfterElement(node, element) {
-    const position = node.compareDocumentPosition(element);
-    return (position & 2) !== 0; // DOCUMENT_POSITION_PRECEDING
 }
 
 /**
@@ -475,7 +390,7 @@ async function main() {
             console.log(`  Citation [${citationNumber}] (instance ${occurrence})...`);
 
             // Extract claim text
-            const claims = extractClaimText(document, citationNumber);
+            const claims = extractClaimsForCitation(document, citationNumber);
             const claimData = claims[occurrence - 1] || claims[0] || { text: '', occurrence: 1 };
 
             // Extract reference URL

--- a/benchmark/extract_dataset.js
+++ b/benchmark/extract_dataset.js
@@ -499,5 +499,7 @@ function writeReviewCSV(dataset) {
     fs.writeFileSync(OUTPUT_REVIEW_CSV, csv);
 }
 
-// Run
-main().catch(console.error);
+// Run only when invoked as a script, not when imported by tests or other modules
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+    main().catch(console.error);
+}

--- a/benchmark/generate_comparison.js
+++ b/benchmark/generate_comparison.js
@@ -1,6 +1,11 @@
 #!/usr/bin/env node
-const fs = require('fs');
-const path = require('path');
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 const results = JSON.parse(fs.readFileSync(path.join(__dirname, 'results.json'), 'utf-8'));
 

--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -2,6 +2,7 @@
   "name": "citation-benchmark",
   "version": "1.0.0",
   "description": "Benchmarking tools for comparing LLM performance on citation verification",
+  "type": "module",
   "scripts": {
     "extract": "node extract_dataset.js",
     "extract:dry": "node extract_dataset.js --dry-run",

--- a/benchmark/run_benchmark.js
+++ b/benchmark/run_benchmark.js
@@ -15,9 +15,14 @@
  *   - results.json: Complete benchmark results
  */
 
-const fs = require('fs');
-const path = require('path');
-const https = require('https');
+import fs from 'fs';
+import path from 'path';
+import https from 'https';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 // Configuration
 const DATASET_PATH = path.join(__dirname, 'dataset.json');

--- a/tests/benchmark_extract.test.js
+++ b/tests/benchmark_extract.test.js
@@ -1,0 +1,49 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+import { extractClaimsForCitation } from '../benchmark/extract_dataset.js';
+
+function mkDoc(html) {
+    return new JSDOM(`<!DOCTYPE html><body>${html}</body>`).window.document;
+}
+
+test('extractClaimsForCitation: returns one entry per occurrence of [N]', () => {
+    const doc = mkDoc(`
+        <p>First sentence.<sup class="reference"><a href="#x">[5]</a></sup>
+        Second sentence.<sup class="reference"><a href="#y">[5]</a></sup></p>
+    `);
+    const claims = extractClaimsForCitation(doc, 5);
+    assert.equal(claims.length, 2);
+    assert.equal(claims[0].occurrence, 1);
+    assert.equal(claims[1].occurrence, 2);
+});
+
+test('extractClaimsForCitation: returns empty array when citation number is absent', () => {
+    const doc = mkDoc(`
+        <p>Only one cite.<sup class="reference"><a href="#x">[1]</a></sup></p>
+    `);
+    const claims = extractClaimsForCitation(doc, 99);
+    assert.deepEqual(claims, []);
+});
+
+test('extractClaimsForCitation: strips Wikipedia maintenance markers from claim text', () => {
+    // This is the test that proves PR #117's behavior is now applied to the
+    // benchmark via the core/claim.js dedup. Without this, marker stripping
+    // would only be exercised by chance on a real-world dataset extraction.
+    const doc = mkDoc(`
+        <p>Water freezes at 0 degrees Celsius [failed verification] at sea level.<sup class="reference"><a href="#x">[1]</a></sup></p>
+    `);
+    const claims = extractClaimsForCitation(doc, 1);
+    assert.equal(claims.length, 1);
+    assert.doesNotMatch(claims[0].text, /failed verification/i,
+        'expected MAINTENANCE_MARKER_RE to strip [failed verification] from claim text');
+    assert.match(claims[0].text, /Water freezes at 0/);
+});
+
+test('extractClaimsForCitation: does NOT match [10] when asked for [1]', () => {
+    const doc = mkDoc(`
+        <p>Ten.<sup class="reference"><a href="#x">[10]</a></sup></p>
+    `);
+    const claims = extractClaimsForCitation(doc, 1);
+    assert.deepEqual(claims, []);
+});


### PR DESCRIPTION
## Summary

Stacks on #118 (core/ extraction) — **do not merge until #118 lands**. Independent of #119 (CLI); the benchmark refactor does not depend on the CLI work.

Four commits on top of #118, each reviewable standalone:

1. **`4f2dc74` — benchmark: migrate to ESM (mechanical conversion, no behavior change).** Adds `"type": "module"` to `benchmark/package.json` and converts all four `benchmark/*.js` (`extract_dataset.js`, `run_benchmark.js`, `analyze_results.js`, `generate_comparison.js`) from `require()` → `import`, plus the standard `dirname(fileURLToPath(import.meta.url))` shim for `__dirname`. The one dynamic `require('http')` in `extract_dataset.js` becomes a static import at the top of that file. Pure consumption-side change; the four files are all runner scripts, none of them export anything after the conversion.

2. **`8c12504` — benchmark: dedup `extractClaimText`, import from `core/claim.js`.** Deletes ~120 LOC of duplicated code from `extract_dataset.js` (the local `extractClaimText` plus its `getTextBeforeElement` / `getTextBetweenElements` / `isAfterElement` TreeWalker helpers). A small exported wrapper `extractClaimsForCitation(document, citationNumber)` now enumerates every `.reference` element matching `[N]` on the page (Wikipedia reuses citation numbers) and delegates per-element extraction to `core/claim.js`'s `extractClaimText`. The `{occurrence, text, containerText}` return shape is preserved so the single call site works unchanged.

   **Intentional behavior change:** `core/claim.js` strips Wikipedia maintenance markers (`[failed verification]`, `[citation needed]`, …) via its exported `MAINTENANCE_MARKER_RE`; the deleted local copy did not. This applies the #117 fix to the benchmark side via the dedup. Coordination note: if this PR lands before #117, #117's benchmark-side change becomes redundant and can be closed.

   Also adds `tests/benchmark_extract.test.js` (4 `node:test` tests) — the third test is load-bearing: `assert.doesNotMatch(claims[0].text, /failed verification/i, ...)` against a fixture containing `[failed verification]`. This locks in the marker-stripping behavior so a future refactor can't silently regress it.

3. **`97a05e3` — benchmark: guard `main()` so importing `extract_dataset.js` is side-effect free.** Wraps the bottom-of-file `main().catch(...)` in the standard ESM script-entry guard `if (process.argv[1] === fileURLToPath(import.meta.url))`. Without this, the test file's import of `extractClaimsForCitation` would execute the module body — triggering a full real-network benchmark run on every `npm test` (~180s, fetching Wikipedia + third-party sources, modifying `benchmark/dataset.json`). After the fix, `npm test` is ~0.8s and side-effect free. Direct invocation (`node benchmark/extract_dataset.js`, `npm run extract`, `npm run extract:dry`) continues to work exactly as before.

4. **`39455ee` — docs: note `benchmark/` is ESM and imports from `core/`; fix dataset count.** Sub-repo `CLAUDE.md`: dataset count `76` → `77`, plus a new "Module system and shared logic" subsection noting the ESM + `core/claim.js` reuse. Surgical — other stale content (e.g., "No test framework" line) is intentionally scoped to a separate doc-refresh PR that pairs with #118.

## Out of scope (flagged for follow-up)

- `extractReferenceUrl` in `extract_dataset.js` is also duplicated against `core/urls.js`. Left alone per the plan; separate PR.
- Other stale lines in `CLAUDE.md` (e.g., "No build system") — those belong to the doc-refresh PR that pairs with #118.

## Test plan

- [x] `npm test` → **26/26 pass** (22 from the existing `node:test` suite on `main` + 4 new from `tests/benchmark_extract.test.js`); completes in ~0.8s with no network I/O
- [x] `cd benchmark && npm run extract:dry -- --limit 5` → exit 0, prints `[DRY RUN] No files written`
- [x] `cd benchmark && npm run analyze` → exit 0 against the committed `results.json` (Claude-Sonnet 75.0% exact-match)
- [x] `cd benchmark && node generate_comparison.js` → exit 0, writes `results_comparison.csv` (unstaged local artifact)
- [ ] `cd benchmark && npm run benchmark:publicai -- --limit 2` — **skipped locally** (no `PUBLICAI_API_KEY` in env); recommend reviewer exercises this path if a key is available, to verify the LLM-call pipeline works under ESM
- [x] `git diff main..HEAD -- core/` is empty — `core/` is consumer-side-only from this PR

## Notes for reviewer

- This PR's branch was cut after #118's content was merged into the fork's local `main`, so against upstream `main` this PR shows **13 commits** — 9 of those are #118's content and 4 are this PR's. Filtering to "changes since #118" gives the actual scope of this PR. Once #118 lands upstream, the diff here will collapse to the intended 4-commit view.
- #118 must land before this one — the Phase 2 dedup imports from `../core/claim.js`, which is created by #118.
- Independent of #119 — both stack on #118; either can be reviewed and merged without the other.
- All four commits are small and intended to be squashed only if the maintainer prefers; individually they tell a clean "convert → dedup → fix test pollution → update docs" story.