### PR TITLE
Drop horizontal modal offset, keep only z-index fix

### DIFF
--- a/main.js
+++ b/main.js
@@ -987,12 +987,8 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
                     border-radius: 3px;
                     padding: 2px 6px;
                 }
-                body {
-                    --verifier-sidebar-width: ${this.sidebarWidth};
-                }
                 body.verifier-sidebar-hidden {
                     margin-right: 0 !important;
-                    --verifier-sidebar-width: 0px !important;
                 }
                 body.verifier-sidebar-hidden #source-verifier-sidebar {
                     display: none;
@@ -1002,11 +998,11 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
                     display: list-item !important;
                 }
                 /* Keep OOUI dialogs above the sidebar (z-index 10000) and
-                   centered within the visible article area. */
+                   the resize handle (10001) so they aren't hidden when the
+                   sidebar overlaps the viewport-centered dialog. */
                 .oo-ui-window-manager-modal,
                 .oo-ui-windowManager-modal {
                     z-index: 10002;
-                    right: var(--verifier-sidebar-width, 0px);
                 }
                 /* Report view styles */
                 #verifier-report-view h4 {
@@ -2087,7 +2083,6 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
                     const widthPx = newWidth + 'px';
                     sidebar.style.width = widthPx;
                     document.body.style.marginRight = widthPx;
-                    document.body.style.setProperty('--verifier-sidebar-width', widthPx);
                     this.sidebarWidth = widthPx;
                     localStorage.setItem('verifier_sidebar_width', widthPx);
                 }


### PR DESCRIPTION
The previous attempt also constrained the OOUI modal's right edge to the sidebar's left edge, which shrank the modal's content box below the dialog frame's natural width. OOUI's overflow:hidden then clipped the dialog text and OK button.

Drop the horizontal constraint and keep only the z-index lift. The dialog will be viewport-centered (visually overlapping the sidebar when the sidebar is wide), but it'll sit on top of the sidebar so it's fully visible and clickable, which is what the bug report was about.