### PR TITLE
HuggingFace: use direct API when HF_API_KEY is set so that other models can be tested

### DIFF
--- a/cli/verify.js
+++ b/cli/verify.js
@@ -153,10 +153,16 @@ const PROVIDER_MODELS = {
 
 const PROVIDER_ENV_VARS = {
     publicai:    null, // routed through the worker proxy; no client-side key
-    huggingface: null, // routed through the worker proxy; no client-side key
+    huggingface: null, // proxy by default; HF_API_KEY (optional) opts into direct
     claude:      'CLAUDE_API_KEY',
     gemini:      'GEMINI_API_KEY',
     openai:      'OPENAI_API_KEY',
+};
+
+// Optional env vars: when present, switch the provider to a direct-call path.
+// Absent is fine — the call falls back to PROVIDER_ENV_VARS' default routing.
+const PROVIDER_OPTIONAL_ENV_VARS = {
+    huggingface: 'HF_API_KEY',
 };
 
 export const HELP_TEXT = `usage: ccs verify <wikipedia-url> <citation-number> [options]
@@ -174,8 +180,9 @@ Options:
   --provider <name>  LLM provider to use. One of:
                        publicai    (default; routed via the worker proxy,
                                     no API key needed)
-                       huggingface (routed via the worker proxy,
-                                    no API key needed)
+                       huggingface (routed via the worker proxy by default;
+                                    set HF_API_KEY to call HF directly and
+                                    unlock any HF-hosted model)
                        claude      (requires CLAUDE_API_KEY)
                        gemini      (requires GEMINI_API_KEY)
                        openai      (requires OPENAI_API_KEY)
@@ -301,11 +308,14 @@ export async function runVerify(opts, { stdout = process.stdout, stderr = proces
     //    include apiKey for publicai (which won't read it).
     const systemPrompt = generateSystemPrompt();
     const userContent = generateUserPrompt(claim, sourceInfo);
+    const optionalEnvVar = PROVIDER_OPTIONAL_ENV_VARS[provider];
     const providerConfig = {
         model: PROVIDER_MODELS[provider],
         systemPrompt,
         userContent,
-        apiKey: envVar ? env[envVar] : undefined,
+        apiKey: envVar
+            ? env[envVar]
+            : (optionalEnvVar ? env[optionalEnvVar] : undefined),
     };
 
     let providerResult;

--- a/core/providers.js
+++ b/core/providers.js
@@ -1,8 +1,9 @@
 // LLM provider dispatch. Pure HTTP routing — callers build the prompt.
 
-// Shared call shape for proxy-routed OpenAI-compatible upstreams (PublicAI, HF).
-// The proxy injects upstream API keys; the userscript only specifies the model.
-async function callProxyChatCompletion({ url, model, systemPrompt, userContent, label }) {
+// Shared call shape for OpenAI-compatible chat-completion upstreams.
+// Used by PublicAI/HF (proxy-routed; key injected upstream) and HF when the
+// caller supplies their own bearer token (direct call to the HF router).
+async function callOpenAICompatibleChat({ url, apiKey, model, systemPrompt, userContent, label }) {
     const requestBody = {
         model: model,
         messages: [
@@ -13,9 +14,12 @@ async function callProxyChatCompletion({ url, model, systemPrompt, userContent, 
         temperature: 0.1
     };
 
+    const headers = { 'Content-Type': 'application/json' };
+    if (apiKey) headers['Authorization'] = `Bearer ${apiKey}`;
+
     const response = await fetch(url, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers,
         body: JSON.stringify(requestBody)
     });
 
@@ -47,16 +51,23 @@ async function callProxyChatCompletion({ url, model, systemPrompt, userContent, 
 }
 
 export async function callPublicAIAPI({ model, systemPrompt, userContent, workerBase = 'https://publicai-proxy.alaexis.workers.dev' }) {
-    return callProxyChatCompletion({
+    return callOpenAICompatibleChat({
         url: workerBase,
         model, systemPrompt, userContent,
         label: 'PublicAI',
     });
 }
 
-export async function callHuggingFaceAPI({ model, systemPrompt, userContent, workerBase = 'https://publicai-proxy.alaexis.workers.dev' }) {
-    return callProxyChatCompletion({
-        url: `${workerBase}/hf`,
+// HF direct router endpoint, used when the caller supplies an apiKey.
+// Without one, the call falls back to the worker proxy's /hf path, which
+// injects an upstream key on the user's behalf.
+const HF_DIRECT_URL = 'https://router.huggingface.co/v1/chat/completions';
+
+export async function callHuggingFaceAPI({ apiKey, model, systemPrompt, userContent, workerBase = 'https://publicai-proxy.alaexis.workers.dev' }) {
+    const direct = Boolean(apiKey);
+    return callOpenAICompatibleChat({
+        url: direct ? HF_DIRECT_URL : `${workerBase}/hf`,
+        apiKey: direct ? apiKey : undefined,
         model, systemPrompt, userContent,
         label: 'HuggingFace',
     });

--- a/main.js
+++ b/main.js
@@ -360,9 +360,10 @@ function extractClaimText(refElement) {
 // --- core/providers.js ---
 // LLM provider dispatch. Pure HTTP routing — callers build the prompt.
 
-// Shared call shape for proxy-routed OpenAI-compatible upstreams (PublicAI, HF).
-// The proxy injects upstream API keys; the userscript only specifies the model.
-async function callProxyChatCompletion({ url, model, systemPrompt, userContent, label }) {
+// Shared call shape for OpenAI-compatible chat-completion upstreams.
+// Used by PublicAI/HF (proxy-routed; key injected upstream) and HF when the
+// caller supplies their own bearer token (direct call to the HF router).
+async function callOpenAICompatibleChat({ url, apiKey, model, systemPrompt, userContent, label }) {
     const requestBody = {
         model: model,
         messages: [
@@ -373,9 +374,12 @@ async function callProxyChatCompletion({ url, model, systemPrompt, userContent, 
         temperature: 0.1
     };
 
+    const headers = { 'Content-Type': 'application/json' };
+    if (apiKey) headers['Authorization'] = `Bearer ${apiKey}`;
+
     const response = await fetch(url, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers,
         body: JSON.stringify(requestBody)
     });
 
@@ -407,16 +411,23 @@ async function callProxyChatCompletion({ url, model, systemPrompt, userContent, 
 }
 
 async function callPublicAIAPI({ model, systemPrompt, userContent, workerBase = 'https://publicai-proxy.alaexis.workers.dev' }) {
-    return callProxyChatCompletion({
+    return callOpenAICompatibleChat({
         url: workerBase,
         model, systemPrompt, userContent,
         label: 'PublicAI',
     });
 }
 
-async function callHuggingFaceAPI({ model, systemPrompt, userContent, workerBase = 'https://publicai-proxy.alaexis.workers.dev' }) {
-    return callProxyChatCompletion({
-        url: `${workerBase}/hf`,
+// HF direct router endpoint, used when the caller supplies an apiKey.
+// Without one, the call falls back to the worker proxy's /hf path, which
+// injects an upstream key on the user's behalf.
+const HF_DIRECT_URL = 'https://router.huggingface.co/v1/chat/completions';
+
+async function callHuggingFaceAPI({ apiKey, model, systemPrompt, userContent, workerBase = 'https://publicai-proxy.alaexis.workers.dev' }) {
+    const direct = Boolean(apiKey);
+    return callOpenAICompatibleChat({
+        url: direct ? HF_DIRECT_URL : `${workerBase}/hf`,
+        apiKey: direct ? apiKey : undefined,
         model, systemPrompt, userContent,
         label: 'HuggingFace',
     });
@@ -636,11 +647,14 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
                     requiresKey: false
                 },
                 huggingface: {
-                    name: 'HuggingFace (Free)',
-                    storageKey: null, // No key needed - proxy injects upstream key
+                    name: 'HuggingFace',
+                    // Optional key: free via the proxy without one; direct call
+                    // to HF (any model) when stored.
+                    storageKey: 'hf_api_key',
                     color: '#FF9D00', // HF yellow-orange
                     model: 'openai/gpt-oss-20b',
-                    requiresKey: false
+                    requiresKey: false,
+                    optionalKey: true
                 },
                 claude: {
                     name: 'Claude',
@@ -1828,7 +1842,13 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
             
             const provider = this.providers[this.currentProvider];
             if (!provider.requiresKey) {
-                infoEl.textContent = '✓ No API key required - using free PublicAI model';
+                if (provider.optionalKey && this.getCurrentApiKey()) {
+                    infoEl.textContent = `✓ Direct mode — using your ${provider.name} API key`;
+                } else if (provider.optionalKey) {
+                    infoEl.textContent = `✓ Free via the proxy. Optional: set a ${provider.name} API key for direct access.`;
+                } else {
+                    infoEl.textContent = `✓ No API key required — ${provider.name} routed via the proxy`;
+                }
                 infoEl.className = 'free-provider';
             } else if (this.getCurrentApiKey()) {
                 infoEl.textContent = `API key configured for ${provider.name}`;
@@ -1847,7 +1867,8 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
             
             const hasKey = this.getCurrentApiKey();
             const requiresKey = this.providerRequiresKey();
-            
+            const optionalKey = this.providers[this.currentProvider].optionalKey;
+
             if (!requiresKey || hasKey) {
                 // Provider is ready to use
                 if (this.reportRunning) {
@@ -1868,10 +1889,16 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
                 privacyNote.textContent = 'Results are logged for research. Your username is not recorded.';
                 container.appendChild(privacyNote);
 
-                // Only show key management buttons for providers that use user keys
-                if (requiresKey && !this.reportRunning) {
-                    container.appendChild(this.buttons.changeKey.$element[0]);
-                    container.appendChild(this.buttons.removeKey.$element[0]);
+                // Key-management buttons: required-key providers always show
+                // change/remove; optional-key providers show change/remove
+                // when a key is stored, or "set key" when not.
+                if (!this.reportRunning) {
+                    if (requiresKey || (optionalKey && hasKey)) {
+                        container.appendChild(this.buttons.changeKey.$element[0]);
+                        container.appendChild(this.buttons.removeKey.$element[0]);
+                    } else if (optionalKey) {
+                        container.appendChild(this.buttons.setKey.$element[0]);
+                    }
                 }
             } else {
                 // Provider needs a key
@@ -2316,8 +2343,8 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
         
         setApiKey() {
             const provider = this.providers[this.currentProvider];
-            
-            if (!provider.requiresKey) {
+
+            if (!provider.requiresKey && !provider.optionalKey) {
                 this.updateStatus('This provider does not require an API key.');
                 return;
             }
@@ -2370,7 +2397,8 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
         }
         
         removeApiKey() {
-            if (!this.providerRequiresKey()) {
+            const provider = this.providers[this.currentProvider];
+            if (!provider.requiresKey && !provider.optionalKey) {
                 this.updateStatus('This provider does not use a stored API key.');
                 return;
             }

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -369,6 +369,79 @@ test('runVerify: missing citation number returns 5', async () => {
   }
 });
 
+test('runVerify: provider=huggingface without HF_API_KEY routes via worker /hf', async () => {
+  const mock = mkFetchMock([
+    {
+      match: (url) => String(url).startsWith('https://en.wikipedia.org/api/rest_v1/'),
+      respond: async () => ({ ok: true, status: 200, text: async () => WIKI_HTML_WITH_ONE_CITATION }),
+    },
+    {
+      match: (url) => String(url).includes('?fetch='),
+      respond: async () => ({ ok: true, json: async () => ({ content: 'x'.repeat(300) }) }),
+    },
+    {
+      match: (url, opts) => String(url) === 'https://publicai-proxy.alaexis.workers.dev/hf' && opts?.method === 'POST',
+      respond: async (_url, opts) => {
+        assert.equal(opts.headers['Authorization'], undefined,
+          'proxy path must not forward an Authorization header');
+        return {
+          ok: true, status: 200, json: async () => ({
+            choices: [{ message: { content: '{"verdict":"SUPPORTED","confidence":80,"comments":"ok"}' } }],
+            usage: { prompt_tokens: 10, completion_tokens: 5 },
+          }),
+        };
+      },
+    },
+  ]);
+  const stdout = mkStream();
+  const stderr = mkStream();
+  try {
+    const code = await runVerify(
+      { url: 'https://en.wikipedia.org/wiki/Sky', citationNumber: 1, provider: 'huggingface', noLog: true },
+      { stdout, stderr, env: {} },
+    );
+    assert.equal(code, 0, `stderr: ${stderr.value()}`);
+  } finally {
+    mock.restore();
+  }
+});
+
+test('runVerify: provider=huggingface with HF_API_KEY hits HF router with Bearer header', async () => {
+  const mock = mkFetchMock([
+    {
+      match: (url) => String(url).startsWith('https://en.wikipedia.org/api/rest_v1/'),
+      respond: async () => ({ ok: true, status: 200, text: async () => WIKI_HTML_WITH_ONE_CITATION }),
+    },
+    {
+      match: (url) => String(url).includes('?fetch='),
+      respond: async () => ({ ok: true, json: async () => ({ content: 'x'.repeat(300) }) }),
+    },
+    {
+      match: (url, opts) => String(url) === 'https://router.huggingface.co/v1/chat/completions' && opts?.method === 'POST',
+      respond: async (_url, opts) => {
+        assert.equal(opts.headers['Authorization'], 'Bearer hf_test_key');
+        return {
+          ok: true, status: 200, json: async () => ({
+            choices: [{ message: { content: '{"verdict":"SUPPORTED","confidence":80,"comments":"ok"}' } }],
+            usage: { prompt_tokens: 10, completion_tokens: 5 },
+          }),
+        };
+      },
+    },
+  ]);
+  const stdout = mkStream();
+  const stderr = mkStream();
+  try {
+    const code = await runVerify(
+      { url: 'https://en.wikipedia.org/wiki/Sky', citationNumber: 1, provider: 'huggingface', noLog: true },
+      { stdout, stderr, env: { HF_API_KEY: 'hf_test_key' } },
+    );
+    assert.equal(code, 0, `stderr: ${stderr.value()}`);
+  } finally {
+    mock.restore();
+  }
+});
+
 test('runVerify: provider 500 returns 10', async () => {
   const mock = mkFetchMock([
     {

--- a/tests/providers.test.js
+++ b/tests/providers.test.js
@@ -94,6 +94,48 @@ test('callHuggingFaceAPI posts to workerBase /hf and returns text + usage', asyn
   }
 });
 
+test('callHuggingFaceAPI with apiKey hits HF router with Bearer header', async () => {
+  const mock = withMockFetch(async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({
+      choices: [{ message: { content: 'hf-direct' } }],
+      usage: { prompt_tokens: 30, completion_tokens: 5 },
+    }),
+  }));
+  try {
+    const result = await callHuggingFaceAPI({
+      apiKey: 'hf_test_key',
+      model: 'meta-llama/Llama-3.3-70B-Instruct',
+      systemPrompt: 's',
+      userContent: 'u',
+    });
+    assert.equal(result.text, 'hf-direct');
+    assert.equal(mock.calls[0].url, 'https://router.huggingface.co/v1/chat/completions');
+    assert.equal(mock.calls[0].opts.headers['Authorization'], 'Bearer hf_test_key');
+  } finally {
+    mock.restore();
+  }
+});
+
+test('callHuggingFaceAPI without apiKey omits Authorization header', async () => {
+  const mock = withMockFetch(async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({
+      choices: [{ message: { content: 'ok' } }],
+      usage: {},
+    }),
+  }));
+  try {
+    await callHuggingFaceAPI({ model: 'm', systemPrompt: 's', userContent: 'u' });
+    assert.equal(mock.calls[0].url, 'https://publicai-proxy.alaexis.workers.dev/hf');
+    assert.equal(mock.calls[0].opts.headers['Authorization'], undefined);
+  } finally {
+    mock.restore();
+  }
+});
+
 test('callHuggingFaceAPI surfaces upstream error messages', async () => {
   const mock = withMockFetch(async () => ({
     ok: false,


### PR DESCRIPTION
I wanted to test HF models that weren't allow-listed on the proxy. So here's a patch for that.

## Summary

Refines the HuggingFace provider added in #186 so a user-supplied `HF_API_KEY` opts the call into HF's direct router (`router.huggingface.co/v1/chat/completions`) instead of the worker proxy. Without a key, behaviour is identical to current `main`: routes through the proxy's `/hf` path with the proxy's injected upstream credential.

The motivation: users (me, that's me, Luis) with their own HF token can reach any HF-hosted model without needing the proxy allowlist updated, while the no-key default keeps the free-tier UX #186 introduced. This helps me research what models are good/bad/better.

## Changes

Three commits, scoped to one concern each:

- **`core/providers.js`** — `callHuggingFaceAPI` branches on `apiKey`. The shared helper is renamed from `callProxyChatCompletion` to `callOpenAICompatibleChat` since it now carries both proxy-routed and direct-call paths. Direct mode adds an `Authorization: Bearer …` header; proxy mode is byte-identical to before.
- **`cli/verify.js`** — Adds `PROVIDER_OPTIONAL_ENV_VARS`, a parallel table for env vars that enable a richer code path when present but aren't required. `HF_API_KEY` flows through to `providerConfig.apiKey` for the huggingface provider; absence stays fine and does not trigger the missing-key exit code.
- **`main.js` (userscript)** — The `huggingface` provider config gains `optionalKey: true` and `storageKey: 'hf_api_key'`. The key-input UI now surfaces set/change/remove buttons for optional-key providers as a secondary affordance; verify remains enabled in both states. The provider-info banner distinguishes "free via proxy" from "direct mode — using your key" and stops asserting the free path is "PublicAI" (which was already inaccurate for the HF-via-proxy case).

## Tests

+4 new tests, 0 modifications to existing ones. 93/93 pass.

- `tests/providers.test.js`: `callHuggingFaceAPI` with `apiKey` hits the HF router and sends a Bearer header; without `apiKey`, omits Authorization (regression guard so the proxy's injected key remains the only credential).
- `tests/cli.test.js`: `runVerify --provider huggingface` without `HF_API_KEY` routes via the proxy's `/hf` path and exits 0 (no exit-8); with `HF_API_KEY` set, hits the HF router with the Bearer header.

## Test plan

- [ ] `npm test` — green (93/93)
- [ ] `npm run build -- --check` — `main.js` in sync with `core/`
- [ ] Manual CLI smoke: `ccs verify <url> <n> --provider huggingface` with and without `HF_API_KEY` set to a real HF token
- [ ] Manual userscript smoke: pick HuggingFace, verify with no stored key (proxy path), set a key via the UI, verify again (direct path)

## Out of scope, flagged for follow-up

`callOpenAIAPI` could fold into `callOpenAICompatibleChat` — the OpenAI body shape already matches, and only the Bearer-from-`apiKey` path differs. Held back to keep this diff narrow; happy to do it as a separate PR if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)