### PR TITLE
Fix OOUI dialog positioning when sidebar is visible

### DIFF
--- a/main.js
+++ b/main.js
@@ -987,8 +987,12 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
                     border-radius: 3px;
                     padding: 2px 6px;
                 }
+                body {
+                    --verifier-sidebar-width: ${this.sidebarWidth};
+                }
                 body.verifier-sidebar-hidden {
                     margin-right: 0 !important;
+                    --verifier-sidebar-width: 0px !important;
                 }
                 body.verifier-sidebar-hidden #source-verifier-sidebar {
                     display: none;
@@ -996,6 +1000,13 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
                 body.verifier-sidebar-hidden #ca-verifier,
                 body.verifier-sidebar-hidden #t-verifier {
                     display: list-item !important;
+                }
+                /* Keep OOUI dialogs above the sidebar (z-index 10000) and
+                   centered within the visible article area. */
+                .oo-ui-window-manager-modal,
+                .oo-ui-windowManager-modal {
+                    z-index: 10002;
+                    right: var(--verifier-sidebar-width, 0px);
                 }
                 /* Report view styles */
                 #verifier-report-view h4 {
@@ -2076,6 +2087,7 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
                     const widthPx = newWidth + 'px';
                     sidebar.style.width = widthPx;
                     document.body.style.marginRight = widthPx;
+                    document.body.style.setProperty('--verifier-sidebar-width', widthPx);
                     this.sidebarWidth = widthPx;
                     localStorage.setItem('verifier_sidebar_width', widthPx);
                 }


### PR DESCRIPTION
## Summary
This PR fixes the positioning of OOUI dialogs (modal windows) to remain centered and properly layered above the verifier sidebar when it's visible.

## Key Changes
- Added a CSS custom property `--verifier-sidebar-width` to the body element to track the current sidebar width
- Updated the property value when the sidebar is hidden (set to 0px)
- Added CSS rules for OOUI dialog managers (`.oo-ui-window-manager-modal` and `.oo-ui-windowManager-modal`) to:
  - Set a higher z-index (10002) to appear above the sidebar (z-index 10000)
  - Use the `--verifier-sidebar-width` custom property to adjust the `right` position, keeping dialogs centered within the visible article area
- Updated the sidebar resize handler to set the CSS custom property whenever the sidebar width changes

## Implementation Details
The solution uses CSS custom properties to communicate the sidebar width to the dialog styling rules, allowing dialogs to automatically adjust their positioning without requiring JavaScript manipulation of individual dialog elements. This ensures dialogs remain properly centered and accessible when the sidebar is toggled.

https://claude.ai/code/session_01XAUFTViPGkzjLzxJQfMb5H