### PR TITLE
Add ccs compare subcommand for diffing two benchmark runs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,7 @@
 # CLAUDE.md
 
+Last verified: 2026-05-06
+
 ## Project Overview
 
 Wikipedia citation verification user script. An AI-powered sidebar tool that lets Wikipedia editors verify whether citations actually support the claims they're attached to. Users click citation numbers, the tool fetches source content via a CORS proxy, sends claim+source to an LLM, and displays a verdict (Supported / Partially Supported / Not Supported / Source Unavailable).
@@ -13,7 +15,8 @@ main.js                          # Main Wikipedia user script (~2,700 lines, sin
 package.json                     # Top-level deps + `npm test` / `npm run build` scripts
 core/                            # Shared pure logic, imported by both benchmark/ and main.js (via sync)
   claim.js, parsing.js, prompts.js, providers.js, urls.js, worker.js
-cli/verify.js                    # Node CLI front-end (verify a single citation from the command line)
+cli/verify.js                    # `ccs verify` subcommand + top-level dispatcher (parseCliArgs, runVerify, main)
+cli/compare.js                   # `ccs compare` subcommand (parseCompareArgs, runCompare)
 bin/ccs                          # Executable shim for the CLI
 scripts/sync-main.js             # Inlines core/ modules into main.js for the userscript build
 tests/                           # `node --test` suite (run via `npm test`)
@@ -23,6 +26,8 @@ benchmark/
   run_benchmark.js               # Run LLM verification on dataset (parallelized; see Benchmark Suite)
   analyze_results.js             # Calculate metrics and confusion matrices
   generate_comparison.js         # Generate comparison CSV
+  compare_results.js             # Pure-ESM comparison engine for two results.json runs (control vs treatment)
+  render_compare.js              # JSON / Markdown / self-contained HTML renderers for ComparisonResult
   dataset.json                   # Current dataset (189 entries: v1: 76 + v2: 34 + v3: 79; counts drift as rows are added)
   dataset_v1.json                # Frozen v1 snapshot for reproducing original analysis
   dataset_v3.json                # Frozen v3 snapshot (post strict-rubric audit, 2026-04-30)
@@ -93,11 +98,14 @@ npm run analyze:v1-snapshot   # Re-derive analysis from frozen v1 snapshots
 npm run analyze:v3            # Analyze results filtered to v3 entries
 npm run analyze:v3-snapshot   # Re-derive analysis from frozen v3 snapshots
 npm run report                # Generate markdown report
