### PR TITLE
Add source content override feature for citation verification

### DIFF
--- a/main.js
+++ b/main.js
@@ -646,6 +646,7 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
             this.currentVerifyId = 0;
 
             this.sourceTextInput = null;
+            this.sourceInputForOverride = false;
 
             // Article report state
             this.reportMode = false;
@@ -732,6 +733,7 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
                     <div id="verifier-source-section">
                         <h4>Source Content</h4>
                         <div id="verifier-source-text">No source loaded yet.</div>
+                        <div id="verifier-source-override-container" style="display: none; margin-top: 8px;"></div>
                         <div id="verifier-source-input-container" style="display: none; margin-top: 10px;">
                             <div id="verifier-source-textarea-container"></div>
                             <div id="verifier-source-buttons" style="margin-top: 8px; display: flex; gap: 8px;">
@@ -1693,6 +1695,13 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
                 flags: ['safe']
             });
 
+            this.buttons.overrideText = new OO.ui.ButtonWidget({
+                label: 'Override content',
+                icon: 'edit',
+                framed: false,
+                title: 'Replace the fetched source content with text you paste in (e.g., the full article from The Wikipedia Library)'
+            });
+
             // Article report buttons
             this.buttons.verifyAll = new OO.ui.ButtonWidget({
                 label: 'Verify All Citations',
@@ -1726,6 +1735,7 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
             document.getElementById('verifier-source-textarea-container').appendChild(this.sourceTextInput.$element[0]);
             document.getElementById('verifier-load-text-btn-container').appendChild(this.buttons.loadText.$element[0]);
             document.getElementById('verifier-cancel-text-btn-container').appendChild(this.buttons.cancelText.$element[0]);
+            document.getElementById('verifier-source-override-container').appendChild(this.buttons.overrideText.$element[0]);
         }
         
         updateProviderInfo() {
@@ -1977,35 +1987,66 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
             }
         }
         
-        showSourceTextInput() {
+        showSourceTextInput(forOverride = false) {
+            this.sourceInputForOverride = forOverride;
             document.getElementById('verifier-source-input-container').style.display = 'block';
-            document.getElementById('verifier-source-text').textContent = 'No URL found. Please paste the source text below:';
+            if (!forOverride) {
+                document.getElementById('verifier-source-text').textContent = 'No URL found. Please paste the source text below:';
+            }
             this.sourceTextInput.setValue('');
+            this.hideOverrideButton();
         }
-        
+
         hideSourceTextInput() {
             document.getElementById('verifier-source-input-container').style.display = 'none';
+            this.refreshOverrideButton();
         }
-        
+
+        showOverrideButton() {
+            const el = document.getElementById('verifier-source-override-container');
+            if (el) el.style.display = '';
+        }
+
+        hideOverrideButton() {
+            const el = document.getElementById('verifier-source-override-container');
+            if (el) el.style.display = 'none';
+        }
+
+        // Show the override button only when a citation is selected and the
+        // manual-input panel is not already open.
+        refreshOverrideButton() {
+            const inputOpen = document.getElementById('verifier-source-input-container').style.display === 'block';
+            if (this.activeClaim && !inputOpen && !this.reportMode) {
+                this.showOverrideButton();
+            } else {
+                this.hideOverrideButton();
+            }
+        }
+
         loadManualSourceText() {
             const text = this.sourceTextInput.getValue().trim();
             if (!text) {
                 this.updateStatus('Please enter some source text', true);
                 return;
             }
-            
+
             this.activeSource = `Manual source text:\n\n${text}`;
             document.getElementById('verifier-source-text').innerHTML = `<strong>Manual Source Text:</strong><br><em>${text.substring(0, 200)}${text.length > 200 ? '...' : ''}</em>`;
+            this.sourceInputForOverride = false;
             this.hideSourceTextInput();
             this.updateButtonVisibility();
             this.updateStatus('Source text loaded. Ready to verify.');
         }
-        
+
         cancelManualSourceText() {
+            const wasOverride = this.sourceInputForOverride;
             this.sourceTextInput.setValue('');
+            this.sourceInputForOverride = false;
             this.hideSourceTextInput();
-            this.activeSource = null;
-            document.getElementById('verifier-source-text').textContent = 'No source loaded.';
+            if (!wasOverride) {
+                this.activeSource = null;
+                document.getElementById('verifier-source-text').textContent = 'No source loaded.';
+            }
             this.updateButtonVisibility();
             this.updateStatus('Cancelled');
         }
@@ -2155,6 +2196,11 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
             
             this.buttons.cancelText.on('click', () => {
                 this.cancelManualSourceText();
+            });
+
+            this.buttons.overrideText.on('click', () => {
+                this.showSourceTextInput(true);
+                this.updateStatus('Paste replacement source text below, then click Load Text.');
             });
 
             this.buttons.verifyAll.on('click', () => {
@@ -2433,6 +2479,7 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
             document.getElementById('verifier-results').style.display = '';
             // Hide report view
             document.getElementById('verifier-report-view').style.display = 'none';
+            this.refreshOverrideButton();
             this.updateButtonVisibility();
         }
 

--- a/main.js
+++ b/main.js
@@ -1979,6 +1979,7 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
                 }
 
                 this.updateButtonVisibility();
+                this.refreshOverrideButton();
                 this.updateStatus(contentFetched ? 'Source fetched. Ready to verify.' : 'Ready to verify claim against source');
                 
             } catch (error) {
@@ -2012,11 +2013,11 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
             if (el) el.style.display = 'none';
         }
 
-        // Show the override button only when a citation is selected and the
-        // manual-input panel is not already open.
+        // Show the override button only when there is a loaded source to override
+        // and the manual-input panel is not already open.
         refreshOverrideButton() {
             const inputOpen = document.getElementById('verifier-source-input-container').style.display === 'block';
-            if (this.activeClaim && !inputOpen && !this.reportMode) {
+            if (this.activeClaim && this.activeSource && !inputOpen && !this.reportMode) {
                 this.showOverrideButton();
             } else {
                 this.hideOverrideButton();


### PR DESCRIPTION
## Summary
This PR adds the ability for users to override fetched source content with manually pasted text during citation verification. This is useful when the automatic source fetching fails or when users want to verify citations against a specific version of content (e.g., from The Wikipedia Library).

## Key Changes
- **New state tracking**: Added `sourceInputForOverride` flag to distinguish between manual input for missing sources vs. overriding existing sources
- **Override button**: Created new "Override content" button that allows users to replace the currently loaded source with custom text
- **UI improvements**: 
  - Added `verifier-source-override-container` div to display the override button
  - Override button only appears when a citation is selected and the manual input panel is not already open
- **Enhanced input handling**:
  - Modified `showSourceTextInput()` to accept a `forOverride` parameter
  - Updated `cancelManualSourceText()` to preserve the active source when canceling an override operation
  - Added `refreshOverrideButton()` method to intelligently show/hide the override button based on UI state
- **Button event handling**: Connected the override button to trigger the source text input panel with appropriate user guidance

## Implementation Details
- The override feature maintains the existing source content when the user cancels the override operation, unlike the normal manual input flow which clears the source
- The override button visibility is contextual and automatically refreshes when citations are selected/deselected or when the manual input panel is toggled
- User-facing messaging distinguishes between "no source found" scenarios and "override existing source" scenarios

https://claude.ai/code/session_01SYHoFtmjbq54sacu3aay1K