### PR TITLE
Add HuggingFace API provider support

### DIFF
--- a/cli/verify.js
+++ b/cli/verify.js
@@ -12,7 +12,7 @@ import { generateSystemPrompt, generateUserPrompt } from '../core/prompts.js';
 import { callProviderAPI } from '../core/providers.js';
 import { parseVerificationResult } from '../core/parsing.js';
 
-const KNOWN_PROVIDERS = ['publicai', 'claude', 'gemini', 'openai'];
+const KNOWN_PROVIDERS = ['publicai', 'huggingface', 'claude', 'gemini', 'openai'];
 
 export function parseCliArgs(argv) {
     const raw = argv.slice(2);
@@ -144,17 +144,19 @@ export function classifyProviderError(err) {
 }
 
 const PROVIDER_MODELS = {
-    publicai: 'aisingapore/Qwen-SEA-LION-v4-32B-IT',
-    claude:   'claude-sonnet-4-6',
-    gemini:   'gemini-flash-latest',
-    openai:   'gpt-4o',
+    publicai:    'aisingapore/Qwen-SEA-LION-v4-32B-IT',
+    huggingface: 'meta-llama/Llama-3.3-70B-Instruct',
+    claude:      'claude-sonnet-4-6',
+    gemini:      'gemini-flash-latest',
+    openai:      'gpt-4o',
 };
 
 const PROVIDER_ENV_VARS = {
-    publicai: null, // routed through the worker proxy; no client-side key
-    claude:   'CLAUDE_API_KEY',
-    gemini:   'GEMINI_API_KEY',
-    openai:   'OPENAI_API_KEY',
+    publicai:    null, // routed through the worker proxy; no client-side key
+    huggingface: null, // routed through the worker proxy; no client-side key
+    claude:      'CLAUDE_API_KEY',
+    gemini:      'GEMINI_API_KEY',
+    openai:      'OPENAI_API_KEY',
 };
 
 export const HELP_TEXT = `usage: ccs verify <wikipedia-url> <citation-number> [options]
@@ -170,11 +172,13 @@ Arguments:
 
 Options:
   --provider <name>  LLM provider to use. One of:
-                       publicai (default; routed via the worker proxy,
-                                 no API key needed)
-                       claude   (requires CLAUDE_API_KEY)
-                       gemini   (requires GEMINI_API_KEY)
-                       openai   (requires OPENAI_API_KEY)
+                       publicai    (default; routed via the worker proxy,
+                                    no API key needed)
+                       huggingface (routed via the worker proxy,
+                                    no API key needed)
+                       claude      (requires CLAUDE_API_KEY)
+                       gemini      (requires GEMINI_API_KEY)
+                       openai      (requires OPENAI_API_KEY)
   --no-log           Do not log the verification to the worker proxy's
                      /log endpoint.
   --help, -h         Show this help and exit.

--- a/cli/verify.js
+++ b/cli/verify.js
@@ -145,7 +145,7 @@ export function classifyProviderError(err) {
 
 const PROVIDER_MODELS = {
     publicai:    'aisingapore/Qwen-SEA-LION-v4-32B-IT',
-    huggingface: 'meta-llama/Llama-3.3-70B-Instruct',
+    huggingface: 'openai/gpt-oss-20b',
     claude:      'claude-sonnet-4-6',
     gemini:      'gemini-flash-latest',
     openai:      'gpt-4o',

--- a/core/providers.js
+++ b/core/providers.js
@@ -1,6 +1,8 @@
 // LLM provider dispatch. Pure HTTP routing — callers build the prompt.
 
-export async function callPublicAIAPI({ model, systemPrompt, userContent, workerBase = 'https://publicai-proxy.alaexis.workers.dev' }) {
+// Shared call shape for proxy-routed OpenAI-compatible upstreams (PublicAI, HF).
+// The proxy injects upstream API keys; the userscript only specifies the model.
+async function callProxyChatCompletion({ url, model, systemPrompt, userContent, label }) {
     const requestBody = {
         model: model,
         messages: [
@@ -11,7 +13,7 @@ export async function callPublicAIAPI({ model, systemPrompt, userContent, worker
         temperature: 0.1
     };
 
-    const response = await fetch(workerBase, {
+    const response = await fetch(url, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(requestBody)
@@ -26,7 +28,7 @@ export async function callPublicAIAPI({ model, systemPrompt, userContent, worker
         } catch {
             errorMessage = errorText;
         }
-        throw new Error(`PublicAI API request failed (${response.status}): ${errorMessage}`);
+        throw new Error(`${label} API request failed (${response.status}): ${errorMessage}`);
     }
 
     const data = await response.json();
@@ -42,6 +44,22 @@ export async function callPublicAIAPI({ model, systemPrompt, userContent, worker
             output: data.usage?.completion_tokens || 0
         }
     };
+}
+
+export async function callPublicAIAPI({ model, systemPrompt, userContent, workerBase = 'https://publicai-proxy.alaexis.workers.dev' }) {
+    return callProxyChatCompletion({
+        url: workerBase,
+        model, systemPrompt, userContent,
+        label: 'PublicAI',
+    });
+}
+
+export async function callHuggingFaceAPI({ model, systemPrompt, userContent, workerBase = 'https://publicai-proxy.alaexis.workers.dev' }) {
+    return callProxyChatCompletion({
+        url: `${workerBase}/hf`,
+        model, systemPrompt, userContent,
+        label: 'HuggingFace',
+    });
 }
 
 export async function callClaudeAPI({ apiKey, model, systemPrompt, userContent }) {
@@ -165,10 +183,11 @@ export async function callOpenAIAPI({ apiKey, model, systemPrompt, userContent }
 
 export async function callProviderAPI(name, config) {
     switch (name) {
-        case 'publicai': return await callPublicAIAPI(config);
-        case 'claude':   return await callClaudeAPI(config);
-        case 'gemini':   return await callGeminiAPI(config);
-        case 'openai':   return await callOpenAIAPI(config);
+        case 'publicai':    return await callPublicAIAPI(config);
+        case 'huggingface': return await callHuggingFaceAPI(config);
+        case 'claude':      return await callClaudeAPI(config);
+        case 'gemini':      return await callGeminiAPI(config);
+        case 'openai':      return await callOpenAIAPI(config);
         default: throw new Error(`Unknown provider: ${name}`);
     }
 }

--- a/main.js
+++ b/main.js
@@ -627,7 +627,7 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
                     name: 'HuggingFace (Free)',
                     storageKey: null, // No key needed - proxy injects upstream key
                     color: '#FF9D00', // HF yellow-orange
-                    model: 'meta-llama/Llama-3.3-70B-Instruct',
+                    model: 'openai/gpt-oss-20b',
                     requiresKey: false
                 },
                 claude: {

--- a/main.js
+++ b/main.js
@@ -353,7 +353,9 @@ function extractClaimText(refElement) {
 // --- core/providers.js ---
 // LLM provider dispatch. Pure HTTP routing — callers build the prompt.
 
-async function callPublicAIAPI({ model, systemPrompt, userContent, workerBase = 'https://publicai-proxy.alaexis.workers.dev' }) {
+// Shared call shape for proxy-routed OpenAI-compatible upstreams (PublicAI, HF).
+// The proxy injects upstream API keys; the userscript only specifies the model.
+async function callProxyChatCompletion({ url, model, systemPrompt, userContent, label }) {
     const requestBody = {
         model: model,
         messages: [
@@ -364,7 +366,7 @@ async function callPublicAIAPI({ model, systemPrompt, userContent, workerBase = 
         temperature: 0.1
     };
 
-    const response = await fetch(workerBase, {
+    const response = await fetch(url, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(requestBody)
@@ -379,7 +381,7 @@ async function callPublicAIAPI({ model, systemPrompt, userContent, workerBase = 
         } catch {
             errorMessage = errorText;
         }
-        throw new Error(`PublicAI API request failed (${response.status}): ${errorMessage}`);
+        throw new Error(`${label} API request failed (${response.status}): ${errorMessage}`);
     }
 
     const data = await response.json();
@@ -395,6 +397,22 @@ async function callPublicAIAPI({ model, systemPrompt, userContent, workerBase = 
             output: data.usage?.completion_tokens || 0
         }
     };
+}
+
+async function callPublicAIAPI({ model, systemPrompt, userContent, workerBase = 'https://publicai-proxy.alaexis.workers.dev' }) {
+    return callProxyChatCompletion({
+        url: workerBase,
+        model, systemPrompt, userContent,
+        label: 'PublicAI',
+    });
+}
+
+async function callHuggingFaceAPI({ model, systemPrompt, userContent, workerBase = 'https://publicai-proxy.alaexis.workers.dev' }) {
+    return callProxyChatCompletion({
+        url: `${workerBase}/hf`,
+        model, systemPrompt, userContent,
+        label: 'HuggingFace',
+    });
 }
 
 async function callClaudeAPI({ apiKey, model, systemPrompt, userContent }) {
@@ -518,10 +536,11 @@ async function callOpenAIAPI({ apiKey, model, systemPrompt, userContent }) {
 
 async function callProviderAPI(name, config) {
     switch (name) {
-        case 'publicai': return await callPublicAIAPI(config);
-        case 'claude':   return await callClaudeAPI(config);
-        case 'gemini':   return await callGeminiAPI(config);
-        case 'openai':   return await callOpenAIAPI(config);
+        case 'publicai':    return await callPublicAIAPI(config);
+        case 'huggingface': return await callHuggingFaceAPI(config);
+        case 'claude':      return await callClaudeAPI(config);
+        case 'gemini':      return await callGeminiAPI(config);
+        case 'openai':      return await callOpenAIAPI(config);
         default: throw new Error(`Unknown provider: ${name}`);
     }
 }
@@ -602,6 +621,13 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
                     storageKey: null, // No key needed - uses built-in key
                     color: '#6B21A8', // Purple for PublicAI
                     model: 'aisingapore/Qwen-SEA-LION-v4-32B-IT',
+                    requiresKey: false
+                },
+                huggingface: {
+                    name: 'HuggingFace (Free)',
+                    storageKey: null, // No key needed - proxy injects upstream key
+                    color: '#FF9D00', // HF yellow-orange
+                    model: 'meta-llama/Llama-3.3-70B-Instruct',
                     requiresKey: false
                 },
                 claude: {

--- a/tests/providers.test.js
+++ b/tests/providers.test.js
@@ -2,6 +2,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
   callPublicAIAPI,
+  callHuggingFaceAPI,
   callClaudeAPI,
   callProviderAPI,
 } from '../core/providers.js';
@@ -61,6 +62,69 @@ test('callPublicAIAPI posts to workerBase and returns text + usage', async () =>
     });
     assert.equal(result.text, 'verdict');
     assert.ok(mock.calls[0].url.startsWith('https://publicai-proxy.alaexis.workers.dev'));
+  } finally {
+    mock.restore();
+  }
+});
+
+test('callHuggingFaceAPI posts to workerBase /hf and returns text + usage', async () => {
+  const mock = withMockFetch(async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({
+      choices: [{ message: { content: 'hf-verdict' } }],
+      usage: { prompt_tokens: 50, completion_tokens: 10 },
+    }),
+  }));
+  try {
+    const result = await callHuggingFaceAPI({
+      model: 'meta-llama/Llama-3.3-70B-Instruct',
+      systemPrompt: 's',
+      userContent: 'u',
+    });
+    assert.equal(result.text, 'hf-verdict');
+    assert.equal(result.usage.input, 50);
+    assert.equal(result.usage.output, 10);
+    assert.equal(mock.calls[0].url, 'https://publicai-proxy.alaexis.workers.dev/hf');
+    const sent = JSON.parse(mock.calls[0].opts.body);
+    assert.equal(sent.model, 'meta-llama/Llama-3.3-70B-Instruct');
+  } finally {
+    mock.restore();
+  }
+});
+
+test('callHuggingFaceAPI surfaces upstream error messages', async () => {
+  const mock = withMockFetch(async () => ({
+    ok: false,
+    status: 429,
+    text: async () => JSON.stringify({ error: { message: 'rate limited' } }),
+  }));
+  try {
+    await assert.rejects(
+      () => callHuggingFaceAPI({ model: 'm', systemPrompt: 's', userContent: 'u' }),
+      /HuggingFace API request failed \(429\): rate limited/
+    );
+  } finally {
+    mock.restore();
+  }
+});
+
+test('callProviderAPI dispatches huggingface to /hf', async () => {
+  const mock = withMockFetch(async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({
+      choices: [{ message: { content: 'ok' } }],
+      usage: {},
+    }),
+  }));
+  try {
+    await callProviderAPI('huggingface', {
+      model: 'meta-llama/Llama-3.3-70B-Instruct',
+      systemPrompt: 's',
+      userContent: 'u',
+    });
+    assert.ok(mock.calls[0].url.endsWith('/hf'));
   } finally {
     mock.restore();
   }


### PR DESCRIPTION
## Summary
This PR adds support for HuggingFace as an LLM provider, routed through the existing worker proxy infrastructure alongside PublicAI.

## Key Changes

- **Refactored shared proxy logic**: Extracted common OpenAI-compatible API calling code into `callProxyChatCompletion()` to support multiple proxy-routed providers (PublicAI and HuggingFace)
- **Added HuggingFace provider**: Implemented `callHuggingFaceAPI()` that routes requests to the `/hf` endpoint on the worker proxy
- **Updated provider dispatch**: Added 'huggingface' case to `callProviderAPI()` switch statement
- **Added HuggingFace configuration**: 
  - Default model: `openai/gpt-oss-20b`
  - Color: `#FF9D00` (HuggingFace yellow-orange)
  - No API key required (proxy-injected)
- **Updated CLI support**: Added 'huggingface' to known providers list and help text in `cli/verify.js`
- **Added comprehensive tests**: Three new test cases covering successful HuggingFace API calls, error handling, and provider dispatch routing

## Implementation Details

The refactoring makes the code more maintainable by consolidating the OpenAI-compatible API call logic. Both PublicAI and HuggingFace now delegate to `callProxyChatCompletion()` with different URLs and labels, reducing duplication and making it easier to add similar proxy-routed providers in the future.

Error messages are now parameterized by provider label, so HuggingFace errors will correctly report "HuggingFace API request failed" instead of "PublicAI API request failed".

https://claude.ai/code/session_01LAwKTyN5VA4i3o8DQTyC1Z