+npm run compare               # Compare two results.json runs (delegates to `ccs compare`; see docs/comparing-benchmark-runs.md)
 ```
 
 ### Module system and shared logic
 
 `benchmark/` is ESM (`"type": "module"` in `benchmark/package.json`) and imports `extractClaimText` from `../core/claim.js`. Editing claim-extraction logic in `core/` automatically affects both the userscript (`main.js`, via the sync script) and the benchmark — no second copy to keep in sync.
+
+`benchmark/compare_results.js` and `benchmark/render_compare.js` are self-contained — they take already-loaded `results.json` / `dataset.json` shapes and don't import from `core/`. The `ccs compare` CLI in `cli/compare.js` is the file-IO layer that wires them up.
 
 **Required environment variables:**
 - `ANTHROPIC_API_KEY` - Claude
@@ -129,5 +137,7 @@ npm run report                # Generate markdown report
 **Adding a new LLM provider:** Add provider config to `this.providers` in the constructor, implement a `callXxxAPI()` method, and add routing in `callProviderAPI()`.
 
 **Updating the benchmark:** Edit `dataset.json` or re-extract with `npm run extract`, then run `npm run benchmark` and `npm run analyze`.
+
+**Comparing two benchmark runs:** `npx ccs compare <control.json> <treatment.json> --dataset <dataset.json>` (or `npm run compare -- ...` from `benchmark/`). Emits JSON / Markdown / HTML with per-provider accuracy deltas and flip counts; supports subset filters and a `--noise-floor` threshold. See `docs/comparing-benchmark-runs.md`.
 
 **Running tests:** `npm test` from the repo root. Tests use `node:test` + `node:assert/strict` and import the modules they cover directly — a script that runs work on import (e.g. `main()` at module load) needs to gate that behind `if (process.argv[1] === fileURLToPath(import.meta.url))` so importing it for tests doesn't trigger the runner. `extract_dataset.js` and `benchmark/run_benchmark.js` follow this pattern.

--- a/benchmark/compare_results.js
+++ b/benchmark/compare_results.js
@@ -79,3 +79,60 @@ export function classifyDirection({ controlVerdict, treatmentVerdict, groundTrut
     }
     return 'lateral';
 }
+
+function pct(num, denom) {
+    return denom > 0 ? (num / denom) * 100 : 0;
+}
+
+/**
+ * Aggregate stats for a list of cells belonging to one provider.
+ * Returns exact + lenient + binary accuracy for control and treatment, deltas,
+ * and flip counts. Lenient treats Partially supported ↔ Supported as a near-miss.
+ *
+ * @param {Array<{direction: string, controlVerdict: string, treatmentVerdict: string, groundTruth: string}>} cells
+ */
+export function computeProviderStats(cells) {
+    const n = cells.length;
+    let cExact = 0, tExact = 0, cLenient = 0, tLenient = 0, cBinary = 0, tBinary = 0;
+    const flips = {
+        improvement: 0,
+        regression: 0,
+        lateral: 0,
+        'unchanged-correct': 0,
+        'unchanged-wrong-same': 0,
+    };
+    for (const cell of cells) {
+        if (verdictsEqualExact(cell.controlVerdict, cell.groundTruth)) cExact++;
+        if (verdictsEqualExact(cell.treatmentVerdict, cell.groundTruth)) tExact++;
+        if (verdictsEqualLenient(cell.controlVerdict, cell.groundTruth)) cLenient++;
+        if (verdictsEqualLenient(cell.treatmentVerdict, cell.groundTruth)) tLenient++;
+        if (verdictsEqualBinary(cell.controlVerdict, cell.groundTruth)) cBinary++;
+        if (verdictsEqualBinary(cell.treatmentVerdict, cell.groundTruth)) tBinary++;
+        flips[cell.direction]++;
+    }
+    return {
+        n,
+        exact: {
+            control: cExact,
+            treatment: tExact,
+            controlPct: pct(cExact, n),
+            treatmentPct: pct(tExact, n),
+            delta: pct(tExact, n) - pct(cExact, n),
+        },
+        lenient: {
+            control: cLenient,
+            treatment: tLenient,
+            controlPct: pct(cLenient, n),
+            treatmentPct: pct(tLenient, n),
+            delta: pct(tLenient, n) - pct(cLenient, n),
+        },
+        binary: {
+            control: cBinary,
+            treatment: tBinary,
+            controlPct: pct(cBinary, n),
+            treatmentPct: pct(tBinary, n),
+            delta: pct(tBinary, n) - pct(cBinary, n),
+        },
+        flips,
+    };
+}

--- a/benchmark/compare_results.js
+++ b/benchmark/compare_results.js
@@ -37,3 +37,22 @@ export function verdictsEqualLenient(a, b) {
     if ((na === 'support' && nb === 'partial') || (na === 'partial' && nb === 'support')) return true;
     return false;
 }
+
+/**
+ * Index result rows by `${entry_id}:${provider}` key.
+ * Drops rows where `error` is truthy or `predicted_verdict === 'ERROR'`
+ * (treating either signal as "no successful prediction").
+ *
+ * @param {Array<Object>} rows
+ * @returns {Map<string, Object>}
+ */
+export function indexCellsByPair(rows) {
+    const out = new Map();
+    for (const row of rows) {
+        if (row.error) continue;
+        if (row.predicted_verdict === 'ERROR') continue;
+        const key = `${row.entry_id}:${row.provider}`;
+        out.set(key, row);
+    }
+    return out;
+}

--- a/benchmark/compare_results.js
+++ b/benchmark/compare_results.js
@@ -235,3 +235,36 @@ export function compareResults({ control, treatment, dataset, options = {} }) {
         flips,
     };
 }
+
+/**
+ * Filter a ComparisonResult post-hoc, returning a new result restricted to
+ * cells matching the predicate. Per-provider stats are re-aggregated over
+ * the filtered cell set; providers with zero matching cells drop out.
+ *
+ * The original result is not mutated.
+ *
+ * @param {ReturnType<typeof compareResults>} result
+ * @param {(cell: { entryId: string, provider: string, datasetEntry: Object, direction: string, controlVerdict: string, treatmentVerdict: string, groundTruth: string }) => boolean} predicate
+ */
+export function filterComparison(result, predicate) {
+    const cells = result.cells.filter(predicate);
+    const cellsByProvider = new Map();
+    for (const cell of cells) {
+        if (!cellsByProvider.has(cell.provider)) cellsByProvider.set(cell.provider, []);
+        cellsByProvider.get(cell.provider).push(cell);
+    }
+    const perProvider = new Map();
+    for (const [provider, providerCells] of cellsByProvider) {
+        perProvider.set(provider, computeProviderStats(providerCells));
+    }
+    const flips = cells.filter(c =>
+        c.direction === 'improvement' || c.direction === 'regression' || c.direction === 'lateral'
+    );
+    return {
+        metadata: { ...result.metadata, filtered: true },
+        coverage: { ...result.coverage, comparedCells: cells.length },
+        cells,
+        perProvider,
+        flips,
+    };
+}

--- a/benchmark/compare_results.js
+++ b/benchmark/compare_results.js
@@ -1,0 +1,39 @@
+/**
+ * Normalize a verdict string to its canonical short form.
+ * Returns one of: 'support' | 'partial' | 'not' | 'unavailable' | <other-lowercased>.
+ * Handles null/undefined and case/whitespace variations.
+ */
+export function normalizeVerdict(v) {
+    const s = String(v ?? '').toLowerCase().trim();
+    if (s.includes('partial')) return 'partial';
+    if (s.includes('not support') || s.includes('not-support') || s.includes('not_support')) return 'not';
+    if (s.includes('support')) return 'support';
+    if (s.includes('unavailable')) return 'unavailable';
+    return s;
+}
+
+export function verdictsEqualExact(a, b) {
+    return normalizeVerdict(a) === normalizeVerdict(b);
+}
+
+function isSupportClass(v) {
+    const n = normalizeVerdict(v);
+    return n === 'support' || n === 'partial';
+}
+
+export function verdictsEqualBinary(a, b) {
+    return isSupportClass(a) === isSupportClass(b);
+}
+
+/**
+ * Lenient match: exact, plus Supported ↔ Partially supported as mutual near-misses.
+ * Useful when the GT distinction between Supported and Partially supported is itself
+ * fuzzy and a control→treatment shift between them shouldn't count as an error.
+ */
+export function verdictsEqualLenient(a, b) {
+    const na = normalizeVerdict(a);
+    const nb = normalizeVerdict(b);
+    if (na === nb) return true;
+    if ((na === 'support' && nb === 'partial') || (na === 'partial' && nb === 'support')) return true;
+    return false;
+}

--- a/benchmark/compare_results.js
+++ b/benchmark/compare_results.js
@@ -136,3 +136,102 @@ export function computeProviderStats(cells) {
         flips,
     };
 }
+
+/**
+ * Compare two result sets. Returns a ComparisonResult with per-cell direction
+ * classification, per-provider aggregates, a flips list, and coverage metadata.
+ *
+ * Cells are computed on the intersection of (entry_id, provider) keys present
+ * in both runs — entries dropped by either side fall out. Dataset rows that
+ * are not `extraction_status === 'complete' && !needs_manual_review` also drop
+ * out (matching the runner's filter).
+ *
+ * @param {Object} args
+ * @param {{rows: Array, metadata?: Object} | Array} args.control
+ * @param {{rows: Array, metadata?: Object} | Array} args.treatment
+ * @param {Array} args.dataset
+ * @param {Object} [args.options]
+ * @param {string[]} [args.options.changeAxes] — what differs between control and treatment
+ * @param {string} [args.options.groundTruthVersion] — GT label, recorded in metadata
+ */
+export function compareResults({ control, treatment, dataset, options = {} }) {
+    const datasetById = new Map(dataset.map(row => [row.id, row]));
+    const validIds = new Set(
+        dataset
+            .filter(r => r.extraction_status === 'complete' && !r.needs_manual_review)
+            .map(r => r.id)
+    );
+
+    const controlRows = Array.isArray(control) ? control : control.rows ?? [];
+    const treatmentRows = Array.isArray(treatment) ? treatment : treatment.rows ?? [];
+
+    const controlByPair = indexCellsByPair(controlRows);
+    const treatmentByPair = indexCellsByPair(treatmentRows);
+
+    const intersectionKeys = [...controlByPair.keys()].filter(k => treatmentByPair.has(k));
+    const cells = [];
+    for (const key of intersectionKeys) {
+        const [entryId, provider] = key.split(':');
+        if (!validIds.has(entryId)) continue;
+        const datasetEntry = datasetById.get(entryId);
+        if (!datasetEntry) continue;
+
+        const controlRow = controlByPair.get(key);
+        const treatmentRow = treatmentByPair.get(key);
+        const direction = classifyDirection({
+            controlVerdict: controlRow.predicted_verdict,
+            treatmentVerdict: treatmentRow.predicted_verdict,
+            groundTruth: datasetEntry.ground_truth,
+        });
+
+        cells.push({
+            entryId,
+            provider,
+            controlVerdict: controlRow.predicted_verdict,
+            treatmentVerdict: treatmentRow.predicted_verdict,
+            groundTruth: datasetEntry.ground_truth,
+            direction,
+            claimText: datasetEntry.claim_text,
+            sourceUrl: datasetEntry.source_url,
+            datasetEntry,
+        });
+    }
+
+    const cellsByProvider = new Map();
+    for (const cell of cells) {
+        if (!cellsByProvider.has(cell.provider)) cellsByProvider.set(cell.provider, []);
+        cellsByProvider.get(cell.provider).push(cell);
+    }
+    const perProvider = new Map();
+    for (const [provider, providerCells] of cellsByProvider) {
+        perProvider.set(provider, computeProviderStats(providerCells));
+    }
+
+    const flips = cells.filter(c =>
+        c.direction === 'improvement' || c.direction === 'regression' || c.direction === 'lateral'
+    );
+
+    const controlMeta = Array.isArray(control) ? {} : (control.metadata ?? {});
+    const treatmentMeta = Array.isArray(treatment) ? {} : (treatment.metadata ?? {});
+
+    return {
+        metadata: {
+            controlRunAt: controlMeta.run_at ?? null,
+            treatmentRunAt: treatmentMeta.run_at ?? null,
+            changeAxes: options.changeAxes ?? [],
+            groundTruthVersion: options.groundTruthVersion ?? null,
+            generatedAt: new Date().toISOString(),
+        },
+        coverage: {
+            datasetTotal: dataset.length,
+            datasetValid: validIds.size,
+            controlOnlyCells: [...controlByPair.keys()].filter(k => !treatmentByPair.has(k)).length,
+            treatmentOnlyCells: [...treatmentByPair.keys()].filter(k => !controlByPair.has(k)).length,
+            intersectionCells: intersectionKeys.length,
+            comparedCells: cells.length,
+        },
+        cells,
+        perProvider,
+        flips,
+    };
+}

--- a/benchmark/compare_results.js
+++ b/benchmark/compare_results.js
@@ -56,3 +56,26 @@ export function indexCellsByPair(rows) {
     }
     return out;
 }
+
+/**
+ * Classify a single (control, treatment, ground_truth) cell into one of:
+ *   'improvement'         — control wrong, treatment correct
+ *   'regression'          — control correct, treatment wrong
+ *   'unchanged-correct'   — both correct
+ *   'unchanged-wrong-same'— both wrong with the same (normalized) verdict
+ *   'lateral'             — both wrong with different verdicts
+ *
+ * @param {{ controlVerdict: string, treatmentVerdict: string, groundTruth: string }} cell
+ * @returns {'improvement'|'regression'|'unchanged-correct'|'unchanged-wrong-same'|'lateral'}
+ */
+export function classifyDirection({ controlVerdict, treatmentVerdict, groundTruth }) {
+    const cCorrect = verdictsEqualExact(controlVerdict, groundTruth);
+    const tCorrect = verdictsEqualExact(treatmentVerdict, groundTruth);
+    if (!cCorrect && tCorrect) return 'improvement';
+    if (cCorrect && !tCorrect) return 'regression';
+    if (cCorrect && tCorrect) return 'unchanged-correct';
+    if (normalizeVerdict(controlVerdict) === normalizeVerdict(treatmentVerdict)) {
+        return 'unchanged-wrong-same';
+    }
+    return 'lateral';
+}

--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -22,7 +22,8 @@
     "analyze:v1-snapshot": "node analyze_results.js --results results_v1.json --dataset dataset_v1.json --analysis analysis_v1_recomputed.json",
     "analyze:v3": "node analyze_results.js --version v3",
     "analyze:v3-snapshot": "node analyze_results.js --results results_v3.json --dataset dataset_v3.json --analysis analysis_v3_recomputed.json",
-    "report": "node analyze_results.js --output report.md"
+    "report": "node analyze_results.js --output report.md",
+    "compare": "node ../bin/ccs compare"
   },
   "dependencies": {
     "jsdom": "^24.0.0"

--- a/benchmark/render_compare.js
+++ b/benchmark/render_compare.js
@@ -127,3 +127,133 @@ export function renderMarkdown(result, options = {}) {
 
     return lines.join('\n');
 }
+
+/**
+ * Render a ComparisonResult as a self-contained HTML document.
+ * Includes inline CSS, a metadata header, a headline-accuracy table with
+ * color-coded delta cells, and a flip table with color-coded direction cells.
+ *
+ * @param {ReturnType<import('./compare_results.js').compareResults>} result
+ * @param {{noiseFloor?: number, title?: string}} [options]
+ */
+export function renderHtml(result, options = {}) {
+    const noiseFloor = options.noiseFloor ?? 5;
+    const title = options.title ?? 'Compare Results';
+
+    const headerRows = [];
+    if (result.metadata.changeAxes && result.metadata.changeAxes.length > 0) {
+        headerRows.push(`<p><span class="metadata-key">Change axes:</span> ${escapeHtml(result.metadata.changeAxes.join(', '))}</p>`);
+    }
+    if (result.metadata.groundTruthVersion) {
+        headerRows.push(`<p><span class="metadata-key">Ground truth version:</span> ${escapeHtml(result.metadata.groundTruthVersion)}</p>`);
+    }
+    if (result.metadata.controlRunAt) {
+        headerRows.push(`<p><span class="metadata-key">Control run at:</span> ${escapeHtml(result.metadata.controlRunAt)}</p>`);
+    }
+    if (result.metadata.treatmentRunAt) {
+        headerRows.push(`<p><span class="metadata-key">Treatment run at:</span> ${escapeHtml(result.metadata.treatmentRunAt)}</p>`);
+    }
+    headerRows.push(`<p><span class="metadata-key">Compared cells:</span> ${result.coverage.comparedCells} of ${result.coverage.intersectionCells} intersection</p>`);
+    headerRows.push(`<p><span class="metadata-key">Dataset:</span> ${result.coverage.datasetValid} valid of ${result.coverage.datasetTotal}</p>`);
+    headerRows.push(`<p><span class="metadata-key">Noise floor:</span> ±${noiseFloor}pp</p>`);
+    headerRows.push(`<p><span class="metadata-key">Generated:</span> ${escapeHtml(result.metadata.generatedAt)}</p>`);
+
+    const headlineRows = [];
+    for (const [provider, stats] of result.perProvider) {
+        headlineRows.push(`        <tr>
+          <td>${escapeHtml(provider)}</td>
+          <td class="num">${stats.n}</td>
+          <td class="num">${stats.exact.control}/${stats.n} (${stats.exact.controlPct.toFixed(1)}%)</td>
+          <td class="num">${stats.exact.treatment}/${stats.n} (${stats.exact.treatmentPct.toFixed(1)}%)</td>
+          <td class="num delta" style="background-color: ${deltaColor(stats.exact.delta, noiseFloor)};">${stats.exact.delta >= 0 ? '+' : ''}${stats.exact.delta.toFixed(1)}</td>
+          <td class="num">${stats.lenient.control}/${stats.n} (${stats.lenient.controlPct.toFixed(1)}%)</td>
+          <td class="num">${stats.lenient.treatment}/${stats.n} (${stats.lenient.treatmentPct.toFixed(1)}%)</td>
+          <td class="num delta" style="background-color: ${deltaColor(stats.lenient.delta, noiseFloor)};">${stats.lenient.delta >= 0 ? '+' : ''}${stats.lenient.delta.toFixed(1)}</td>
+          <td class="num">${stats.binary.control}/${stats.n} (${stats.binary.controlPct.toFixed(1)}%)</td>
+          <td class="num">${stats.binary.treatment}/${stats.n} (${stats.binary.treatmentPct.toFixed(1)}%)</td>
+          <td class="num delta" style="background-color: ${deltaColor(stats.binary.delta, noiseFloor)};">${stats.binary.delta >= 0 ? '+' : ''}${stats.binary.delta.toFixed(1)}</td>
+        </tr>`);
+    }
+
+    const flipRows = [];
+    for (const flip of result.flips) {
+        const claim = flip.claimText.length > 80 ? flip.claimText.slice(0, 80) + '…' : flip.claimText;
+        flipRows.push(`        <tr style="background-color: ${directionColor(flip.direction)};">
+          <td>${escapeHtml(flip.provider)}</td>
+          <td>${escapeHtml(flip.entryId)}</td>
+          <td><a href="${escapeHtml(flip.sourceUrl)}" target="_blank" rel="noopener" title="${escapeHtml(flip.claimText)}">${escapeHtml(claim)}</a></td>
+          <td>${escapeHtml(flip.controlVerdict)}</td>
+          <td>${escapeHtml(flip.treatmentVerdict)}</td>
+          <td>${escapeHtml(flip.groundTruth)}</td>
+          <td><strong>${escapeHtml(flip.direction)}</strong></td>
+        </tr>`);
+    }
+    if (flipRows.length === 0) {
+        flipRows.push(`        <tr><td colspan="7"><em>No flips — every cell either stayed correct or stayed wrong with the same verdict.</em></td></tr>`);
+    }
+
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${escapeHtml(title)}</title>
+  <style>
+    * { box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; margin: 20px; line-height: 1.6; color: #333; }
+    h1, h2 { color: #222; }
+    h1 { border-bottom: 2px solid #ccc; padding-bottom: 10px; }
+    .header-section { background: #f9f9f9; padding: 15px; border-radius: 4px; margin-bottom: 30px; }
+    .header-section p { margin: 5px 0; }
+    .metadata-key { font-weight: bold; display: inline-block; width: 180px; }
+    table { border-collapse: collapse; width: 100%; margin-bottom: 30px; background: white; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
+    th, td { border: 1px solid #ddd; padding: 10px; text-align: left; }
+    th { background: #f0f0f0; font-weight: 600; }
+    tr:nth-child(even) { background: #fafafa; }
+    .num { text-align: right; }
+    .delta { font-weight: 600; text-align: center; }
+    a { color: #0066cc; text-decoration: none; }
+    a:hover { text-decoration: underline; }
+  </style>
+</head>
+<body>
+  <h1>${escapeHtml(title)}</h1>
+  <div class="header-section">
+${headerRows.join('\n')}
+  </div>
+  <h2>Headline accuracy</h2>
+  <table>
+    <thead>
+      <tr>
+        <th>Provider</th><th>n</th>
+        <th>Control exact</th><th>Treatment exact</th><th>Δ exact</th>
+        <th>Control lenient</th><th>Treatment lenient</th><th>Δ lenient</th>
+        <th>Control binary</th><th>Treatment binary</th><th>Δ binary</th>
+      </tr>
+    </thead>
+    <tbody>
+${headlineRows.join('\n')}
+    </tbody>
+  </table>
+  <p style="font-size: 0.9em; color: #666;">Green = Δ ≥ +${noiseFloor}pp · Red = Δ ≤ -${noiseFloor}pp · Grey = within ±${noiseFloor}pp noise floor.</p>
+  <h2>Flips</h2>
+  <table>
+    <thead>
+      <tr>
+        <th>Provider</th><th>Entry ID</th><th>Claim</th>
+        <th>Control</th><th>Treatment</th><th>Ground truth</th><th>Direction</th>
+      </tr>
+    </thead>
+    <tbody>
+${flipRows.join('\n')}
+    </tbody>
+  </table>
+  <p style="font-size: 0.9em; color: #666;">
+    <span style="background: #e6ffe6; padding: 2px 4px;">green = improvement</span> ·
+    <span style="background: #ffe6e6; padding: 2px 4px;">red = regression</span> ·
+    <span style="background: #fff5cc; padding: 2px 4px;">yellow = lateral</span>.
+  </p>
+</body>
+</html>
+`;
+}

