### PR TITLE
Add dark theme styling for verification warning elements

### DIFF
--- a/main.js
+++ b/main.js
@@ -1540,6 +1540,12 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
                         background: #3a3a1a !important;
                         color: #e0c060 !important;
                     }
+                    html.skin-theme-clientpref-os .verifier-truncation-warning,
+                    html.skin-theme-clientpref-os .report-card-truncated {
+                        background: #3a3a1a !important;
+                        color: #e0c060 !important;
+                        border-color: #5a5a2a !important;
+                    }
                     html.skin-theme-clientpref-os .report-card-verdict.not-supported {
                         background: #3a1a1a !important;
                         color: #e06060 !important;


### PR DESCRIPTION
## Summary
Added dark theme CSS styling for verification warning and truncation elements to ensure consistent appearance when using the OS-preferred color scheme.

## Changes
- Added dark theme styles for `.verifier-truncation-warning` and `.report-card-truncated` elements under the `html.skin-theme-clientpref-os` selector
- Applied consistent dark theme color scheme:
  - Background: `#3a3a1a` (dark olive)
  - Text color: `#e0c060` (golden yellow)
  - Border color: `#5a5a2a` (darker olive for borders)

## Details
These styles ensure that verification warning messages and truncated report cards display properly in dark mode with appropriate contrast and visual hierarchy, matching the existing dark theme styling pattern used elsewhere in the codebase.

https://claude.ai/code/session_01HCkUgt1M2vDm5NdGUVuzkQ