### PR TITLE
providers: constrain Gemini to JSON output via responseMimeType

### DIFF
--- a/benchmark/run_benchmark.js
+++ b/benchmark/run_benchmark.js
@@ -248,7 +248,10 @@ async function callGemini(config, systemPrompt, userPrompt) {
         }],
         generationConfig: {
             temperature: 0.1,
-            maxOutputTokens: 1000
+            maxOutputTokens: 1000,
+            // Constrains Gemini to emit syntactically valid JSON only;
+            // see issue #75.
+            responseMimeType: 'application/json'
         }
     });
 

--- a/core/providers.js
+++ b/core/providers.js
@@ -86,7 +86,12 @@ export async function callGeminiAPI({ apiKey, model, systemPrompt, userContent }
         systemInstruction: { parts: [{ text: systemPrompt }] },
         generationConfig: {
             maxOutputTokens: 2048,
-            temperature: 0.0
+            temperature: 0.0,
+            // responseMimeType: 'application/json' constrains Gemini to emit
+            // syntactically valid JSON only. Without it, Gemini occasionally
+            // wraps output in markdown fences or emits prose, both of which
+            // the verdict parser fails on. See issue #75.
+            responseMimeType: 'application/json'
         }
     };
 

--- a/main.js
+++ b/main.js
@@ -446,7 +446,12 @@ async function callGeminiAPI({ apiKey, model, systemPrompt, userContent }) {
         systemInstruction: { parts: [{ text: systemPrompt }] },
         generationConfig: {
             maxOutputTokens: 2048,
-            temperature: 0.0
+            temperature: 0.0,
+            // responseMimeType: 'application/json' constrains Gemini to emit
+            // syntactically valid JSON only. Without it, Gemini occasionally
+            // wraps output in markdown fences or emits prose, both of which
+            // the verdict parser fails on. See issue #75.
+            responseMimeType: 'application/json'
         }
     };
 

--- a/tests/providers.test.js
+++ b/tests/providers.test.js
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import {
   callPublicAIAPI,
   callClaudeAPI,
+  callGeminiAPI,
   callProviderAPI,
 } from '../core/providers.js';
 
@@ -90,6 +91,33 @@ test('callProviderAPI throws on unknown provider', async () => {
     () => callProviderAPI('nope', {}),
     /Unknown provider: nope/
   );
+});
+
+test('callGeminiAPI requests JSON-only output via responseMimeType', async () => {
+  // Issue #75: Gemini occasionally emits prose, markdown-fenced JSON, or
+  // truncated JSON which the verdict parser then fails to read. Setting
+  // responseMimeType: application/json constrains Gemini to emit syntactically
+  // valid JSON, recovering parse-failed rows.
+  const mock = withMockFetch(async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({
+      candidates: [{ content: { parts: [{ text: '{"verdict":"Supported"}' }] } }],
+      usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 5 },
+    }),
+  }));
+  try {
+    await callGeminiAPI({
+      apiKey: 'k',
+      model: 'gemini-2.5-flash',
+      systemPrompt: 's',
+      userContent: 'u',
+    });
+    const body = JSON.parse(mock.calls[0].opts.body);
+    assert.equal(body.generationConfig.responseMimeType, 'application/json');
+  } finally {
+    mock.restore();
+  }
 });
 
 test('callClaudeAPI throws on non-ok response', async () => {


### PR DESCRIPTION
Gemini was failing a loooot when I tried to compare it to other models tonight. This fix cut the parse-failure rate from 53.5% to 32.6% and lifted Gemini's binary accuracy from 73.3% to 79.1%.

What it does: adds "responseMimeType: 'application/json'" to the generationConfig in core/providers.js callGeminiAPI, the synced main.js copy, and the benchmark/run_benchmark.js callGemini path. This parameter forces Gemini to return valid json, never prose or markdown-fenced json, which was happening sometimes. 

Partially addresses #75; #179 may also be coming into play.