--- a/benchmark/render_compare.js
+++ b/benchmark/render_compare.js
@@ -1,0 +1,35 @@
+/**
+ * Escape HTML-significant characters: & < > " '
+ * Returns empty string for null/undefined.
+ */
+export function escapeHtml(s) {
+    if (s === null || s === undefined) return '';
+    return String(s)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#x27;');
+}
+
+/**
+ * Background color for an accuracy delta given a noise floor (in pp).
+ * Green if delta >= +floor, red if delta <= -floor, grey otherwise.
+ */
+export function deltaColor(delta, noiseFloor = 5) {
+    if (delta >= noiseFloor) return '#e6ffe6';
+    if (delta <= -noiseFloor) return '#ffe6e6';
+    return '#f0f0f0';
+}
+
+/**
+ * Background color for a flip direction.
+ */
+export function directionColor(direction) {
+    switch (direction) {
+        case 'improvement': return '#e6ffe6';
+        case 'regression':  return '#ffe6e6';
+        case 'lateral':     return '#fff5cc';
+        default:            return '#ffffff';
+    }
+}

--- a/benchmark/render_compare.js
+++ b/benchmark/render_compare.js
@@ -114,12 +114,12 @@ export function renderMarkdown(result, options = {}) {
     if (result.flips.length === 0) {
         lines.push('_No flips — every cell either stayed correct or stayed wrong with the same verdict._');
     } else {
-        lines.push('| Provider | Entry ID | Direction | Control | Treatment | Ground truth | Claim |');
+        lines.push('| Provider | Entry ID | Claim | Control | Treatment | Ground truth | Direction |');
         lines.push('|---|---|---|---|---|---|---|');
         for (const flip of result.flips) {
             const claim = flip.claimText.length > 60 ? flip.claimText.slice(0, 60) + '…' : flip.claimText;
             lines.push(
-                `| ${flip.provider} | ${flip.entryId} | ${flip.direction} | ${flip.controlVerdict} | ${flip.treatmentVerdict} | ${flip.groundTruth} | ${claim.replace(/\|/g, '\\|')} |`
+                `| ${flip.provider} | ${flip.entryId} | ${claim.replace(/\|/g, '\\|')} | ${flip.controlVerdict} | ${flip.treatmentVerdict} | ${flip.groundTruth} | ${flip.direction} |`
             );
         }
     }

--- a/benchmark/render_compare.js
+++ b/benchmark/render_compare.js
@@ -33,3 +33,24 @@ export function directionColor(direction) {
         default:            return '#ffffff';
     }
 }
+
+/**
+ * Serialize a ComparisonResult to pretty-printed JSON.
+ * The `perProvider` Map is converted to a plain object.
+ * The `cells` array drops the back-reference to `datasetEntry` to avoid
+ * duplicating dataset content into the report.
+ *
+ * @param {ReturnType<import('./compare_results.js').compareResults>} result
+ * @param {{indent?: number}} [options]
+ */
+export function renderJson(result, options = {}) {
+    const indent = options.indent ?? 2;
+    const serializable = {
+        metadata: result.metadata,
+        coverage: result.coverage,
+        perProvider: Object.fromEntries(result.perProvider),
+        cells: result.cells.map(({ datasetEntry, ...rest }) => rest),
+        flips: result.flips.map(({ datasetEntry, ...rest }) => rest),
+    };
+    return JSON.stringify(serializable, null, indent);
+}

--- a/benchmark/render_compare.js
+++ b/benchmark/render_compare.js
@@ -54,3 +54,76 @@ export function renderJson(result, options = {}) {
     };
     return JSON.stringify(serializable, null, indent);
 }
+
+function fmtPct(n) {
+    return `${n.toFixed(1)}%`;
+}
+function fmtDelta(n) {
+    const sign = n >= 0 ? '+' : '';
+    return `${sign}${n.toFixed(1)}`;
+}
+
+/**
+ * Render a ComparisonResult as a Markdown report.
+ * Sections: header (metadata + coverage), headline accuracy table, flip table.
+ *
+ * @param {ReturnType<import('./compare_results.js').compareResults>} result
+ * @param {{noiseFloor?: number}} [options]
+ */
+export function renderMarkdown(result, options = {}) {
+    const noiseFloor = options.noiseFloor ?? 5;
+    const lines = [];
+    lines.push(`# Compare Results — ${result.metadata.generatedAt}`);
+    lines.push('');
+    if (result.metadata.changeAxes && result.metadata.changeAxes.length > 0) {
+        const axes = result.metadata.changeAxes.map(a => `\`${a}\``).join(', ');
+        lines.push(`Change axes: ${axes}`);
+    }
+    if (result.metadata.groundTruthVersion) {
+        lines.push(`Ground truth version: \`${result.metadata.groundTruthVersion}\``);
+    }
+    if (result.metadata.controlRunAt) {
+        lines.push(`Control run at: ${result.metadata.controlRunAt}`);
+    }
+    if (result.metadata.treatmentRunAt) {
+        lines.push(`Treatment run at: ${result.metadata.treatmentRunAt}`);
+    }
+    lines.push('');
+    lines.push(`Compared cells: **${result.coverage.comparedCells}** of ${result.coverage.intersectionCells} intersection (${result.coverage.controlOnlyCells} control-only, ${result.coverage.treatmentOnlyCells} treatment-only excluded). Dataset: ${result.coverage.datasetValid} valid of ${result.coverage.datasetTotal}.`);
+    lines.push(`Noise floor: ±${noiseFloor}pp (single-provider 95% CI heuristic).`);
+    lines.push('');
+
+    lines.push('## Headline accuracy');
+    lines.push('');
+    lines.push('| Provider | n | Control exact | Treatment exact | Δ exact | Control lenient | Treatment lenient | Δ lenient | Control binary | Treatment binary | Δ binary |');
+    lines.push('|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|');
+    for (const [provider, stats] of result.perProvider) {
+        const flag = (Math.abs(stats.exact.delta) < noiseFloor
+                   && Math.abs(stats.lenient.delta) < noiseFloor
+                   && Math.abs(stats.binary.delta) < noiseFloor)
+            ? ' (noise)'
+            : '';
+        lines.push(
+            `| ${provider}${flag} | ${stats.n} | ${fmtPct(stats.exact.controlPct)} | ${fmtPct(stats.exact.treatmentPct)} | ${fmtDelta(stats.exact.delta)} | ${fmtPct(stats.lenient.controlPct)} | ${fmtPct(stats.lenient.treatmentPct)} | ${fmtDelta(stats.lenient.delta)} | ${fmtPct(stats.binary.controlPct)} | ${fmtPct(stats.binary.treatmentPct)} | ${fmtDelta(stats.binary.delta)} |`
+        );
+    }
+    lines.push('');
+
+    lines.push('## Flips');
+    lines.push('');
+    if (result.flips.length === 0) {
+        lines.push('_No flips — every cell either stayed correct or stayed wrong with the same verdict._');
+    } else {
+        lines.push('| Provider | Entry ID | Direction | Control | Treatment | Ground truth | Claim |');
+        lines.push('|---|---|---|---|---|---|---|');
+        for (const flip of result.flips) {
+            const claim = flip.claimText.length > 60 ? flip.claimText.slice(0, 60) + '…' : flip.claimText;
+            lines.push(
+                `| ${flip.provider} | ${flip.entryId} | ${flip.direction} | ${flip.controlVerdict} | ${flip.treatmentVerdict} | ${flip.groundTruth} | ${claim.replace(/\|/g, '\\|')} |`
+            );
+        }
+    }
+    lines.push('');
+
+    return lines.join('\n');
+}

