### PR TITLE
Consolidate benchmark provider HTTP calls onto core/providers.js

### DIFF
--- a/benchmark/run_benchmark.js
+++ b/benchmark/run_benchmark.js
@@ -17,20 +17,18 @@
 
 import fs from 'fs';
 import path from 'path';
-import https from 'https';
 import { fileURLToPath } from 'url';
 import { dirname } from 'path';
 import { generateSystemPrompt as coreGenerateSystemPrompt, generateUserPrompt } from '../core/prompts.js';
+import {
+    callOpenAICompatibleChat,
+    callClaudeAPI,
+    callGeminiAPI,
+} from '../core/providers.js';
 import { loadRows, loadMetadata, todayIso } from './io.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
-
-// Reuse TCP/TLS connections across requests. Saves ~100–300ms per call (≈3–9%
-// of a typical 3.5s LLM call — inference time dominates), but the main reason
-// to enable it here is to avoid ephemeral-port / connection-tracking pressure
-// when many requests fan out to the same host under per-host parallelism.
-const httpsAgent = new https.Agent({ keepAlive: true, maxSockets: 64 });
 
 const MAX_RETRIES = 5;
 const RETRYABLE_STATUS = /^HTTP (429|500|502|503|504)\b/;
@@ -164,9 +162,15 @@ export async function withRetry(fn, { maxRetries = MAX_RETRIES, sleepFn = sleep 
 }
 
 /**
- * Make API call to provider, retrying on transient failures.
+ * Make API call to provider. Delegates HTTP transport to core/providers.js
+ * (single source of truth shared with main.js + cli/verify.js); the runner
+ * adds env-var auth, latency timing, retry, and error-to-verdict-shape conversion.
+ *
+ * Return shape: { verdict, confidence, comments, raw_response, usage, latency, error }
+ *   usage: { input, output, cost_usd } — cost_usd is null where the upstream
+ *   API doesn't surface per-call cost (everything except OpenRouter today).
  */
-async function callProvider(provider, systemPrompt, userPrompt) {
+export async function callProvider(provider, systemPrompt, userPrompt) {
     const config = PROVIDERS[provider];
     const startTime = Date.now();
     try {
@@ -191,97 +195,80 @@ async function callProvider(provider, systemPrompt, userPrompt) {
     }
 }
 
-/**
- * Call PublicAI API
- */
+// Shim helper: parse the raw response text into the verdict shape and
+// attach the usage object captured by core/providers.js.
+function shapeResult({ text, usage }) {
+    return { ...parseResponse(text), usage };
+}
+
+// Benchmark-side knobs preserved verbatim from the pre-consolidation runner.
+// core/providers.js has its own defaults tuned for userscript/CLI use; the
+// runner overrides them here so that benchmark numbers stay comparable to
+// past runs until a deliberate re-baselining experiment changes them.
+const BENCHMARK_MAX_TOKENS = 1000;
+const BENCHMARK_TEMPERATURE = 0.1;
+// The pre-consolidation runner concatenated `${systemPrompt}\n\n${userPrompt}`
+// into a single Gemini user turn rather than using the proper systemInstruction
+// + contents shape. callGeminiAPI now defaults to the structured shape; the
+// runner opts back into concatenation here so historical Gemini benchmark
+// numbers stay reproducible. Worth re-evaluating empirically (see GH #179, #181).
+const BENCHMARK_GEMINI_STRUCTURED = false;
+
 async function callPublicAI(config, systemPrompt, userPrompt) {
     const apiKey = process.env[config.keyEnv];
     if (!apiKey) throw new Error(`Missing ${config.keyEnv}`);
-
-    const response = await httpPost(config.endpoint, {
+    return shapeResult(await callOpenAICompatibleChat({
+        url: config.endpoint,
+        apiKey,
         model: config.model,
-        messages: [
-            { role: 'system', content: systemPrompt },
-            { role: 'user', content: userPrompt }
-        ],
-        temperature: 0.1,
-        max_tokens: 1000
-    }, {
-        'Authorization': `Bearer ${apiKey}`
-    });
-
-    const content = response.choices?.[0]?.message?.content || '';
-    return parseResponse(content);
+        systemPrompt,
+        userContent: userPrompt,
+        maxTokens: BENCHMARK_MAX_TOKENS,
+        temperature: BENCHMARK_TEMPERATURE,
+        label: 'PublicAI',
+    }));
 }
 
-/**
- * Call Claude API
- */
 async function callClaude(config, systemPrompt, userPrompt) {
     const apiKey = process.env[config.keyEnv];
     if (!apiKey) throw new Error(`Missing ${config.keyEnv}`);
-
-    const response = await httpPost(config.endpoint, {
+    return shapeResult(await callClaudeAPI({
+        apiKey,
         model: config.model,
-        max_tokens: 1000,
-        system: systemPrompt,
-        messages: [{ role: 'user', content: userPrompt }]
-    }, {
-        'x-api-key': apiKey,
-        'anthropic-version': '2023-06-01'
-    });
-
-    const content = response.content?.[0]?.text || '';
-    return parseResponse(content);
+        systemPrompt,
+        userContent: userPrompt,
+        maxTokens: BENCHMARK_MAX_TOKENS,
+        // Claude's body has historically not set temperature; preserved unchanged.
+    }));
 }
 
-/**
- * Call OpenAI API
- */
 async function callOpenAI(config, systemPrompt, userPrompt) {
     const apiKey = process.env[config.keyEnv];
     if (!apiKey) throw new Error(`Missing ${config.keyEnv}`);
-
-    const response = await httpPost(config.endpoint, {
+    return shapeResult(await callOpenAICompatibleChat({
+        url: config.endpoint,
+        apiKey,
         model: config.model,
-        messages: [
-            { role: 'system', content: systemPrompt },
-            { role: 'user', content: userPrompt }
-        ],
-        temperature: 0.1,
-        max_tokens: 1000
-    }, {
-        'Authorization': `Bearer ${apiKey}`
-    });
-
-    const content = response.choices?.[0]?.message?.content || '';
-    return parseResponse(content);
+        systemPrompt,
+        userContent: userPrompt,
+        maxTokens: BENCHMARK_MAX_TOKENS,
+        temperature: BENCHMARK_TEMPERATURE,
+        label: 'OpenAI',
+    }));
 }
 
-/**
- * Call Gemini API
- */
 async function callGemini(config, systemPrompt, userPrompt) {
     const apiKey = process.env[config.keyEnv];
     if (!apiKey) throw new Error(`Missing ${config.keyEnv}`);
-
-    const url = `${config.endpoint}?key=${apiKey}`;
-
-    const response = await httpPost(url, {
-        contents: [{
-            parts: [{ text: `${systemPrompt}\n\n${userPrompt}` }]
-        }],
-        generationConfig: {
-            temperature: 0.1,
-            maxOutputTokens: 1000,
-            // Constrains Gemini to emit syntactically valid JSON only;
-            // see issue #75.
-            responseMimeType: 'application/json'
-        }
-    });
-
-    const content = response.candidates?.[0]?.content?.parts?.[0]?.text || '';
-    return parseResponse(content);
+    return shapeResult(await callGeminiAPI({
+        apiKey,
+        model: config.model,
+        systemPrompt,
+        userContent: userPrompt,
+        maxTokens: BENCHMARK_MAX_TOKENS,
+        temperature: BENCHMARK_TEMPERATURE,
+        useStructuredPrompt: BENCHMARK_GEMINI_STRUCTURED,
+    }));
 }
 
 /**
@@ -333,51 +320,6 @@ function normalizeVerdict(verdict) {
     if (v.includes('UNAVAILABLE')) return 'Source unavailable';
     if (v.includes('SUPPORTED')) return 'Supported';
     return verdict;
-}
-
-/**
- * HTTP POST helper
- */
-function httpPost(url, body, extraHeaders = {}) {
-    return new Promise((resolve, reject) => {
-        const urlObj = new URL(url);
-        const options = {
-            hostname: urlObj.hostname,
-            port: urlObj.port || 443,
-            path: urlObj.pathname + urlObj.search,
-            method: 'POST',
-            agent: httpsAgent,
-            headers: {
-                'Content-Type': 'application/json',
-                ...extraHeaders
-            }
-        };
-
-        const req = https.request(options, (res) => {
-            let data = '';
-            res.on('data', chunk => data += chunk);
-            res.on('end', () => {
-                try {
-                    if (res.statusCode >= 400) {
-                        reject(new Error(`HTTP ${res.statusCode}: ${data.substring(0, 200)}`));
-                        return;
-                    }
-                    resolve(JSON.parse(data));
-                } catch (e) {
-                    reject(new Error(`Parse error: ${e.message}`));
-                }
-            });
-        });
-
-        req.on('error', reject);
-        req.setTimeout(60000, () => {
-            req.destroy();
-            reject(new Error('Request timeout'));
-        });
-
-        req.write(JSON.stringify(body));
-        req.end();
-    });
 }
 
 /**

--- a/core/providers.js
+++ b/core/providers.js
@@ -1,21 +1,25 @@
 // LLM provider dispatch. Pure HTTP routing — callers build the prompt.
 
 // Shared call shape for OpenAI-compatible chat-completion upstreams.
-// Used by PublicAI/HF (proxy-routed; key injected upstream) and HF when the
-// caller supplies their own bearer token (direct call to the HF router).
-async function callOpenAICompatibleChat({ url, apiKey, model, systemPrompt, userContent, label }) {
+// Used by PublicAI/HF (proxy-routed; key injected upstream), HF when the
+// caller supplies their own bearer token (direct call to the HF router),
+// OpenRouter (which adds attribution headers and surfaces per-call cost),
+// and the benchmark runner (which calls direct PublicAI/OpenAI endpoints
+// with bearer auth from environment variables).
+export async function callOpenAICompatibleChat({ url, apiKey, model, systemPrompt, userContent, label, extraHeaders, maxTokens = 2048, temperature = 0.1 }) {
     const requestBody = {
         model: model,
         messages: [
             { role: "system", content: systemPrompt },
             { role: "user", content: userContent }
         ],
-        max_tokens: 2048,
-        temperature: 0.1
+        max_tokens: maxTokens,
+        temperature: temperature
     };
 
     const headers = { 'Content-Type': 'application/json' };
     if (apiKey) headers['Authorization'] = `Bearer ${apiKey}`;
+    if (extraHeaders) Object.assign(headers, extraHeaders);
 
     const response = await fetch(url, {
         method: 'POST',
@@ -45,15 +49,17 @@ async function callOpenAICompatibleChat({ url, apiKey, model, systemPrompt, user
         text: data.choices[0].message.content,
         usage: {
             input: data.usage?.prompt_tokens || 0,
-            output: data.usage?.completion_tokens || 0
+            output: data.usage?.completion_tokens || 0,
+            cost_usd: data.usage?.cost ?? null
         }
     };
 }
 
-export async function callPublicAIAPI({ model, systemPrompt, userContent, workerBase = 'https://publicai-proxy.alaexis.workers.dev' }) {
+export async function callPublicAIAPI({ apiKey, model, systemPrompt, userContent, workerBase = 'https://publicai-proxy.alaexis.workers.dev', maxTokens, temperature }) {
     return callOpenAICompatibleChat({
         url: workerBase,
-        model, systemPrompt, userContent,
+        apiKey,
+        model, systemPrompt, userContent, maxTokens, temperature,
         label: 'PublicAI',
     });
 }
@@ -63,20 +69,38 @@ export async function callPublicAIAPI({ model, systemPrompt, userContent, worker
 // injects an upstream key on the user's behalf.
 const HF_DIRECT_URL = 'https://router.huggingface.co/v1/chat/completions';
 
-export async function callHuggingFaceAPI({ apiKey, model, systemPrompt, userContent, workerBase = 'https://publicai-proxy.alaexis.workers.dev' }) {
+export async function callHuggingFaceAPI({ apiKey, model, systemPrompt, userContent, workerBase = 'https://publicai-proxy.alaexis.workers.dev', maxTokens, temperature }) {
     const direct = Boolean(apiKey);
     return callOpenAICompatibleChat({
         url: direct ? HF_DIRECT_URL : `${workerBase}/hf`,
         apiKey: direct ? apiKey : undefined,
-        model, systemPrompt, userContent,
+        model, systemPrompt, userContent, maxTokens, temperature,
         label: 'HuggingFace',
     });
 }
 
-export async function callClaudeAPI({ apiKey, model, systemPrompt, userContent }) {
+// OpenRouter routes OpenAI-compatible requests across many open-weight backends.
+// Per-call USD cost is surfaced on response.usage.cost (no opt-in flag required
+// as of 2026; the older `usage: { include: true }` parameter is deprecated).
+// Attribution headers (HTTP-Referer + X-Title) are recommended by OpenRouter
+// for analytics; they don't affect routing.
+export async function callOpenRouterAPI({ apiKey, model, systemPrompt, userContent, maxTokens, temperature }) {
+    return callOpenAICompatibleChat({
+        url: 'https://openrouter.ai/api/v1/chat/completions',
+        apiKey,
+        model, systemPrompt, userContent, maxTokens, temperature,
+        label: 'OpenRouter',
+        extraHeaders: {
+            'HTTP-Referer': 'https://github.com/alex-o-748/citation-checker-script',
+            'X-Title': 'citation-checker-script',
+        },
+    });
+}
+
+export async function callClaudeAPI({ apiKey, model, systemPrompt, userContent, maxTokens = 3000 }) {
     const requestBody = {
         model: model,
-        max_tokens: 3000,
+        max_tokens: maxTokens,
         system: systemPrompt,
         messages: [{ role: "user", content: userContent }]
     };
@@ -102,26 +126,37 @@ export async function callClaudeAPI({ apiKey, model, systemPrompt, userContent }
         text: data.content[0].text,
         usage: {
             input: data.usage?.input_tokens || 0,
-            output: data.usage?.output_tokens || 0
+            output: data.usage?.output_tokens || 0,
+            cost_usd: null
         }
     };
 }
 
-export async function callGeminiAPI({ apiKey, model, systemPrompt, userContent }) {
+export async function callGeminiAPI({ apiKey, model, systemPrompt, userContent, maxTokens = 2048, temperature = 0.1, useStructuredPrompt = true }) {
     const API_URL = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`;
 
-    const requestBody = {
-        contents: [{ parts: [{ text: userContent }] }],
-        systemInstruction: { parts: [{ text: systemPrompt }] },
-        generationConfig: {
-            maxOutputTokens: 2048,
-            temperature: 0.0,
-            // responseMimeType: 'application/json' constrains Gemini to emit
-            // syntactically valid JSON only. Without it, Gemini occasionally
-            // wraps output in markdown fences or emits prose, both of which
-            // the verdict parser fails on. See issue #75.
-            responseMimeType: 'application/json'
+    // useStructuredPrompt:true (default) uses Gemini's proper systemInstruction
+    // + contents shape; the userscript and CLI have always used this.
+    // useStructuredPrompt:false concatenates `${systemPrompt}\n\n${userContent}`
+    // into a single user turn — the historical benchmark-runner shape, kept
+    // available so past benchmark numbers stay reproducible until a deliberate
+    // re-baselining run picks the canonical shape.
+    const requestBody = useStructuredPrompt
+        ? {
+            contents: [{ parts: [{ text: userContent }] }],
+            systemInstruction: { parts: [{ text: systemPrompt }] },
         }
+        : {
+            contents: [{ parts: [{ text: `${systemPrompt}\n\n${userContent}` }] }],
+        };
+    requestBody.generationConfig = {
+        maxOutputTokens: maxTokens,
+        temperature: temperature,
+        // responseMimeType: 'application/json' constrains Gemini to emit
+        // syntactically valid JSON only. Without it, Gemini occasionally
+        // wraps output in markdown fences or emits prose, both of which
+        // the verdict parser fails on. See issue #75.
+        responseMimeType: 'application/json'
     };
 
     const response = await fetch(API_URL, {
@@ -145,20 +180,21 @@ export async function callGeminiAPI({ apiKey, model, systemPrompt, userContent }
         text: responseData.candidates[0].content.parts[0].text,
         usage: {
             input: responseData.usageMetadata?.promptTokenCount || 0,
-            output: responseData.usageMetadata?.candidatesTokenCount || 0
+            output: responseData.usageMetadata?.candidatesTokenCount || 0,
+            cost_usd: null
         }
     };
 }
 
-export async function callOpenAIAPI({ apiKey, model, systemPrompt, userContent }) {
+export async function callOpenAIAPI({ apiKey, model, systemPrompt, userContent, maxTokens = 2000, temperature = 0.1 }) {
     const requestBody = {
         model: model,
-        max_tokens: 2000,
+        max_tokens: maxTokens,
         messages: [
             { role: "system", content: systemPrompt },
             { role: "user", content: userContent }
         ],
-        temperature: 0.1
+        temperature: temperature
     };
 
     const response = await fetch('https://api.openai.com/v1/chat/completions', {
@@ -192,7 +228,8 @@ export async function callOpenAIAPI({ apiKey, model, systemPrompt, userContent }
         text: data.choices[0].message.content,
         usage: {
             input: data.usage?.prompt_tokens || 0,
-            output: data.usage?.completion_tokens || 0
+            output: data.usage?.completion_tokens || 0,
+            cost_usd: null
         }
     };
 }
@@ -201,6 +238,7 @@ export async function callProviderAPI(name, config) {
     switch (name) {
         case 'publicai':    return await callPublicAIAPI(config);
         case 'huggingface': return await callHuggingFaceAPI(config);
+        case 'openrouter':  return await callOpenRouterAPI(config);
         case 'claude':      return await callClaudeAPI(config);
         case 'gemini':      return await callGeminiAPI(config);
         case 'openai':      return await callOpenAIAPI(config);

--- a/main.js
+++ b/main.js
@@ -361,21 +361,25 @@ function extractClaimText(refElement) {
 // LLM provider dispatch. Pure HTTP routing — callers build the prompt.
 
 // Shared call shape for OpenAI-compatible chat-completion upstreams.
-// Used by PublicAI/HF (proxy-routed; key injected upstream) and HF when the
-// caller supplies their own bearer token (direct call to the HF router).
-async function callOpenAICompatibleChat({ url, apiKey, model, systemPrompt, userContent, label }) {
+// Used by PublicAI/HF (proxy-routed; key injected upstream), HF when the
+// caller supplies their own bearer token (direct call to the HF router),
+// OpenRouter (which adds attribution headers and surfaces per-call cost),
+// and the benchmark runner (which calls direct PublicAI/OpenAI endpoints
+// with bearer auth from environment variables).
+async function callOpenAICompatibleChat({ url, apiKey, model, systemPrompt, userContent, label, extraHeaders, maxTokens = 2048, temperature = 0.1 }) {
     const requestBody = {
         model: model,
         messages: [
             { role: "system", content: systemPrompt },
             { role: "user", content: userContent }
         ],
-        max_tokens: 2048,
-        temperature: 0.1
+        max_tokens: maxTokens,
+        temperature: temperature
     };
 
     const headers = { 'Content-Type': 'application/json' };
     if (apiKey) headers['Authorization'] = `Bearer ${apiKey}`;
+    if (extraHeaders) Object.assign(headers, extraHeaders);
 
     const response = await fetch(url, {
         method: 'POST',
@@ -405,15 +409,17 @@ async function callOpenAICompatibleChat({ url, apiKey, model, systemPrompt, user
         text: data.choices[0].message.content,
         usage: {
             input: data.usage?.prompt_tokens || 0,
-            output: data.usage?.completion_tokens || 0
+            output: data.usage?.completion_tokens || 0,
+            cost_usd: data.usage?.cost ?? null
         }
     };
 }
 
-async function callPublicAIAPI({ model, systemPrompt, userContent, workerBase = 'https://publicai-proxy.alaexis.workers.dev' }) {
+async function callPublicAIAPI({ apiKey, model, systemPrompt, userContent, workerBase = 'https://publicai-proxy.alaexis.workers.dev', maxTokens, temperature }) {
     return callOpenAICompatibleChat({
         url: workerBase,
-        model, systemPrompt, userContent,
+        apiKey,
+        model, systemPrompt, userContent, maxTokens, temperature,
         label: 'PublicAI',
     });
 }
@@ -423,20 +429,38 @@ async function callPublicAIAPI({ model, systemPrompt, userContent, workerBase = 
 // injects an upstream key on the user's behalf.
 const HF_DIRECT_URL = 'https://router.huggingface.co/v1/chat/completions';
 
-async function callHuggingFaceAPI({ apiKey, model, systemPrompt, userContent, workerBase = 'https://publicai-proxy.alaexis.workers.dev' }) {
+async function callHuggingFaceAPI({ apiKey, model, systemPrompt, userContent, workerBase = 'https://publicai-proxy.alaexis.workers.dev', maxTokens, temperature }) {
     const direct = Boolean(apiKey);
     return callOpenAICompatibleChat({
         url: direct ? HF_DIRECT_URL : `${workerBase}/hf`,
         apiKey: direct ? apiKey : undefined,
-        model, systemPrompt, userContent,
+        model, systemPrompt, userContent, maxTokens, temperature,
         label: 'HuggingFace',
     });
 }
 
-async function callClaudeAPI({ apiKey, model, systemPrompt, userContent }) {
+// OpenRouter routes OpenAI-compatible requests across many open-weight backends.
+// Per-call USD cost is surfaced on response.usage.cost (no opt-in flag required
+// as of 2026; the older `usage: { include: true }` parameter is deprecated).
+// Attribution headers (HTTP-Referer + X-Title) are recommended by OpenRouter
+// for analytics; they don't affect routing.
+async function callOpenRouterAPI({ apiKey, model, systemPrompt, userContent, maxTokens, temperature }) {
+    return callOpenAICompatibleChat({
+        url: 'https://openrouter.ai/api/v1/chat/completions',
+        apiKey,
+        model, systemPrompt, userContent, maxTokens, temperature,
+        label: 'OpenRouter',
+        extraHeaders: {
+            'HTTP-Referer': 'https://github.com/alex-o-748/citation-checker-script',
+            'X-Title': 'citation-checker-script',
+        },
+    });
+}
+
+async function callClaudeAPI({ apiKey, model, systemPrompt, userContent, maxTokens = 3000 }) {
     const requestBody = {
         model: model,
-        max_tokens: 3000,
+        max_tokens: maxTokens,
         system: systemPrompt,
         messages: [{ role: "user", content: userContent }]
     };
@@ -462,26 +486,37 @@ async function callClaudeAPI({ apiKey, model, systemPrompt, userContent }) {
         text: data.content[0].text,
         usage: {
             input: data.usage?.input_tokens || 0,
-            output: data.usage?.output_tokens || 0
+            output: data.usage?.output_tokens || 0,
+            cost_usd: null
         }
     };
 }
 
-async function callGeminiAPI({ apiKey, model, systemPrompt, userContent }) {
+async function callGeminiAPI({ apiKey, model, systemPrompt, userContent, maxTokens = 2048, temperature = 0.1, useStructuredPrompt = true }) {
     const API_URL = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`;
 
-    const requestBody = {
-        contents: [{ parts: [{ text: userContent }] }],
-        systemInstruction: { parts: [{ text: systemPrompt }] },
-        generationConfig: {
-            maxOutputTokens: 2048,
-            temperature: 0.0,
-            // responseMimeType: 'application/json' constrains Gemini to emit
-            // syntactically valid JSON only. Without it, Gemini occasionally
-            // wraps output in markdown fences or emits prose, both of which
-            // the verdict parser fails on. See issue #75.
-            responseMimeType: 'application/json'
+    // useStructuredPrompt:true (default) uses Gemini's proper systemInstruction
+    // + contents shape; the userscript and CLI have always used this.
+    // useStructuredPrompt:false concatenates `${systemPrompt}\n\n${userContent}`
+    // into a single user turn — the historical benchmark-runner shape, kept
+    // available so past benchmark numbers stay reproducible until a deliberate
+    // re-baselining run picks the canonical shape.
+    const requestBody = useStructuredPrompt
+        ? {
+            contents: [{ parts: [{ text: userContent }] }],
+            systemInstruction: { parts: [{ text: systemPrompt }] },
         }
+        : {
+            contents: [{ parts: [{ text: `${systemPrompt}\n\n${userContent}` }] }],
+        };
+    requestBody.generationConfig = {
+        maxOutputTokens: maxTokens,
+        temperature: temperature,
+        // responseMimeType: 'application/json' constrains Gemini to emit
+        // syntactically valid JSON only. Without it, Gemini occasionally
+        // wraps output in markdown fences or emits prose, both of which
+        // the verdict parser fails on. See issue #75.
+        responseMimeType: 'application/json'
     };
 
     const response = await fetch(API_URL, {
@@ -505,20 +540,21 @@ async function callGeminiAPI({ apiKey, model, systemPrompt, userContent }) {
         text: responseData.candidates[0].content.parts[0].text,
         usage: {
             input: responseData.usageMetadata?.promptTokenCount || 0,
-            output: responseData.usageMetadata?.candidatesTokenCount || 0
+            output: responseData.usageMetadata?.candidatesTokenCount || 0,
+            cost_usd: null
         }
     };
 }
 
-async function callOpenAIAPI({ apiKey, model, systemPrompt, userContent }) {
+async function callOpenAIAPI({ apiKey, model, systemPrompt, userContent, maxTokens = 2000, temperature = 0.1 }) {
     const requestBody = {
         model: model,
-        max_tokens: 2000,
+        max_tokens: maxTokens,
         messages: [
             { role: "system", content: systemPrompt },
             { role: "user", content: userContent }
         ],
-        temperature: 0.1
+        temperature: temperature
     };
 
     const response = await fetch('https://api.openai.com/v1/chat/completions', {
@@ -552,7 +588,8 @@ async function callOpenAIAPI({ apiKey, model, systemPrompt, userContent }) {
         text: data.choices[0].message.content,
         usage: {
             input: data.usage?.prompt_tokens || 0,
-            output: data.usage?.completion_tokens || 0
+            output: data.usage?.completion_tokens || 0,
+            cost_usd: null
         }
     };
 }
@@ -561,6 +598,7 @@ async function callProviderAPI(name, config) {
     switch (name) {
         case 'publicai':    return await callPublicAIAPI(config);
         case 'huggingface': return await callHuggingFaceAPI(config);
+        case 'openrouter':  return await callOpenRouterAPI(config);
         case 'claude':      return await callClaudeAPI(config);
         case 'gemini':      return await callGeminiAPI(config);
         case 'openai':      return await callOpenAIAPI(config);

--- a/tests/benchmark_providers.test.js
+++ b/tests/benchmark_providers.test.js
@@ -1,0 +1,125 @@
+// Characterization tests for benchmark/run_benchmark.js's callProvider.
+//
+// Asserts the unified contract that every provider type produces:
+//   { verdict, confidence, comments, raw_response, usage: { input, output, cost_usd }, latency, error }
+//
+// Pre-refactor, callProvider used Node's `https` module per provider, returned
+// { verdict, ... } without a usage field, and routed through a local httpPost
+// helper. Post-refactor, callProvider delegates to core/providers.js (which
+// uses fetch), giving every provider a consistent usage shape including
+// cost_usd: null where the upstream API doesn't expose per-call cost.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { callProvider } from '../benchmark/run_benchmark.js';
+
+function withMockFetch(handler) {
+    const original = globalThis.fetch;
+    const calls = [];
+    globalThis.fetch = async (url, opts) => {
+        calls.push({ url, opts });
+        return handler(url, opts);
+    };
+    return {
+        calls,
+        restore: () => { globalThis.fetch = original; },
+    };
+}
+
+const VERDICT_JSON = '{"verdict":"SUPPORTED","confidence":85,"comments":"clear match"}';
+
+function withEnv(vars, fn) {
+    const saved = {};
+    for (const [k, v] of Object.entries(vars)) {
+        saved[k] = process.env[k];
+        if (v === undefined) delete process.env[k];
+        else process.env[k] = v;
+    }
+    return fn().finally(() => {
+        for (const [k, v] of Object.entries(saved)) {
+            if (v === undefined) delete process.env[k];
+            else process.env[k] = v;
+        }
+    });
+}
+
+test('callProvider publicai returns parsed verdict and usage shape, max_tokens=1000', async () => {
+    const mock = withMockFetch(async () => ({
+        ok: true, status: 200,
+        json: async () => ({
+            choices: [{ message: { content: VERDICT_JSON } }],
+            usage: { prompt_tokens: 120, completion_tokens: 18 },
+        }),
+    }));
+    try {
+        await withEnv({ PUBLICAI_API_KEY: 'test' }, async () => {
+            const result = await callProvider('apertus-70b', 'sys', 'user');
+            assert.equal(result.verdict, 'Supported');
+            assert.equal(result.confidence, 85);
+            assert.equal(result.comments, 'clear match');
+            assert.equal(result.usage.input, 120);
+            assert.equal(result.usage.output, 18);
+            assert.equal(result.usage.cost_usd, null);
+            assert.equal(result.error, null);
+            assert.equal(typeof result.latency, 'number');
+            // Benchmark holds max_tokens at 1000 across providers (preserves
+            // pre-consolidation runner behavior; see BENCHMARK_MAX_TOKENS).
+            const sent = JSON.parse(mock.calls[0].opts.body);
+            assert.equal(sent.max_tokens, 1000);
+        });
+    } finally {
+        mock.restore();
+    }
+});
+
+test('callProvider claude returns parsed verdict and usage shape', async () => {
+    const mock = withMockFetch(async () => ({
+        ok: true, status: 200,
+        json: async () => ({
+            content: [{ text: VERDICT_JSON }],
+            usage: { input_tokens: 200, output_tokens: 30 },
+        }),
+    }));
+    try {
+        await withEnv({ ANTHROPIC_API_KEY: 'test' }, async () => {
+            const result = await callProvider('claude-sonnet-4-5', 'sys', 'user');
+            assert.equal(result.verdict, 'Supported');
+            assert.equal(result.usage.input, 200);
+            assert.equal(result.usage.output, 30);
+            assert.equal(result.usage.cost_usd, null);
+            assert.equal(result.error, null);
+        });
+    } finally {
+        mock.restore();
+    }
+});
+
+test('callProvider gemini returns parsed verdict and usage shape', async () => {
+    const mock = withMockFetch(async () => ({
+        ok: true, status: 200,
+        json: async () => ({
+            candidates: [{ content: { parts: [{ text: VERDICT_JSON }] } }],
+            usageMetadata: { promptTokenCount: 90, candidatesTokenCount: 14 },
+        }),
+    }));
+    try {
+        await withEnv({ GEMINI_API_KEY: 'test' }, async () => {
+            const result = await callProvider('gemini-2.5-flash', 'sys', 'user');
+            assert.equal(result.verdict, 'Supported');
+            assert.equal(result.usage.input, 90);
+            assert.equal(result.usage.output, 14);
+            assert.equal(result.usage.cost_usd, null);
+            assert.equal(result.error, null);
+        });
+    } finally {
+        mock.restore();
+    }
+});
+
+test('callProvider returns ERROR shape when env var is missing', async () => {
+    await withEnv({ PUBLICAI_API_KEY: undefined }, async () => {
+        const result = await callProvider('apertus-70b', 'sys', 'user');
+        assert.equal(result.verdict, 'ERROR');
+        assert.match(result.error, /PUBLICAI_API_KEY/);
+        assert.equal(typeof result.latency, 'number');
+    });
+});

--- a/tests/providers.test.js
+++ b/tests/providers.test.js
@@ -5,6 +5,7 @@ import {
   callHuggingFaceAPI,
   callClaudeAPI,
   callGeminiAPI,
+  callOpenRouterAPI,
   callProviderAPI,
 } from '../core/providers.js';
 
@@ -136,6 +137,25 @@ test('callHuggingFaceAPI without apiKey omits Authorization header', async () =>
   }
 });
 
+test('callHuggingFaceAPI returns usage.cost_usd: null (HF does not surface per-call cost)', async () => {
+  const mock = withMockFetch(async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({
+      choices: [{ message: { content: 'ok' } }],
+      usage: { prompt_tokens: 40, completion_tokens: 8 },
+    }),
+  }));
+  try {
+    const result = await callHuggingFaceAPI({ model: 'm', systemPrompt: 's', userContent: 'u' });
+    assert.equal(result.usage.cost_usd, null);
+    assert.equal(result.usage.input, 40);
+    assert.equal(result.usage.output, 8);
+  } finally {
+    mock.restore();
+  }
+});
+
 test('callHuggingFaceAPI surfaces upstream error messages', async () => {
   const mock = withMockFetch(async () => ({
     ok: false,
@@ -221,6 +241,316 @@ test('callGeminiAPI requests JSON-only output via responseMimeType', async () =>
     });
     const body = JSON.parse(mock.calls[0].opts.body);
     assert.equal(body.generationConfig.responseMimeType, 'application/json');
+  } finally {
+    mock.restore();
+  }
+});
+
+test('callOpenRouterAPI hits OpenRouter API with attribution headers and surfaces cost', async () => {
+  const mock = withMockFetch(async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({
+      choices: [{ message: { content: 'or-verdict' } }],
+      usage: { prompt_tokens: 80, completion_tokens: 12, cost: 0.000345 },
+    }),
+  }));
+  try {
+    const result = await callOpenRouterAPI({
+      apiKey: 'or_test_key',
+      model: 'qwen/qwen3-32b',
+      systemPrompt: 's',
+      userContent: 'u',
+    });
+    assert.equal(result.text, 'or-verdict');
+    assert.equal(result.usage.input, 80);
+    assert.equal(result.usage.output, 12);
+    assert.equal(result.usage.cost_usd, 0.000345);
+    assert.equal(mock.calls[0].url, 'https://openrouter.ai/api/v1/chat/completions');
+    assert.equal(mock.calls[0].opts.headers['Authorization'], 'Bearer or_test_key');
+    assert.ok(mock.calls[0].opts.headers['HTTP-Referer']);
+    assert.ok(mock.calls[0].opts.headers['X-Title']);
+  } finally {
+    mock.restore();
+  }
+});
+
+test('callOpenRouterAPI returns cost_usd: null when usage.cost missing', async () => {
+  const mock = withMockFetch(async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({
+      choices: [{ message: { content: 'no-cost' } }],
+      usage: { prompt_tokens: 10, completion_tokens: 2 },
+    }),
+  }));
+  try {
+    const result = await callOpenRouterAPI({
+      apiKey: 'k',
+      model: 'm',
+      systemPrompt: 's',
+      userContent: 'u',
+    });
+    assert.equal(result.usage.cost_usd, null);
+  } finally {
+    mock.restore();
+  }
+});
+
+test('callOpenRouterAPI surfaces upstream error messages', async () => {
+  const mock = withMockFetch(async () => ({
+    ok: false,
+    status: 402,
+    text: async () => JSON.stringify({ error: { message: 'insufficient credits' } }),
+  }));
+  try {
+    await assert.rejects(
+      () => callOpenRouterAPI({ apiKey: 'k', model: 'm', systemPrompt: 's', userContent: 'u' }),
+      /OpenRouter API request failed \(402\): insufficient credits/
+    );
+  } finally {
+    mock.restore();
+  }
+});
+
+test('callProviderAPI dispatches openrouter to OpenRouter API', async () => {
+  const mock = withMockFetch(async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({
+      choices: [{ message: { content: 'via-dispatcher' } }],
+      usage: {},
+    }),
+  }));
+  try {
+    const result = await callProviderAPI('openrouter', {
+      apiKey: 'k',
+      model: 'm',
+      systemPrompt: 's',
+      userContent: 'u',
+    });
+    assert.equal(result.text, 'via-dispatcher');
+    assert.ok(mock.calls[0].url.startsWith('https://openrouter.ai/'));
+  } finally {
+    mock.restore();
+  }
+});
+
+test('callPublicAIAPI honors maxTokens parameter (overrides default)', async () => {
+  const mock = withMockFetch(async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({
+      choices: [{ message: { content: 'ok' } }],
+      usage: {},
+    }),
+  }));
+  try {
+    await callPublicAIAPI({
+      model: 'm',
+      systemPrompt: 's',
+      userContent: 'u',
+      maxTokens: 500,
+    });
+    const sent = JSON.parse(mock.calls[0].opts.body);
+    assert.equal(sent.max_tokens, 500);
+  } finally {
+    mock.restore();
+  }
+});
+
+test('callClaudeAPI honors maxTokens parameter', async () => {
+  const mock = withMockFetch(async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({
+      content: [{ text: 'ok' }],
+      usage: { input_tokens: 0, output_tokens: 0 },
+    }),
+  }));
+  try {
+    await callClaudeAPI({
+      apiKey: 'k',
+      model: 'm',
+      systemPrompt: 's',
+      userContent: 'u',
+      maxTokens: 750,
+    });
+    const sent = JSON.parse(mock.calls[0].opts.body);
+    assert.equal(sent.max_tokens, 750);
+  } finally {
+    mock.restore();
+  }
+});
+
+test('callGeminiAPI honors maxTokens parameter (maps to maxOutputTokens)', async () => {
+  const mock = withMockFetch(async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({
+      candidates: [{ content: { parts: [{ text: 'ok' }] } }],
+      usageMetadata: {},
+    }),
+  }));
+  try {
+    await callGeminiAPI({
+      apiKey: 'k',
+      model: 'm',
+      systemPrompt: 's',
+      userContent: 'u',
+      maxTokens: 1100,
+    });
+    const sent = JSON.parse(mock.calls[0].opts.body);
+    assert.equal(sent.generationConfig.maxOutputTokens, 1100);
+  } finally {
+    mock.restore();
+  }
+});
+
+test('callOpenAIAPI honors maxTokens parameter', async () => {
+  const mock = withMockFetch(async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({
+      choices: [{ message: { content: 'ok' } }],
+      usage: {},
+    }),
+  }));
+  try {
+    const { callOpenAIAPI } = await import('../core/providers.js');
+    await callOpenAIAPI({
+      apiKey: 'k',
+      model: 'm',
+      systemPrompt: 's',
+      userContent: 'u',
+      maxTokens: 600,
+    });
+    const sent = JSON.parse(mock.calls[0].opts.body);
+    assert.equal(sent.max_tokens, 600);
+  } finally {
+    mock.restore();
+  }
+});
+
+test('callOpenAICompatibleChat-based providers honor temperature parameter (default 0.1)', async () => {
+  // Default temperature = 0.1
+  let mock = withMockFetch(async () => ({
+    ok: true, status: 200,
+    json: async () => ({ choices: [{ message: { content: 'ok' } }], usage: {} }),
+  }));
+  try {
+    await callPublicAIAPI({ model: 'm', systemPrompt: 's', userContent: 'u' });
+    let sent = JSON.parse(mock.calls[0].opts.body);
+    assert.equal(sent.temperature, 0.1);
+  } finally {
+    mock.restore();
+  }
+
+  // Override via temperature parameter
+  mock = withMockFetch(async () => ({
+    ok: true, status: 200,
+    json: async () => ({ choices: [{ message: { content: 'ok' } }], usage: {} }),
+  }));
+  try {
+    await callPublicAIAPI({ model: 'm', systemPrompt: 's', userContent: 'u', temperature: 0.5 });
+    let sent = JSON.parse(mock.calls[0].opts.body);
+    assert.equal(sent.temperature, 0.5);
+  } finally {
+    mock.restore();
+  }
+});
+
+test('callOpenAIAPI honors temperature parameter (default 0.1, override works)', async () => {
+  const { callOpenAIAPI } = await import('../core/providers.js');
+  const mock = withMockFetch(async () => ({
+    ok: true, status: 200,
+    json: async () => ({ choices: [{ message: { content: 'ok' } }], usage: {} }),
+  }));
+  try {
+    await callOpenAIAPI({
+      apiKey: 'k', model: 'm', systemPrompt: 's', userContent: 'u', temperature: 0.3,
+    });
+    const sent = JSON.parse(mock.calls[0].opts.body);
+    assert.equal(sent.temperature, 0.3);
+  } finally {
+    mock.restore();
+  }
+});
+
+test('callGeminiAPI default temperature is 0.1 (was 0.0; aligned with other providers)', async () => {
+  const mock = withMockFetch(async () => ({
+    ok: true, status: 200,
+    json: async () => ({
+      candidates: [{ content: { parts: [{ text: 'ok' }] } }],
+      usageMetadata: {},
+    }),
+  }));
+  try {
+    await callGeminiAPI({
+      apiKey: 'k', model: 'm', systemPrompt: 's', userContent: 'u',
+    });
+    const body = JSON.parse(mock.calls[0].opts.body);
+    assert.equal(body.generationConfig.temperature, 0.1);
+  } finally {
+    mock.restore();
+  }
+});
+
+test('callGeminiAPI honors temperature parameter override', async () => {
+  const mock = withMockFetch(async () => ({
+    ok: true, status: 200,
+    json: async () => ({
+      candidates: [{ content: { parts: [{ text: 'ok' }] } }],
+      usageMetadata: {},
+    }),
+  }));
+  try {
+    await callGeminiAPI({
+      apiKey: 'k', model: 'm', systemPrompt: 's', userContent: 'u', temperature: 0.7,
+    });
+    const body = JSON.parse(mock.calls[0].opts.body);
+    assert.equal(body.generationConfig.temperature, 0.7);
+  } finally {
+    mock.restore();
+  }
+});
+
+test('callGeminiAPI uses structured systemInstruction + contents by default', async () => {
+  const mock = withMockFetch(async () => ({
+    ok: true, status: 200,
+    json: async () => ({
+      candidates: [{ content: { parts: [{ text: 'ok' }] } }],
+      usageMetadata: {},
+    }),
+  }));
+  try {
+    await callGeminiAPI({
+      apiKey: 'k', model: 'm', systemPrompt: 'SYS', userContent: 'USR',
+    });
+    const body = JSON.parse(mock.calls[0].opts.body);
+    assert.deepEqual(body.systemInstruction, { parts: [{ text: 'SYS' }] });
+    assert.deepEqual(body.contents, [{ parts: [{ text: 'USR' }] }]);
+  } finally {
+    mock.restore();
+  }
+});
+
+test('callGeminiAPI with useStructuredPrompt:false concatenates system+user', async () => {
+  const mock = withMockFetch(async () => ({
+    ok: true, status: 200,
+    json: async () => ({
+      candidates: [{ content: { parts: [{ text: 'ok' }] } }],
+      usageMetadata: {},
+    }),
+  }));
+  try {
+    await callGeminiAPI({
+      apiKey: 'k', model: 'm', systemPrompt: 'SYS', userContent: 'USR',
+      useStructuredPrompt: false,
+    });
+    const body = JSON.parse(mock.calls[0].opts.body);
+    assert.equal(body.systemInstruction, undefined);
+    assert.deepEqual(body.contents, [{ parts: [{ text: 'SYS\n\nUSR' }] }]);
   } finally {
     mock.restore();
   }


### PR DESCRIPTION
## Summary

Consolidates the benchmark runner's HTTP-call layer onto `core/providers.js`, completing the unification pattern established by #165 (which unified the prompt). Adds `callOpenRouterAPI` to `core/providers.js` and gives every provider a uniform `{ text, usage: { input, output, cost_usd } }` return shape.

Pure consolidation — no new product features, no userscript or CLI behavior changes.

## Why

`benchmark/run_benchmark.js` previously carried its own per-provider HTTP-call functions (`callPublicAI` / `callClaude` / `callOpenAI` / `callGemini`) that drifted in subtle ways from `core/providers.js`'s canonical implementations:

- Gemini concatenated system+user as one text block instead of using the proper `systemInstruction` + `contents` shape.
- `temperature` was 0.1 in the runner vs 0.0 in core.
- `max_tokens` was 1000 in the runner vs 2000–3000 in core.
- A custom Node-https `httpPost` helper handled transport, separately from core's `fetch`-based calls.

The drift was unintentional (predates the `core/` factor in the #118–120 series). #165 already unified the *prompt* layer; this PR finishes the same job for the *transport* layer.

`callOpenRouterAPI` is added preemptively so that the next benchmarking PR (which adds OpenRouter and HuggingFace panel members on top of this base) can use the consolidated pattern from the start instead of re-introducing a duplicate transport.

## Changes

Two commits, one concern each:

**`core/providers.js` (commit 1):**
- Adds `callOpenRouterAPI` — hits `openrouter.ai/api/v1/chat/completions` via the shared OpenAI-compatible helper, sends HTTP-Referer + X-Title attribution headers, surfaces per-call USD cost from `response.usage.cost`.
- Exports the previously-internal `callOpenAICompatibleChat` helper so callers (e.g. the benchmark runner) hitting OpenAI-compatible endpoints other than the proxy or HF router can reuse the transport.
- Every `callXxxAPI` now returns `usage.cost_usd` (populated for OpenRouter, `null` everywhere else) for contract uniformity.
- `main.js` regenerated by `sync-main.js`.

**`benchmark/run_benchmark.js` (commit 2):**
- Each provider call function becomes a thin shim: read API key from env, delegate transport to the corresponding `core/providers.js` function, parse with the runner's existing `parseResponse`, attach the `usage` object so `callProvider` surfaces token counts and cost uniformly.
- `httpPost` (Node-https-based) deleted — no remaining callers.
- The `https` import is gone.
- `callProvider` is exported and the script-mode launcher (`main().catch`) is guarded by an `import.meta.url` check so tests can import the module without auto-running a benchmark.

## Knobs are parameter-driven; behavior is preserved on both sides

Earlier iterations of this PR took the bigger swing of "delegate fully and let the runner inherit core's defaults," which would have shifted Gemini's request shape, temperature, and `max_tokens` for the next benchmark run. Reviewer feedback pushed back on changing benchmark behavior without justification. Final shape parameterizes the diff points so each caller keeps its historical knobs:

- **`maxTokens`** — defaults preserve `core/providers.js`'s per-provider values (Claude 3000, OpenAI 2000, PublicAI/HF/OR 2048, Gemini 2048). Runner pins `BENCHMARK_MAX_TOKENS = 1000` across providers.
- **`temperature`** — default `0.1` for every provider that already had an explicit temperature. Runner pins `BENCHMARK_TEMPERATURE = 0.1`. Claude's body has no `temperature` field on either side, unchanged.
- **`useStructuredPrompt` (Gemini only)** — default `true` (proper `systemInstruction` + `contents` API shape; userscript and CLI behavior). Runner pins `BENCHMARK_GEMINI_STRUCTURED = false` to preserve historical concatenated `${systemPrompt}\n\n${userContent}` shape.

The one userscript/CLI-visible default change is **Gemini's `temperature`: 0.0 → 0.1**, aligning Gemini with every other provider that sets temperature explicitly. Per discussion on #179 and #181, no strong opinion against this; consistency is the small upside. Easy to revert by changing one default if desired.

Frozen historical snapshots (`results_v1.json` / `results_v3.json` / `historical-runs/*.json`) are unaffected since they don't regenerate.

## Test plan

`npm test` — 130 passing, 0 failing (origin/main baseline: 111 — this PR adds 19 tests):
- 4 in `tests/providers.test.js` exercising `callOpenRouterAPI` (success with cost capture, `cost_usd: null` when missing, error surfacing, dispatcher).
- 1 locking in HuggingFace's `usage.cost_usd: null` contract.
- 4 covering the new `maxTokens` parameter on `callPublicAIAPI` / `callClaudeAPI` / `callGeminiAPI` / `callOpenAIAPI`.
- 5 covering the new `temperature` and `useStructuredPrompt` parameters (default-0.1 across OpenAI-compatible providers, Gemini default-now-0.1, override paths, both Gemini prompt shapes).
- 4 in the new `tests/benchmark_providers.test.js` exercising `callProvider` end-to-end through mock fetch for `publicai` / `claude` / `gemini`, plus the missing-env-var error path; the publicai test also asserts `max_tokens: 1000` reaches upstream so the `BENCHMARK_MAX_TOKENS` pin is regression-guarded.
- 1 contract test for HuggingFace `cost_usd: null`.

`npm run build -- --check` — `main.js` in sync with `core/`.

## Out of scope

- The runner's `parseResponse` and `normalizeVerdict` helpers still live in `run_benchmark.js`, parallel to `core/parsing.js`'s `parseVerificationResult`. The drift is real but the parsers have semantically different fallback behavior (the runner has a regex-match fallback for non-JSON responses; core/parsing returns `verdict: 'ERROR'` on any parse failure). Worth a separate, focused PR.
- The userscript's `main.js` has its own copy of the verdict parser logic at `parseVerificationResult` (line 133). Same story — different drift surface, separate PR.
- OpenRouter and HuggingFace runner-side wiring lives in the open-weights-voting-panel branch and is the natural next consumer of this consolidation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)