### PR TITLE
Fix dialog rendering by appending to teleport target instead of body

### DIFF
--- a/main.js
+++ b/main.js
@@ -2300,7 +2300,11 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
             });
             
             const windowManager = new OO.ui.WindowManager();
-            $('body').append(windowManager.$element);
+            // Append to #mw-teleport-target (lifted above the sidebar by our
+            // CSS) so the dialog renders on top when the sidebar overlaps it.
+            // Fall back to body if the teleport target is unavailable.
+            const dialogHost = document.getElementById('mw-teleport-target') || document.body;
+            dialogHost.appendChild(windowManager.$element[0]);
             windowManager.addWindows([dialog]);
             
             windowManager.openWindow(dialog, {


### PR DESCRIPTION
## Summary
Updated the dialog window manager to append to a dedicated teleport target element instead of directly to the body, ensuring dialogs render above the sidebar when there's overlap.

## Key Changes
- Changed window manager element append target from `body` to `#mw-teleport-target` (a CSS-lifted container)
- Added fallback to `document.body` if the teleport target is unavailable
- Updated DOM manipulation to use native `appendChild()` with the raw DOM element instead of jQuery's `append()`
- Added explanatory comments documenting the rationale for the change

## Implementation Details
The teleport target element is positioned above the sidebar via CSS, which ensures dialogs render on top of overlapping sidebar content. The fallback to body maintains backward compatibility if the teleport target is not present in the DOM.

https://claude.ai/code/session_01QkWdTLseksEE3prf52S1gr