--- a/cli/compare.js
+++ b/cli/compare.js
@@ -1,0 +1,179 @@
+import { parseArgs } from 'node:util';
+import fs from 'node:fs';
+import { UsageError } from './verify.js';
+import { compareResults, filterComparison } from '../benchmark/compare_results.js';
+import { renderJson, renderMarkdown, renderHtml } from '../benchmark/render_compare.js';
+
+export const COMPARE_HELP_TEXT = `usage: ccs compare <control.json> <treatment.json> --dataset <dataset.json> [options]
+
+Compare two benchmark results.json files and produce a per-provider accuracy
++ flip report. Always exits 0 on success — inspect the report for regressions
+rather than relying on exit codes.
+
+Arguments:
+  <control.json>     Baseline results.json (treated as the "before" run).
+  <treatment.json>   Comparison results.json (treated as the "after" run).
+
+Required:
+  --dataset <path>   Path to the dataset.json that produced both runs.
+                     Used for ground_truth, claim_text, and source_url.
+
+Options:
+  --report <path>    Write the report to this path. Format is chosen by
+                     extension: .html, .md / .markdown, or .json. If omitted,
+                     JSON is written to stdout.
+  --filter <expr>    Post-hoc subset filter. Supported expressions:
+                       version=<v1|v2|v3|...>   filter by dataset_version
+                       provider=<name>          filter to a single provider
+                       direction=<imp|reg|...>  filter by direction class
+  --noise-floor <pp> Annotate per-provider rows whose |Δ| is below this
+                     threshold (in percentage points). Default: 5.
+  --change-axis <a>  What differs between control and treatment (e.g.,
+                     "prompt", "source_text"). Repeat for multiple axes.
+                     Recorded in report metadata.
+  --gt-version <s>   Ground-truth version label (e.g.,
+                     "post-audit-2026-04-30"). Recorded in report metadata.
+  --help, -h         Show this help and exit.
+
+Examples:
+  ccs compare control.json treatment.json --dataset dataset.json
+  ccs compare control.json treatment.json --dataset dataset.json --report report.html
+  ccs compare control.json treatment.json --dataset dataset.json --report out.md --filter version=v2
+`;
+
+export function parseCompareArgs(args) {
+    if (args.includes('-h') || args.includes('--help')) {
+        return { help: true, scope: 'compare' };
+    }
+
+    const { values, positionals } = parseArgs({
+        args,
+        options: {
+            dataset:        { type: 'string' },
+            report:         { type: 'string' },
+            filter:         { type: 'string' },
+            'noise-floor':  { type: 'string', default: '5' },
+            'change-axis':  { type: 'string', multiple: true },
+            'gt-version':   { type: 'string' },
+            help:           { type: 'boolean', short: 'h', default: false },
+        },
+        allowPositionals: true,
+        strict: true,
+    });
+
+    const [controlPath, treatmentPath] = positionals;
+    if (!controlPath || !treatmentPath) {
+        throw new UsageError('usage: ccs compare <control.json> <treatment.json> --dataset <dataset.json>');
+    }
+    if (!values.dataset) {
+        throw new UsageError('--dataset <path-to-dataset.json> is required');
+    }
+    const noiseFloor = parseFloat(values['noise-floor']);
+    if (!Number.isFinite(noiseFloor) || noiseFloor < 0) {
+        throw new UsageError(`--noise-floor must be a non-negative number (got: ${values['noise-floor']})`);
+    }
+
+    return {
+        help: false,
+        controlPath,
+        treatmentPath,
+        datasetPath: values.dataset,
+        reportPath: values.report ?? null,
+        filter: values.filter ?? null,
+        noiseFloor,
+        changeAxes: values['change-axis'] ?? [],
+        groundTruthVersion: values['gt-version'] ?? null,
+    };
+}
+
+function parseFilterExpression(expr) {
+    const eq = expr.indexOf('=');
+    if (eq === -1) {
+        throw new UsageError(`bad --filter syntax (expected key=value): ${expr}`);
+    }
+    const key = expr.slice(0, eq);
+    const value = expr.slice(eq + 1);
+    if (key === 'version') {
+        return ({ datasetEntry }) => datasetEntry.dataset_version === value;
+    }
+    if (key === 'provider') {
+        return ({ provider }) => provider === value;
+    }
+    if (key === 'direction') {
+        return ({ direction }) => direction === value;
+    }
+    throw new UsageError(`unknown --filter key: ${key} (supported: version, provider, direction)`);
+}
+
+function chooseRenderer(reportPath) {
+    const lower = reportPath.toLowerCase();
+    if (lower.endsWith('.html'))     return { fn: renderHtml,     mode: 'html' };
+    if (lower.endsWith('.md') || lower.endsWith('.markdown')) {
+        return { fn: renderMarkdown, mode: 'markdown' };
+    }
+    if (lower.endsWith('.json'))     return { fn: renderJson,     mode: 'json' };
+    return null;
+}
+
+export async function runCompare(opts, { stdout = process.stdout, stderr = process.stderr } = {}) {
+    let control, treatment, dataset;
+    try {
+        control = JSON.parse(fs.readFileSync(opts.controlPath, 'utf8'));
+    } catch (err) {
+        stderr.write(`ccs compare: failed to read control (${opts.controlPath}): ${err.message}\n`);
+        return 2;
+    }
+    try {
+        treatment = JSON.parse(fs.readFileSync(opts.treatmentPath, 'utf8'));
+    } catch (err) {
+        stderr.write(`ccs compare: failed to read treatment (${opts.treatmentPath}): ${err.message}\n`);
+        return 2;
+    }
+    try {
+        const datasetRaw = JSON.parse(fs.readFileSync(opts.datasetPath, 'utf8'));
+        dataset = Array.isArray(datasetRaw) ? datasetRaw : (datasetRaw.rows ?? []);
+    } catch (err) {
+        stderr.write(`ccs compare: failed to read dataset (${opts.datasetPath}): ${err.message}\n`);
+        return 2;
+    }
+
+    let result = compareResults({
+        control, treatment, dataset,
+        options: {
+            changeAxes: opts.changeAxes,
+            groundTruthVersion: opts.groundTruthVersion,
+        },
+    });
+
+    if (opts.filter) {
+        let predicate;
+        try {
+            predicate = parseFilterExpression(opts.filter);
+        } catch (err) {
+            stderr.write(`ccs compare: ${err.message}\n`);
+            return 2;
+        }
+        result = filterComparison(result, predicate);
+    }
+
+    if (result.coverage.comparedCells === 0) {
+        stderr.write(`ccs compare: no cells in intersection — control and treatment share no successful (entry_id, provider) pairs (or all pairs were filtered out).\n`);
+        return 2;
+    }
+
+    if (!opts.reportPath) {
+        stdout.write(renderJson(result, { indent: 2 }));
+        stdout.write('\n');
+        return 0;
+    }
+
+    const renderer = chooseRenderer(opts.reportPath);
+    if (!renderer) {
+        stderr.write(`ccs compare: unrecognized report extension (use .html, .md, or .json): ${opts.reportPath}\n`);
+        return 2;
+    }
+    const rendered = renderer.fn(result, { noiseFloor: opts.noiseFloor });
+    fs.writeFileSync(opts.reportPath, rendered, 'utf8');
+    stdout.write(`Report written to ${opts.reportPath} (${result.coverage.comparedCells} cells compared)\n`);
+    return 0;
+}

--- a/cli/compare.js
+++ b/cli/compare.js
@@ -25,7 +25,7 @@ Options:
   --filter <expr>    Post-hoc subset filter. Supported expressions:
                        version=<v1|v2|v3|...>   filter by dataset_version
                        provider=<name>          filter to a single provider
-                       direction=<imp|reg|...>  filter by direction class
+                       direction=<improvement|regression|lateral|unchanged-correct|unchanged-wrong-same>  filter by direction class
   --noise-floor <pp> Annotate per-provider rows whose |Δ| is below this
                      threshold (in percentage points). Default: 5.
   --change-axis <a>  What differs between control and treatment (e.g.,
@@ -100,6 +100,10 @@ function parseFilterExpression(expr) {
         return ({ provider }) => provider === value;
     }
     if (key === 'direction') {
+        const VALID = ['improvement', 'regression', 'lateral', 'unchanged-correct', 'unchanged-wrong-same'];
+        if (!VALID.includes(value)) {
+            throw new UsageError(`unknown direction: ${value} (supported: ${VALID.join(', ')})`);
+        }
         return ({ direction }) => direction === value;
     }
     throw new UsageError(`unknown --filter key: ${key} (supported: version, provider, direction)`);
@@ -107,11 +111,11 @@ function parseFilterExpression(expr) {
 
 function chooseRenderer(reportPath) {
     const lower = reportPath.toLowerCase();
-    if (lower.endsWith('.html'))     return { fn: renderHtml,     mode: 'html' };
+    if (lower.endsWith('.html'))     return renderHtml;
     if (lower.endsWith('.md') || lower.endsWith('.markdown')) {
-        return { fn: renderMarkdown, mode: 'markdown' };
+        return renderMarkdown;
     }
-    if (lower.endsWith('.json'))     return { fn: renderJson,     mode: 'json' };
+    if (lower.endsWith('.json'))     return renderJson;
     return null;
 }
 
@@ -167,12 +171,12 @@ export async function runCompare(opts, { stdout = process.stdout, stderr = proce
         return 0;
     }
 
-    const renderer = chooseRenderer(opts.reportPath);
-    if (!renderer) {
+    const render = chooseRenderer(opts.reportPath);
+    if (!render) {
         stderr.write(`ccs compare: unrecognized report extension (use .html, .md, or .json): ${opts.reportPath}\n`);
         return 2;
     }
-    const rendered = renderer.fn(result, { noiseFloor: opts.noiseFloor });
+    const rendered = render(result, { noiseFloor: opts.noiseFloor });
     fs.writeFileSync(opts.reportPath, rendered, 'utf8');
     stdout.write(`Report written to ${opts.reportPath} (${result.coverage.comparedCells} cells compared)\n`);
     return 0;

--- a/cli/verify.js
+++ b/cli/verify.js
@@ -11,6 +11,7 @@ import { fetchSourceContent, logVerification } from '../core/worker.js';
 import { generateSystemPrompt, generateUserPrompt } from '../core/prompts.js';
 import { callProviderAPI } from '../core/providers.js';
 import { parseVerificationResult } from '../core/parsing.js';
+import { parseCompareArgs, COMPARE_HELP_TEXT, runCompare } from './compare.js';
 
 const KNOWN_PROVIDERS = ['publicai', 'huggingface', 'claude', 'gemini', 'openai'];
 
@@ -27,7 +28,10 @@ export function parseCliArgs(argv) {
         const opts = parseVerifyArgs(subArgs);
         return { ...opts, subcommand: 'verify' };
     }
-    // 'compare' will be added in Task 4 once cli/compare.js is in place.
+    if (subcommand === 'compare') {
+        const opts = parseCompareArgs(subArgs);
+        return { ...opts, subcommand: 'compare' };
+    }
 
     throw new UsageError(`unknown subcommand: ${subcommand}`);
 }
@@ -385,6 +389,8 @@ export async function main(argv, { stdout = process.stdout, stderr = process.std
     if (opts.help) {
         if (opts.scope === 'verify') {
             stdout.write(VERIFY_HELP_TEXT);
+        } else if (opts.scope === 'compare') {
+            stdout.write(COMPARE_HELP_TEXT);
         } else {
             stdout.write(TOP_LEVEL_HELP_TEXT);
         }
@@ -393,6 +399,10 @@ export async function main(argv, { stdout = process.stdout, stderr = process.std
 
     if (opts.subcommand === 'verify') {
         return await runVerify(opts, { stdout, stderr, env });
+    }
+
+    if (opts.subcommand === 'compare') {
+        return await runCompare(opts, { stdout, stderr });
     }
 
     // Unreachable — parseCliArgs would have thrown.

--- a/cli/verify.js
+++ b/cli/verify.js
@@ -17,12 +17,28 @@ const KNOWN_PROVIDERS = ['publicai', 'huggingface', 'claude', 'gemini', 'openai'
 export function parseCliArgs(argv) {
     const raw = argv.slice(2);
 
-    if (raw.length === 0) {
-        return { help: true };
+    if (raw.length === 0) return { help: true, scope: 'top' };
+    if (raw[0] === '-h' || raw[0] === '--help') return { help: true, scope: 'top' };
+
+    const subcommand = raw[0];
+    const subArgs = raw.slice(1);
+
+    if (subcommand === 'verify') {
+        const opts = parseVerifyArgs(subArgs);
+        return { ...opts, subcommand: 'verify' };
+    }
+    // 'compare' will be added in Task 4 once cli/compare.js is in place.
+
+    throw new UsageError(`unknown subcommand: ${subcommand}`);
+}
+
+function parseVerifyArgs(args) {
+    if (args.includes('-h') || args.includes('--help')) {
+        return { help: true, scope: 'verify' };
     }
 
     const { values, positionals } = parseArgs({
-        args: raw,
+        args,
         options: {
             provider: { type: 'string', default: 'publicai' },
             'no-log': { type: 'boolean', default: false },
@@ -32,20 +48,8 @@ export function parseCliArgs(argv) {
         strict: true,
     });
 
-    if (values.help) {
-        return { help: true };
-    }
-
-    const subcommand = positionals[0];
-    if (!subcommand) {
-        return { help: true };
-    }
-    if (subcommand !== 'verify') {
-        throw new UsageError(`unknown subcommand: ${subcommand}`);
-    }
-
-    const url = positionals[1];
-    const citationStr = positionals[2];
+    const url = positionals[0];
+    const citationStr = positionals[1];
     if (!url || !citationStr) {
         throw new UsageError('usage: ccs verify <wikipedia-url> <citation-number> [--provider <name>] [--no-log]');
     }
@@ -62,7 +66,6 @@ export function parseCliArgs(argv) {
 
     return {
         help: false,
-        subcommand: 'verify',
         url,
         citationNumber,
         provider,
@@ -165,7 +168,7 @@ const PROVIDER_OPTIONAL_ENV_VARS = {
     huggingface: 'HF_API_KEY',
 };
 
-export const HELP_TEXT = `usage: ccs verify <wikipedia-url> <citation-number> [options]
+export const VERIFY_HELP_TEXT = `usage: ccs verify <wikipedia-url> <citation-number> [options]
 
 Verify a Wikipedia citation by fetching its source and asking an LLM
 whether the cited claim is supported.
@@ -207,6 +210,17 @@ Examples:
   ccs verify https://en.wikipedia.org/wiki/Great_Migration_(African_American) 14
   ccs verify https://en.wikipedia.org/wiki/Foo 3 --provider claude
   ccs verify https://en.wikipedia.org/wiki/Foo?oldid=1234567 3 --no-log
+`;
+
+export const TOP_LEVEL_HELP_TEXT = `usage: ccs <subcommand> [...]
+
+Subcommands:
+  verify    Verify a Wikipedia citation by fetching its source and asking
+            an LLM whether the cited claim is supported.
+  compare   Compare two benchmark results.json files and produce a
+            per-provider accuracy + flip report (Markdown, HTML, or JSON).
+
+Run \`ccs <subcommand> --help\` for subcommand-specific options.
 `;
 
 async function fetchWikipediaHtml(restUrl) {
@@ -369,11 +383,20 @@ export async function main(argv, { stdout = process.stdout, stderr = process.std
     }
 
     if (opts.help) {
-        stdout.write(HELP_TEXT);
+        if (opts.scope === 'verify') {
+            stdout.write(VERIFY_HELP_TEXT);
+        } else {
+            stdout.write(TOP_LEVEL_HELP_TEXT);
+        }
         return 0;
     }
 
-    return await runVerify(opts, { stdout, stderr, env });
+    if (opts.subcommand === 'verify') {
+        return await runVerify(opts, { stdout, stderr, env });
+    }
+
+    // Unreachable — parseCliArgs would have thrown.
+    throw new Error(`unhandled subcommand: ${opts.subcommand}`);
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/docs/comparing-benchmark-runs.md
+++ b/docs/comparing-benchmark-runs.md
@@ -1,0 +1,92 @@
+# Comparing benchmark runs
+
+The `ccs compare` subcommand turns two `results.json` files (a *control* and a *treatment*) into a structured per-provider accuracy + flip report. It exists so contributors can validate prompt changes, worker-side changes, dataset augmentations, or panel-member swaps against a baseline without writing a one-off comparison script every time.
+
+The tool operates on the *intersection* of cells present in both runs — `(entry_id, provider)` pairs that successfully predicted in both control and treatment. Cells where either side errored or didn't run are excluded from the comparison so accuracy isn't skewed by missing data.
+
+## Quick start
+
+From inside `benchmark/`:
+
+```sh
+# Render a Markdown report
+npm run compare -- control.json treatment.json --dataset dataset.json --report out.md
+
+# Render a self-contained HTML report
+npm run compare -- control.json treatment.json --dataset dataset.json --report out.html
+
+# Print JSON to stdout for piping into another tool
+npm run compare -- control.json treatment.json --dataset dataset.json
+```
+
+Or invoke the underlying CLI directly:
+
+```sh
+npx ccs compare control.json treatment.json --dataset dataset.json --report out.html
+```
+
+The format of the report is chosen by the file extension on `--report`: `.html`, `.md` (or `.markdown`), or `.json`. With no `--report`, JSON is written to stdout.
+
+## What the report shows
+
+Two tables, in both Markdown and HTML output:
+
+1. **Headline accuracy.** For each provider, the count of correct cells out of total compared cells, in both control and treatment, with a Δ in percentage points. Three metrics:
+    - *exact match* — the predicted verdict equals ground truth literally (after case/whitespace normalization).
+    - *lenient* — exact, plus `Supported ↔ Partially supported` counted as a near-miss. Useful when the GT distinction between those two is itself fuzzy and a Supported→Partially shift shouldn't count as an error.
+    - *binary* — Supported and Partially supported are pooled into one class; Not supported and Source unavailable into the other.
+
+    Rows whose `|Δ|` falls below the noise floor (default ±5pp, configurable via `--noise-floor`) on *all three* metrics are flagged so a reader treats them as noise rather than signal.
+2. **Flip table.** Every cell that changed verdict, classified as one of:
+    - **improvement** — wrong in control, correct in treatment.
+    - **regression** — correct in control, wrong in treatment.
+    - **lateral** — wrong in both, but the verdict shifted to a different wrong answer.
+
+Cells that were *unchanged-correct* or *unchanged-wrong-same* are aggregated in the per-provider counts but don't appear in the flip table.
+
+## Subset filtering
+
+The `--filter <key>=<value>` flag re-aggregates the comparison over a subset of cells *after the full comparison runs*. This is deliberate: pre-classifying rows before the experiment and filtering before the comparison invites confirmation bias. Always run the full comparison, then slice in the report.
+
+Supported filter keys:
+
+| Key | Example | Effect |
+|---|---|---|
+| `version` | `--filter version=v2` | Restrict to dataset rows with `dataset_version === 'v2'`. |
+| `provider` | `--filter provider=openrouter-vote-3` | Restrict to a single provider/panel. |
+| `direction` | `--filter direction=regression` | Restrict to cells with a specific flip direction (useful for "show me only the regressions"). |
+
+Combine filters by running the comparison multiple times with different `--filter` values; the JSON output is small enough that piping through `jq` is also fine for ad-hoc slicing.
+
+## Recording what changed
+
+Two optional flags add metadata to the report so a reader knows what they're looking at:
+
+- `--change-axis <name>` — repeat for each thing that differs between control and treatment (e.g., `--change-axis prompt --change-axis source_text`). Recorded in the report's metadata block.
+- `--gt-version <label>` — the ground-truth version (e.g., `post-audit-2026-04-30`). Useful when re-scoring an old result file against a revised dataset; the report records which GT was applied.
+
+These don't change the comparison logic, only the report's metadata. Use them so readers can audit which axis each comparison isolates.
+
+## When to use this
+
+- **Before/after a prompt change.** Run the benchmark once with the old prompt, once with the new, then compare. `--change-axis prompt`.
+- **Before/after a worker / proxy change.** Compare against a baseline run before the change. `--change-axis source_text`.
+- **Control vs augmented dataset.** When testing whether a dataset augmentation (e.g., prepending Citoid metadata) helps, run both with and without and compare.
+- **Provider-panel A/B.** Compare runs that included a different mix of panel members.
+- **Pre-submission check before opening a PR.** Run your branch's benchmark against a frozen canonical baseline; the report's flip table is what to paste into the PR description.
+
+## Exit codes
+
+- `0` — comparison ran successfully. Always returned on a clean run, regardless of whether regressions were found. **Inspect the report; the tool does not gate on regressions.**
+- `2` — bad arguments, file not found, JSON parse failure, no overlapping cells, or unrecognized `--filter` key. Genuine errors only.
+
+If you want a CI gate that fails on regression, pipe the JSON output through a separate script that decides the threshold — do not bake gating into this tool.
+
+## Source layout
+
+- `benchmark/compare_results.js` — pure comparison logic (`compareResults`, `filterComparison`, verdict normalizers, classification, aggregation).
+- `benchmark/render_compare.js` — Markdown / HTML / JSON renderers (`renderMarkdown`, `renderHtml`, `renderJson`).
+- `cli/compare.js` — argument parsing and the `runCompare` orchestration that loads files, calls compare, applies filters, writes reports.
+- `tests/compare_results.test.js`, `tests/render_compare.test.js`, `tests/compare_cli.test.js` — unit + integration coverage.
+
+The pure logic in `compare_results.js` and `render_compare.js` does no I/O — they take parsed inputs and return data structures or strings. The CLI is the only layer that touches the filesystem. This is intentional so the comparison logic is callable from a script, a test, or a future GUI without dragging file-system assumptions along.

--- a/docs/comparing-benchmark-runs.md
+++ b/docs/comparing-benchmark-runs.md
@@ -54,7 +54,7 @@ Supported filter keys:
 |---|---|---|
 | `version` | `--filter version=v2` | Restrict to dataset rows with `dataset_version === 'v2'`. |
 | `provider` | `--filter provider=openrouter-vote-3` | Restrict to a single provider/panel. |
-| `direction` | `--filter direction=regression` | Restrict to cells with a specific flip direction (useful for "show me only the regressions"). |
+| `direction` | `--filter direction=regression` | Restrict to cells with a specific flip direction (valid values: `improvement`, `regression`, `lateral`, `unchanged-correct`, `unchanged-wrong-same`). |
 
 Combine filters by running the comparison multiple times with different `--filter` values; the JSON output is small enough that piping through `jq` is also fine for ad-hoc slicing.
 

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { JSDOM } from 'jsdom';
-import { HELP_TEXT, main, parseCliArgs, parseWikiUrl, deriveRestUrl, findReferenceByCitationNumber, classifyProviderError, runVerify } from '../cli/verify.js';
+import { VERIFY_HELP_TEXT, TOP_LEVEL_HELP_TEXT, main, parseCliArgs, parseWikiUrl, deriveRestUrl, findReferenceByCitationNumber, classifyProviderError, runVerify } from '../cli/verify.js';
 
 function args(...rest) {
   return ['node', 'bin/ccs', ...rest];
@@ -662,47 +662,65 @@ test('runVerify: DOM traversal chain works against a realistic Wikipedia fixture
   }
 });
 
-test('HELP_TEXT: documents the verify subcommand usage', () => {
-  assert.match(HELP_TEXT, /ccs verify <wikipedia-url> <citation-number>/);
+test('VERIFY_HELP_TEXT: documents the verify subcommand usage', () => {
+  assert.match(VERIFY_HELP_TEXT, /ccs verify <wikipedia-url> <citation-number>/);
 });
 
-test('HELP_TEXT: documents --provider with all four choices', () => {
-  assert.match(HELP_TEXT, /--provider/);
+test('VERIFY_HELP_TEXT: documents --provider with all four choices', () => {
+  assert.match(VERIFY_HELP_TEXT, /--provider/);
   for (const p of ['publicai', 'claude', 'gemini', 'openai']) {
-    assert.match(HELP_TEXT, new RegExp(p), `HELP_TEXT missing provider: ${p}`);
+    assert.match(VERIFY_HELP_TEXT, new RegExp(p), `VERIFY_HELP_TEXT missing provider: ${p}`);
   }
 });
 
-test('HELP_TEXT: documents --no-log', () => {
-  assert.match(HELP_TEXT, /--no-log/);
+test('VERIFY_HELP_TEXT: documents --no-log', () => {
+  assert.match(VERIFY_HELP_TEXT, /--no-log/);
 });
 
-test('HELP_TEXT: documents the API key env vars for external providers', () => {
+test('VERIFY_HELP_TEXT: documents the API key env vars for external providers', () => {
   for (const v of ['CLAUDE_API_KEY', 'GEMINI_API_KEY', 'OPENAI_API_KEY']) {
-    assert.match(HELP_TEXT, new RegExp(v), `HELP_TEXT missing env var: ${v}`);
+    assert.match(VERIFY_HELP_TEXT, new RegExp(v), `VERIFY_HELP_TEXT missing env var: ${v}`);
   }
   // PublicAI goes through the proxy and needs no client-side key — document
   // that explicitly so users don't go looking for a PUBLICAI_API_KEY.
   // Use [\s\S] (not [^\n]*) so the match can span the line break between
   // "publicai" and "no API key" in the formatted block.
-  assert.match(HELP_TEXT, /publicai[\s\S]*?no API key/i);
+  assert.match(VERIFY_HELP_TEXT, /publicai[\s\S]*?no API key/i);
 });
 
-test('HELP_TEXT: documents every exit code from the error table', () => {
+test('VERIFY_HELP_TEXT: documents every exit code from the error table', () => {
   // Exit codes from docs/design-plans/2026-04-23-factor-and-cli.md, minus the
   // success exit (0), which doesn't need to appear in a table of failures.
   const expectedCodes = ['2', '3', '4', '5', '6', '7', '8', '9', '10', '11'];
   for (const code of expectedCodes) {
-    assert.match(HELP_TEXT, new RegExp(`\\b${code}\\b`), `HELP_TEXT missing exit code ${code}`);
+    assert.match(VERIFY_HELP_TEXT, new RegExp(`\\b${code}\\b`), `VERIFY_HELP_TEXT missing exit code ${code}`);
   }
 });
 
-test('main() with --help writes HELP_TEXT to the injected stdout and returns 0', async () => {
+test('main() with verify --help writes VERIFY_HELP_TEXT to the injected stdout and returns 0', async () => {
   const stdout = mkStream();
   const stderr = mkStream();
-  const code = await main(['node', 'bin/ccs', '--help'], { stdout, stderr, env: {} });
+  const code = await main(['node', 'bin/ccs', 'verify', '--help'], { stdout, stderr, env: {} });
   assert.equal(code, 0, `stderr: ${stderr.value()}`);
   assert.match(stdout.value(), /ccs verify/);
   assert.match(stdout.value(), /Exit codes:/);
+});
+
+test('main() with no args writes top-level help mentioning subcommands', async () => {
+  const stdout = mkStream();
+  const stderr = mkStream();
+  const code = await main(['node', 'bin/ccs'], { stdout, stderr });
+  assert.equal(code, 0);
+  assert.match(stdout.value(), /Subcommands:/);
+  assert.match(stdout.value(), /verify/);
+  assert.match(stdout.value(), /compare/);
+});
+
+test('main() with --help (no subcommand) writes top-level help', async () => {
+  const stdout = mkStream();
+  const stderr = mkStream();
+  const code = await main(['node', 'bin/ccs', '--help'], { stdout, stderr });
+  assert.equal(code, 0);
+  assert.match(stdout.value(), /Subcommands:/);
 });
 

--- a/tests/compare_cli.test.js
+++ b/tests/compare_cli.test.js
@@ -165,3 +165,18 @@ test('runCompare with --filter version=v2 narrows to v2 rows', async () => {
         for (const f of [c, t, d, reportPath]) try { fs.unlinkSync(f); } catch {}
     }
 });
+
+test('runCompare returns 2 on unknown --filter direction', async () => {
+    const { c, t, d } = setup();
+    const stderr = [];
+    try {
+        const code = await runCompare(
+            { controlPath: c, treatmentPath: t, datasetPath: d, reportPath: null, filter: 'direction=reg', noiseFloor: 5, changeAxes: [], groundTruthVersion: null },
+            { stdout: { write: () => {} }, stderr: { write: (s) => stderr.push(s) } },
+        );
+        assert.equal(code, 2);
+        assert.match(stderr.join(''), /unknown direction: reg/);
+    } finally {
+        for (const f of [c, t, d]) fs.unlinkSync(f);
+    }
+});

--- a/tests/compare_cli.test.js
+++ b/tests/compare_cli.test.js
@@ -1,0 +1,167 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { parseCompareArgs, COMPARE_HELP_TEXT, runCompare } from '../cli/compare.js';
+import { UsageError } from '../cli/verify.js';
+
+test('parseCompareArgs: --help short-circuits with scope=compare', () => {
+    const opts = parseCompareArgs(['--help']);
+    assert.equal(opts.help, true);
+    assert.equal(opts.scope, 'compare');
+});
+
+test('parseCompareArgs: requires control + treatment positionals and --dataset', () => {
+    assert.throws(() => parseCompareArgs([]), UsageError);
+    assert.throws(() => parseCompareArgs(['c.json']), UsageError);
+    assert.throws(() => parseCompareArgs(['c.json', 't.json']), UsageError); // missing --dataset
+});
+
+test('parseCompareArgs: returns full opts on a complete invocation', () => {
+    const opts = parseCompareArgs([
+        'control.json',
+        'treatment.json',
+        '--dataset', 'dataset.json',
+        '--report', 'report.html',
+        '--filter', 'version=v2',
+        '--noise-floor', '7',
+        '--change-axis', 'prompt',
+        '--change-axis', 'source_text',
+        '--gt-version', 'post-audit-2026-04-30',
+    ]);
+    assert.equal(opts.help, false);
+    assert.equal(opts.controlPath, 'control.json');
+    assert.equal(opts.treatmentPath, 'treatment.json');
+    assert.equal(opts.datasetPath, 'dataset.json');
+    assert.equal(opts.reportPath, 'report.html');
+    assert.equal(opts.filter, 'version=v2');
+    assert.equal(opts.noiseFloor, 7);
+    assert.deepEqual(opts.changeAxes, ['prompt', 'source_text']);
+    assert.equal(opts.groundTruthVersion, 'post-audit-2026-04-30');
+});
+
+test('parseCompareArgs: defaults reportPath to null and noiseFloor to 5', () => {
+    const opts = parseCompareArgs(['c.json', 't.json', '--dataset', 'd.json']);
+    assert.equal(opts.reportPath, null);
+    assert.equal(opts.noiseFloor, 5);
+    assert.deepEqual(opts.changeAxes, []);
+});
+
+test('COMPARE_HELP_TEXT mentions key flags', () => {
+    assert.match(COMPARE_HELP_TEXT, /--dataset/);
+    assert.match(COMPARE_HELP_TEXT, /--report/);
+    assert.match(COMPARE_HELP_TEXT, /--filter/);
+});
+
+function tmp(suffix = '.json') {
+    return path.join(os.tmpdir(), `ccs-compare-${Date.now()}-${Math.random().toString(36).slice(2)}${suffix}`);
+}
+
+const FIX_DATASET = [
+    { id: 'r1', ground_truth: 'Supported', claim_text: 'c1', source_url: 'http://x/1', extraction_status: 'complete', needs_manual_review: false, dataset_version: 'v1' },
+    { id: 'r2', ground_truth: 'Not supported', claim_text: 'c2', source_url: 'http://x/2', extraction_status: 'complete', needs_manual_review: false, dataset_version: 'v2' },
+];
+const FIX_CONTROL = { rows: [
+    { entry_id: 'r1', provider: 'mistral', predicted_verdict: 'Not supported', error: null },
+    { entry_id: 'r2', provider: 'mistral', predicted_verdict: 'Supported', error: null },
+] };
+const FIX_TREATMENT = { rows: [
+    { entry_id: 'r1', provider: 'mistral', predicted_verdict: 'Supported', error: null },
+    { entry_id: 'r2', provider: 'mistral', predicted_verdict: 'Not supported', error: null },
+] };
+
+function setup() {
+    const c = tmp(), t = tmp(), d = tmp();
+    fs.writeFileSync(c, JSON.stringify(FIX_CONTROL));
+    fs.writeFileSync(t, JSON.stringify(FIX_TREATMENT));
+    fs.writeFileSync(d, JSON.stringify(FIX_DATASET));
+    return { c, t, d };
+}
+
+test('runCompare writes JSON to stdout when no --report given', async () => {
+    const { c, t, d } = setup();
+    const out = [];
+    const stdout = { write: (s) => out.push(s) };
+    const stderr = { write: () => {} };
+    try {
+        const code = await runCompare(
+            { controlPath: c, treatmentPath: t, datasetPath: d, reportPath: null, filter: null, noiseFloor: 5, changeAxes: [], groundTruthVersion: null },
+            { stdout, stderr },
+        );
+        assert.equal(code, 0);
+        const json = JSON.parse(out.join(''));
+        assert.equal(json.coverage.comparedCells, 2);
+    } finally {
+        for (const f of [c, t, d]) fs.unlinkSync(f);
+    }
+});
+
+test('runCompare writes HTML to disk when --report ends in .html', async () => {
+    const { c, t, d } = setup();
+    const reportPath = tmp('.html');
+    const stdout = { write: () => {} };
+    const stderr = { write: () => {} };
+    try {
+        const code = await runCompare(
+            { controlPath: c, treatmentPath: t, datasetPath: d, reportPath, filter: null, noiseFloor: 5, changeAxes: [], groundTruthVersion: null },
+            { stdout, stderr },
+        );
+        assert.equal(code, 0);
+        const contents = fs.readFileSync(reportPath, 'utf8');
+        assert.match(contents, /<!DOCTYPE html>/);
+        assert.match(contents, /Headline accuracy/);
+    } finally {
+        for (const f of [c, t, d, reportPath]) try { fs.unlinkSync(f); } catch {}
+    }
+});
+
+test('runCompare returns 2 when control file is missing', async () => {
+    const { t, d } = setup();
+    const stderr = [];
+    const code = await runCompare(
+        { controlPath: '/nonexistent.json', treatmentPath: t, datasetPath: d, reportPath: null, filter: null, noiseFloor: 5, changeAxes: [], groundTruthVersion: null },
+        { stdout: { write: () => {} }, stderr: { write: (s) => stderr.push(s) } },
+    );
+    assert.equal(code, 2);
+    assert.match(stderr.join(''), /ccs compare: /);
+    for (const f of [t, d]) fs.unlinkSync(f);
+});
+
+test('runCompare returns 2 on no-overlap intersection', async () => {
+    const c = tmp(), t = tmp(), d = tmp();
+    fs.writeFileSync(c, JSON.stringify({ rows: [{ entry_id: 'r1', provider: 'mistral', predicted_verdict: 'Supported', error: null }] }));
+    fs.writeFileSync(t, JSON.stringify({ rows: [{ entry_id: 'r2', provider: 'granite', predicted_verdict: 'Supported', error: null }] }));
+    fs.writeFileSync(d, JSON.stringify(FIX_DATASET));
+    const stderr = [];
+    try {
+        const code = await runCompare(
+            { controlPath: c, treatmentPath: t, datasetPath: d, reportPath: null, filter: null, noiseFloor: 5, changeAxes: [], groundTruthVersion: null },
+            { stdout: { write: () => {} }, stderr: { write: (s) => stderr.push(s) } },
+        );
+        assert.equal(code, 2);
+        assert.match(stderr.join(''), /no cells in intersection/);
+    } finally {
+        for (const f of [c, t, d]) fs.unlinkSync(f);
+    }
+});
+
+test('runCompare with --filter version=v2 narrows to v2 rows', async () => {
+    const { c, t, d } = setup();
+    const reportPath = tmp('.json');
+    const stdout = { write: () => {} };
+    const stderr = { write: () => {} };
+    try {
+        const code = await runCompare(
+            { controlPath: c, treatmentPath: t, datasetPath: d, reportPath, filter: 'version=v2', noiseFloor: 5, changeAxes: [], groundTruthVersion: null },
+            { stdout, stderr },
+        );
+        assert.equal(code, 0);
+        const json = JSON.parse(fs.readFileSync(reportPath, 'utf8'));
+        // FIX_DATASET has one v2 row → filter to 1 cell.
+        assert.equal(json.coverage.comparedCells, 1);
+        assert.equal(json.metadata.filtered, true);
+    } finally {
+        for (const f of [c, t, d, reportPath]) try { fs.unlinkSync(f); } catch {}
+    }
+});

--- a/tests/compare_results.test.js
+++ b/tests/compare_results.test.js
@@ -43,3 +43,32 @@ test('verdictsEqualLenient: Supported↔Partially supported is a near-miss; ever
     assert.equal(verdictsEqualLenient('Partially supported', 'Not supported'), false);
     assert.equal(verdictsEqualLenient('Source unavailable', 'Not supported'), false);
 });
+
+import { indexCellsByPair } from '../benchmark/compare_results.js';
+
+test('indexCellsByPair builds entry_id:provider Map from rows', () => {
+    const rows = [
+        { entry_id: 'row_1', provider: 'claude', predicted_verdict: 'Supported', error: null },
+        { entry_id: 'row_1', provider: 'gemini', predicted_verdict: 'Not supported', error: null },
+        { entry_id: 'row_2', provider: 'claude', predicted_verdict: 'Partially supported', error: null },
+    ];
+    const idx = indexCellsByPair(rows);
+    assert.equal(idx.size, 3);
+    assert.equal(idx.get('row_1:claude').predicted_verdict, 'Supported');
+    assert.equal(idx.get('row_2:claude').predicted_verdict, 'Partially supported');
+});
+
+test('indexCellsByPair drops rows with error or predicted_verdict ERROR', () => {
+    const rows = [
+        { entry_id: 'row_1', provider: 'claude', predicted_verdict: 'Supported', error: null },
+        { entry_id: 'row_1', provider: 'gemini', predicted_verdict: 'ERROR', error: 'rate limit' },
+        { entry_id: 'row_2', provider: 'claude', predicted_verdict: 'ERROR', error: null },
+        { entry_id: 'row_2', provider: 'gemini', predicted_verdict: 'Supported', error: 'timeout' },
+    ];
+    const idx = indexCellsByPair(rows);
+    assert.equal(idx.size, 1);
+    assert.equal(idx.has('row_1:claude'), true);
+    assert.equal(idx.has('row_1:gemini'), false);
+    assert.equal(idx.has('row_2:claude'), false);
+    assert.equal(idx.has('row_2:gemini'), false);
+});

--- a/tests/compare_results.test.js
+++ b/tests/compare_results.test.js
@@ -166,3 +166,95 @@ test('computeProviderStats aggregates exact + lenient + binary accuracy and flip
     assert.equal(stats.flips['unchanged-correct'], 2);
     assert.equal(stats.flips['unchanged-wrong-same'], 0);
 });
+
+import { compareResults } from '../benchmark/compare_results.js';
+
+const FIXTURE_DATASET = [
+    { id: 'row_1', ground_truth: 'Supported', claim_text: 'C1', source_url: 'http://x/1', extraction_status: 'complete', needs_manual_review: false, dataset_version: 'v1' },
+    { id: 'row_2', ground_truth: 'Partially supported', claim_text: 'C2', source_url: 'http://x/2', extraction_status: 'complete', needs_manual_review: false, dataset_version: 'v1' },
+    { id: 'row_3', ground_truth: 'Not supported', claim_text: 'C3', source_url: 'http://x/3', extraction_status: 'complete', needs_manual_review: false, dataset_version: 'v2' },
+    { id: 'row_4', ground_truth: 'Supported', claim_text: 'C4', source_url: 'http://x/4', extraction_status: 'complete', needs_manual_review: false, dataset_version: 'v2' },
+    { id: 'row_5', ground_truth: 'Not supported', claim_text: 'C5', source_url: 'http://x/5', extraction_status: 'complete', needs_manual_review: false, dataset_version: 'v2' },
+    { id: 'row_skip', ground_truth: 'Supported', claim_text: 'skip', source_url: 'http://x/s', extraction_status: 'complete', needs_manual_review: true, dataset_version: 'v1' },
+];
+
+const FIXTURE_CONTROL = {
+    metadata: { run_at: '2026-05-01T10:00:00Z' },
+    rows: [
+        // mistral cells
+        { entry_id: 'row_1', provider: 'mistral', predicted_verdict: 'Supported', error: null },
+        { entry_id: 'row_2', provider: 'mistral', predicted_verdict: 'Supported', error: null },
+        { entry_id: 'row_3', provider: 'mistral', predicted_verdict: 'Not supported', error: null },
+        { entry_id: 'row_4', provider: 'mistral', predicted_verdict: 'Supported', error: null },
+        { entry_id: 'row_5', provider: 'mistral', predicted_verdict: 'Supported', error: null },
+        // granite cells
+        { entry_id: 'row_1', provider: 'granite', predicted_verdict: 'Not supported', error: null },
+        { entry_id: 'row_2', provider: 'granite', predicted_verdict: 'Not supported', error: null },
+        { entry_id: 'row_3', provider: 'granite', predicted_verdict: 'Not supported', error: null },
+        { entry_id: 'row_4', provider: 'granite', predicted_verdict: 'Partially supported', error: null },
+        { entry_id: 'row_5', provider: 'granite', predicted_verdict: 'Partially supported', error: null },
+        // a vote-3 panel cell (validates that synthesized panel rows compare like any other provider)
+        { entry_id: 'row_1', provider: 'openrouter-vote-3', predicted_verdict: 'Supported', error: null },
+        // an errored cell that must be filtered
+        { entry_id: 'row_skip', provider: 'mistral', predicted_verdict: 'ERROR', error: 'rate limit' },
+    ],
+};
+
+const FIXTURE_TREATMENT = {
+    metadata: { run_at: '2026-05-02T10:00:00Z' },
+    rows: [
+        // mistral cells
+        { entry_id: 'row_1', provider: 'mistral', predicted_verdict: 'Supported', error: null },           // unchanged-correct (GT Supported)
+        { entry_id: 'row_2', provider: 'mistral', predicted_verdict: 'Partially supported', error: null }, // improvement (was Supported, now Partially supported, GT Partially supported)
+        { entry_id: 'row_3', provider: 'mistral', predicted_verdict: 'Not supported', error: null },       // unchanged-correct (GT Not supported)
+        { entry_id: 'row_4', provider: 'mistral', predicted_verdict: 'Supported', error: null },           // unchanged-correct (GT Supported)
+        { entry_id: 'row_5', provider: 'mistral', predicted_verdict: 'Not supported', error: null },       // improvement (was Supported, now Not supported, GT Not supported)
+        // granite cells
+        { entry_id: 'row_1', provider: 'granite', predicted_verdict: 'Supported', error: null },           // improvement (was Not supported, GT Supported)
+        { entry_id: 'row_2', provider: 'granite', predicted_verdict: 'Partially supported', error: null }, // improvement (was Not supported, GT Partially supported)
+        { entry_id: 'row_3', provider: 'granite', predicted_verdict: 'Supported', error: null },           // regression (was Not supported, GT Not supported)
+        { entry_id: 'row_4', provider: 'granite', predicted_verdict: 'Partially supported', error: null }, // unchanged-wrong-same (both Partially, GT Supported)
+        { entry_id: 'row_5', provider: 'granite', predicted_verdict: 'Supported', error: null },           // lateral (control Partially, treatment Supported, GT Not supported)
+        // panel cell
+        { entry_id: 'row_1', provider: 'openrouter-vote-3', predicted_verdict: 'Supported', error: null }, // unchanged-correct
+    ],
+};
+
+test('compareResults builds intersection cells, classifies, aggregates per provider', () => {
+    const result = compareResults({
+        control: FIXTURE_CONTROL,
+        treatment: FIXTURE_TREATMENT,
+        dataset: FIXTURE_DATASET,
+        options: { changeAxes: ['prompt'], groundTruthVersion: 'fixture-v1' },
+    });
+
+    // Coverage: 5 valid dataset rows × 2 providers + 1 vote-3 row = 11 cells.
+    // row_skip (needs_manual_review) drops out; errored cell drops out.
+    assert.equal(result.coverage.datasetTotal, 6);
+    assert.equal(result.coverage.datasetValid, 5);
+    assert.equal(result.coverage.comparedCells, 11);
+
+    // Metadata is recorded.
+    assert.deepEqual(result.metadata.changeAxes, ['prompt']);
+    assert.equal(result.metadata.groundTruthVersion, 'fixture-v1');
+    assert.equal(result.metadata.controlRunAt, '2026-05-01T10:00:00Z');
+    assert.equal(result.metadata.treatmentRunAt, '2026-05-02T10:00:00Z');
+
+    // Per-provider aggregation: mistral has 5 cells, granite has 5, vote-3 has 1.
+    assert.equal(result.perProvider.get('mistral').n, 5);
+    assert.equal(result.perProvider.get('granite').n, 5);
+    assert.equal(result.perProvider.get('openrouter-vote-3').n, 1);
+
+    // mistral row_5: control Supported, treatment Not supported, GT Not supported → improvement
+    const mistralRow5 = result.cells.find(c => c.entryId === 'row_5' && c.provider === 'mistral');
+    assert.equal(mistralRow5.direction, 'improvement');
+
+    // granite row_5: control Partially, treatment Supported, GT Not supported → both wrong, different → lateral
+    const graniteRow5 = result.cells.find(c => c.entryId === 'row_5' && c.provider === 'granite');
+    assert.equal(graniteRow5.direction, 'lateral');
+
+    // Flips array contains only improvement/regression/lateral entries.
+    for (const flip of result.flips) {
+        assert.ok(['improvement', 'regression', 'lateral'].includes(flip.direction));
+    }
+});

--- a/tests/compare_results.test.js
+++ b/tests/compare_results.test.js
@@ -129,3 +129,40 @@ test('classifyDirection: lateral when both wrong but with different verdicts', (
         'lateral',
     );
 });
+
+import { computeProviderStats } from '../benchmark/compare_results.js';
+
+test('computeProviderStats aggregates exact + lenient + binary accuracy and flip counts', () => {
+    const cells = [
+        // 2 unchanged-correct, 1 improvement, 1 regression, 1 lateral, plus
+        // a 6th cell exercising lenient: control Supported, treatment Partially supported, GT Supported.
+        // Exact: control correct, treatment wrong (Partial != Support exactly).
+        // Lenient: both correct (Partial↔Support is lenient).
+        // Binary: both correct.
+        // Direction: regression (control correct exact, treatment wrong exact).
+        { direction: 'unchanged-correct', controlVerdict: 'Supported', treatmentVerdict: 'Supported', groundTruth: 'Supported' },
+        { direction: 'unchanged-correct', controlVerdict: 'Not supported', treatmentVerdict: 'Not supported', groundTruth: 'Not supported' },
+        { direction: 'improvement', controlVerdict: 'Not supported', treatmentVerdict: 'Supported', groundTruth: 'Supported' },
+        { direction: 'regression', controlVerdict: 'Supported', treatmentVerdict: 'Not supported', groundTruth: 'Supported' },
+        { direction: 'lateral', controlVerdict: 'Not supported', treatmentVerdict: 'Source unavailable', groundTruth: 'Supported' },
+        { direction: 'regression', controlVerdict: 'Supported', treatmentVerdict: 'Partially supported', groundTruth: 'Supported' },
+    ];
+    const stats = computeProviderStats(cells);
+    assert.equal(stats.n, 6);
+    // Exact: control rows 1, 2, 4, 6 = 4; treatment rows 1, 2, 3 = 3.
+    assert.equal(stats.exact.control, 4);
+    assert.equal(stats.exact.treatment, 3);
+    // Lenient: control rows 1, 2, 4, 6 = 4; treatment rows 1, 2, 3, 6 = 4 (row 6 is Partial vs Support GT, lenient counts it).
+    assert.equal(stats.lenient.control, 4);
+    assert.equal(stats.lenient.treatment, 4);
+    assert.equal(stats.lenient.delta, 0);
+    // Binary: row 1, 2, 4, 6 control correct (4); treatment 1, 2, 3, 6 correct (4).
+    assert.equal(stats.binary.control, 4);
+    assert.equal(stats.binary.treatment, 4);
+    // Flip counts.
+    assert.equal(stats.flips.improvement, 1);
+    assert.equal(stats.flips.regression, 2);
+    assert.equal(stats.flips.lateral, 1);
+    assert.equal(stats.flips['unchanged-correct'], 2);
+    assert.equal(stats.flips['unchanged-wrong-same'], 0);
+});

--- a/tests/compare_results.test.js
+++ b/tests/compare_results.test.js
@@ -258,3 +258,38 @@ test('compareResults builds intersection cells, classifies, aggregates per provi
         assert.ok(['improvement', 'regression', 'lateral'].includes(flip.direction));
     }
 });
+
+import { filterComparison } from '../benchmark/compare_results.js';
+
+test('filterComparison restricts cells to a predicate match and re-aggregates', () => {
+    const result = compareResults({
+        control: FIXTURE_CONTROL,
+        treatment: FIXTURE_TREATMENT,
+        dataset: FIXTURE_DATASET,
+    });
+
+    // Filter to v2 rows only.
+    const v2Only = filterComparison(result, ({ datasetEntry }) =>
+        datasetEntry.dataset_version === 'v2');
+
+    // 3 v2 rows × 2 providers = 6 cells (no vote-3 cell on v2 rows in fixture).
+    assert.equal(v2Only.coverage.comparedCells, 6);
+    assert.equal(v2Only.metadata.filtered, true);
+
+    // Per-provider should re-aggregate over only the v2 cells.
+    assert.equal(v2Only.perProvider.get('mistral').n, 3);
+    assert.equal(v2Only.perProvider.get('granite').n, 3);
+    // vote-3 had no v2 cells; provider drops out entirely.
+    assert.equal(v2Only.perProvider.has('openrouter-vote-3'), false);
+});
+
+test('filterComparison by provider name restricts to single-provider view', () => {
+    const result = compareResults({
+        control: FIXTURE_CONTROL,
+        treatment: FIXTURE_TREATMENT,
+        dataset: FIXTURE_DATASET,
+    });
+    const mistralOnly = filterComparison(result, ({ provider }) => provider === 'mistral');
+    assert.equal(mistralOnly.perProvider.size, 1);
+    assert.equal(mistralOnly.perProvider.get('mistral').n, 5);
+});

--- a/tests/compare_results.test.js
+++ b/tests/compare_results.test.js
@@ -72,3 +72,60 @@ test('indexCellsByPair drops rows with error or predicted_verdict ERROR', () => 
     assert.equal(idx.has('row_2:claude'), false);
     assert.equal(idx.has('row_2:gemini'), false);
 });
+
+import { classifyDirection } from '../benchmark/compare_results.js';
+
+test('classifyDirection: improvement when control wrong, treatment correct', () => {
+    assert.equal(
+        classifyDirection({
+            controlVerdict: 'Not supported',
+            treatmentVerdict: 'Supported',
+            groundTruth: 'Supported',
+        }),
+        'improvement',
+    );
+});
+
+test('classifyDirection: regression when control correct, treatment wrong', () => {
+    assert.equal(
+        classifyDirection({
+            controlVerdict: 'Supported',
+            treatmentVerdict: 'Not supported',
+            groundTruth: 'Supported',
+        }),
+        'regression',
+    );
+});
+
+test('classifyDirection: unchanged-correct when both match GT', () => {
+    assert.equal(
+        classifyDirection({
+            controlVerdict: 'Supported',
+            treatmentVerdict: 'Supported',
+            groundTruth: 'Supported',
+        }),
+        'unchanged-correct',
+    );
+});
+
+test('classifyDirection: unchanged-wrong-same when both wrong with same verdict', () => {
+    assert.equal(
+        classifyDirection({
+            controlVerdict: 'Not supported',
+            treatmentVerdict: 'Not supported',
+            groundTruth: 'Supported',
+        }),
+        'unchanged-wrong-same',
+    );
+});
+
+test('classifyDirection: lateral when both wrong but with different verdicts', () => {
+    assert.equal(
+        classifyDirection({
+            controlVerdict: 'Not supported',
+            treatmentVerdict: 'Source unavailable',
+            groundTruth: 'Supported',
+        }),
+        'lateral',
+    );
+});

--- a/tests/compare_results.test.js
+++ b/tests/compare_results.test.js
@@ -1,0 +1,45 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    normalizeVerdict,
+    verdictsEqualExact,
+    verdictsEqualBinary,
+    verdictsEqualLenient,
+} from '../benchmark/compare_results.js';
+
+test('normalizeVerdict canonicalizes the four verdict classes', () => {
+    assert.equal(normalizeVerdict('Supported'), 'support');
+    assert.equal(normalizeVerdict('Partially supported'), 'partial');
+    assert.equal(normalizeVerdict('Not supported'), 'not');
+    assert.equal(normalizeVerdict('Source unavailable'), 'unavailable');
+    assert.equal(normalizeVerdict(' SUPPORTED '), 'support');
+    assert.equal(normalizeVerdict(null), '');
+    assert.equal(normalizeVerdict(undefined), '');
+    assert.equal(normalizeVerdict('something else'), 'something else');
+});
+
+test('verdictsEqualExact treats normalized verdicts as equivalent', () => {
+    assert.equal(verdictsEqualExact('Supported', 'supported'), true);
+    assert.equal(verdictsEqualExact('Supported', 'Partially supported'), false);
+    assert.equal(verdictsEqualExact('Not supported', 'NOT_SUPPORTED'), true);
+});
+
+test('verdictsEqualBinary treats Supported and Partially supported as the same class', () => {
+    assert.equal(verdictsEqualBinary('Supported', 'Partially supported'), true);
+    assert.equal(verdictsEqualBinary('Supported', 'Not supported'), false);
+    assert.equal(verdictsEqualBinary('Source unavailable', 'Not supported'), true);
+    assert.equal(verdictsEqualBinary('Partially supported', 'Source unavailable'), false);
+});
+
+test('verdictsEqualLenient: Supported↔Partially supported is a near-miss; everything else like exact', () => {
+    // Exact matches are also lenient.
+    assert.equal(verdictsEqualLenient('Supported', 'Supported'), true);
+    assert.equal(verdictsEqualLenient('Not supported', 'Not supported'), true);
+    // Supported ↔ Partially supported is mutually lenient.
+    assert.equal(verdictsEqualLenient('Supported', 'Partially supported'), true);
+    assert.equal(verdictsEqualLenient('Partially supported', 'Supported'), true);
+    // No other pair is lenient.
+    assert.equal(verdictsEqualLenient('Supported', 'Not supported'), false);
+    assert.equal(verdictsEqualLenient('Partially supported', 'Not supported'), false);
+    assert.equal(verdictsEqualLenient('Source unavailable', 'Not supported'), false);
+});

--- a/tests/render_compare.test.js
+++ b/tests/render_compare.test.js
@@ -1,0 +1,31 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    escapeHtml,
+    deltaColor,
+    directionColor,
+} from '../benchmark/render_compare.js';
+
+test('escapeHtml escapes the five HTML-significant characters', () => {
+    assert.equal(escapeHtml('<a href="x">&\'</a>'), '&lt;a href=&quot;x&quot;&gt;&amp;&#x27;&lt;/a&gt;');
+    assert.equal(escapeHtml(''), '');
+    assert.equal(escapeHtml(null), '');
+    assert.equal(escapeHtml(undefined), '');
+    assert.equal(escapeHtml(42), '42');
+});
+
+test('deltaColor returns green/red/grey based on noise floor', () => {
+    assert.equal(deltaColor(10, 5), '#e6ffe6'); // above floor → green
+    assert.equal(deltaColor(-10, 5), '#ffe6e6'); // below -floor → red
+    assert.equal(deltaColor(2, 5), '#f0f0f0'); // within ±floor → grey
+    assert.equal(deltaColor(-3, 5), '#f0f0f0');
+    assert.equal(deltaColor(0, 5), '#f0f0f0');
+});
+
+test('directionColor maps each direction to a distinct shade', () => {
+    assert.equal(directionColor('improvement'), '#e6ffe6');
+    assert.equal(directionColor('regression'), '#ffe6e6');
+    assert.equal(directionColor('lateral'), '#fff5cc');
+    assert.equal(directionColor('unchanged-correct'), '#ffffff');
+    assert.equal(directionColor('unchanged-wrong-same'), '#ffffff');
+});

--- a/tests/render_compare.test.js
+++ b/tests/render_compare.test.js
@@ -29,3 +29,23 @@ test('directionColor maps each direction to a distinct shade', () => {
     assert.equal(directionColor('unchanged-correct'), '#ffffff');
     assert.equal(directionColor('unchanged-wrong-same'), '#ffffff');
 });
+
+import { renderJson } from '../benchmark/render_compare.js';
+import { compareResults } from '../benchmark/compare_results.js';
+
+const TINY_DATASET = [
+    { id: 'r1', ground_truth: 'Supported', claim_text: 'c1', source_url: 'http://x/1', extraction_status: 'complete', needs_manual_review: false },
+];
+const TINY_CONTROL = { rows: [{ entry_id: 'r1', provider: 'p', predicted_verdict: 'Not supported', error: null }] };
+const TINY_TREATMENT = { rows: [{ entry_id: 'r1', provider: 'p', predicted_verdict: 'Supported', error: null }] };
+
+test('renderJson serializes a ComparisonResult round-trippable through JSON.parse', () => {
+    const result = compareResults({ control: TINY_CONTROL, treatment: TINY_TREATMENT, dataset: TINY_DATASET });
+    const json = renderJson(result);
+    const parsed = JSON.parse(json);
+    assert.equal(parsed.coverage.comparedCells, 1);
+    assert.equal(parsed.cells[0].direction, 'improvement');
+    // perProvider was a Map; should serialize to a plain object.
+    assert.equal(typeof parsed.perProvider, 'object');
+    assert.equal(parsed.perProvider.p.n, 1);
+});

--- a/tests/render_compare.test.js
+++ b/tests/render_compare.test.js
@@ -49,3 +49,29 @@ test('renderJson serializes a ComparisonResult round-trippable through JSON.pars
     assert.equal(typeof parsed.perProvider, 'object');
     assert.equal(parsed.perProvider.p.n, 1);
 });
+
+import { renderMarkdown } from '../benchmark/render_compare.js';
+
+test('renderMarkdown emits a headline accuracy table (exact + lenient + binary) and a flip table', () => {
+    const result = compareResults({ control: TINY_CONTROL, treatment: TINY_TREATMENT, dataset: TINY_DATASET });
+    const md = renderMarkdown(result);
+    // Headline section — header row carries all three metric pairs in order: exact, lenient, binary.
+    assert.match(md, /## Headline accuracy/);
+    assert.match(md, /\| Provider \| n \| Control exact \| Treatment exact \| Δ exact \| Control lenient \| Treatment lenient \| Δ lenient \| Control binary \| Treatment binary \| Δ binary \|/);
+    assert.match(md, /\| p \| 1 \|/);
+    // Flip section
+    assert.match(md, /## Flips/);
+    assert.match(md, /improvement/);
+    // Coverage / metadata block
+    assert.match(md, /Compared cells: \*\*1\*\*/);
+});
+
+test('renderMarkdown notes when changeAxes are provided', () => {
+    const result = compareResults({
+        control: TINY_CONTROL, treatment: TINY_TREATMENT, dataset: TINY_DATASET,
+        options: { changeAxes: ['prompt', 'source_text'], groundTruthVersion: 'post-audit-2026-04-30' },
+    });
+    const md = renderMarkdown(result);
+    assert.match(md, /Change axes: `prompt`, `source_text`/);
+    assert.match(md, /Ground truth version: `post-audit-2026-04-30`/);
+});

--- a/tests/render_compare.test.js
+++ b/tests/render_compare.test.js
@@ -75,3 +75,34 @@ test('renderMarkdown notes when changeAxes are provided', () => {
     assert.match(md, /Change axes: `prompt`, `source_text`/);
     assert.match(md, /Ground truth version: `post-audit-2026-04-30`/);
 });
+
+import { renderHtml } from '../benchmark/render_compare.js';
+
+test('renderHtml emits a self-contained HTML document with headline and flip tables', () => {
+    const result = compareResults({ control: TINY_CONTROL, treatment: TINY_TREATMENT, dataset: TINY_DATASET });
+    const html = renderHtml(result);
+    assert.match(html, /<!DOCTYPE html>/);
+    assert.match(html, /<style>/); // inline CSS
+    assert.match(html, /Headline accuracy/);
+    assert.match(html, /Flips/);
+    assert.match(html, /<td[^>]*>p<\/td>/); // provider name in a row
+    assert.match(html, /improvement/);
+    // Color-coded direction cell present
+    assert.match(html, /background-color:\s*#e6ffe6/);
+});
+
+test('renderHtml escapes claim text and source URLs', () => {
+    const datasetWithDangerousChars = [{
+        id: 'r1', ground_truth: 'Supported',
+        claim_text: '<script>alert("x")</script>',
+        source_url: 'http://x/?a=b&c=d',
+        extraction_status: 'complete', needs_manual_review: false,
+    }];
+    const control = { rows: [{ entry_id: 'r1', provider: 'p', predicted_verdict: 'Not supported', error: null }] };
+    const treatment = { rows: [{ entry_id: 'r1', provider: 'p', predicted_verdict: 'Supported', error: null }] };
+    const result = compareResults({ control, treatment, dataset: datasetWithDangerousChars });
+    const html = renderHtml(result);
+    assert.equal(html.includes('<script>alert'), false);
+    assert.match(html, /&lt;script&gt;alert/);
+    assert.match(html, /a=b&amp;c=d/);
+});


### PR DESCRIPTION
Basically what I want to do now is:
1. change the prompt
2. see if it improves accuracy

(2) requires repeatable before/after comparisons. So adding a "compare" subcommand to do that.

I don't think this is the "final" form of a comparison framework, but it's a useful intermediate step. 

The [doc](https://github.com/alex-o-748/citation-checker-script/pull/195/changes#diff-b37316aae98ae4f4da200a7d978b1099a6aecdc0dbce4029afad2d8c98671a2c) might be a good place to start to understand how it is intended to be used.

## Summary

Adds a `ccs compare` CLI subcommand. It takes two `results.json` files plus a `dataset.json` into a structured per-provider accuracy + flip report (Markdown, HTML, or JSON output). 

For an example of the output, see https://github.com/alex-o-748/citation-checker-script/issues/169#issuecomment-4393759204

## What `ccs compare` produces

Two tables in every render format:

1. **Headline accuracy** — for each provider, the count of correct cells out of total compared cells, in both control and treatment, with a Δ in percentage points. Three metrics: *exact match*, *lenient* (Supported↔Partially-supported counted equivalent), and *binary* (Supported+Partially pooled vs Not-supported+Source-unavailable pooled). Rows below the noise floor (default ±5pp, configurable) are flagged so a reader treats them as noise rather than signal.
2. **Flip table** — every cell that changed verdict, classified as *improvement* / *regression* / *lateral*. Cells that stayed correct or stayed wrong with the same verdict don't appear. This can be used to investigate changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)