### PR TITLE
Migrate default provider to Qwen-HF and simplify theming

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Inspired by [User:Polygnotus/Scripts/AI_Source_Verification.js](https://en.wikip
 - Click any `[N]` citation in an article to verify the associated claim
 - Batch-verify every citation in an article and generate a wiki-markup report of failed citations
 - Multiple LLM providers with a unified interface:
+  - **Qwen-HF** (default, free, no API key — `Qwen/Qwen3-32B` via HuggingFace)
   - **PublicAI** (free, no API key — Qwen-SEA-LION / OLMo / Apertus)
   - **Claude** (Anthropic)
   - **Gemini** (Google)
@@ -26,7 +27,7 @@ To install, add the following line to your [`common.js`](https://en.wikipedia.or
 importScript('User:Alaexis/AI_Source_Verification.js');
 ```
 
-API keys for paid providers are stored in `localStorage` and configured from the sidebar UI. PublicAI works out of the box with no key.
+API keys for paid providers are stored in `localStorage` and configured from the sidebar UI. Qwen-HF (the default) and PublicAI both work out of the box with no key.
 
 ## Usage
 

--- a/main.js
+++ b/main.js
@@ -2855,6 +2855,8 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
             let modelDesc;
             if (this.currentProvider === 'publicai') {
                 modelDesc = 'a PublicAI-hosted open-source LLM';
+            } else if (this.currentProvider === 'huggingface') {
+                modelDesc = `a HuggingFace-hosted open-source LLM (${provider.model})`;
             } else {
                 modelDesc = provider.model;
             }

--- a/main.js
+++ b/main.js
@@ -623,18 +623,18 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
     class WikipediaSourceVerifier {
         constructor() {
             this.providers = {
+                huggingface: {
+                    name: 'Qwen-HF (free)',
+                    storageKey: null, // No key needed - proxy injects upstream key
+                    color: '#FF9D00', // HF yellow-orange
+                    model: 'Qwen/Qwen3-32B',
+                    requiresKey: false
+                },
                 publicai: {
                     name: 'PublicAI (Free)',
                     storageKey: null, // No key needed - uses built-in key
                     color: '#6B21A8', // Purple for PublicAI
                     model: 'aisingapore/Qwen-SEA-LION-v4-32B-IT',
-                    requiresKey: false
-                },
-                huggingface: {
-                    name: 'HuggingFace (Free)',
-                    storageKey: null, // No key needed - proxy injects upstream key
-                    color: '#FF9D00', // HF yellow-orange
-                    model: 'openai/gpt-oss-20b',
                     requiresKey: false
                 },
                 claude: {
@@ -666,7 +666,7 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
                 storedProvider = 'publicai';
                 localStorage.setItem('source_verifier_provider', 'publicai');
             }
-            this.currentProvider = storedProvider || 'publicai';
+            this.currentProvider = storedProvider || 'huggingface';
             this.sidebarWidth = localStorage.getItem('verifier_sidebar_width') || '400px';
             this.isVisible = localStorage.getItem('verifier_sidebar_visible') === 'true';
             this.buttons = {};
@@ -1823,7 +1823,7 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
             
             const provider = this.providers[this.currentProvider];
             if (!provider.requiresKey) {
-                infoEl.textContent = '✓ No API key required - using free PublicAI model';
+                infoEl.textContent = `✓ No API key required - using free ${provider.name} model`;
                 infoEl.className = 'free-provider';
             } else if (this.getCurrentApiKey()) {
                 infoEl.textContent = `API key configured for ${provider.name}`;
@@ -2961,7 +2961,7 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
             this.updateButtonVisibility();
 
             const startTime = Date.now();
-            const useProxy = this.currentProvider === 'publicai';
+            const useProxy = this.currentProvider === 'publicai' || this.currentProvider === 'huggingface';
             const delayBetweenCalls = useProxy ? 3000 : 1000;
 
             for (let i = 0; i < citations.length; i++) {

--- a/main.js
+++ b/main.js
@@ -626,35 +626,30 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
                 huggingface: {
                     name: 'Qwen-HF (free)',
                     storageKey: null, // No key needed - proxy injects upstream key
-                    color: '#FF9D00', // HF yellow-orange
                     model: 'Qwen/Qwen3-32B',
                     requiresKey: false
                 },
                 publicai: {
                     name: 'PublicAI (Free)',
                     storageKey: null, // No key needed - uses built-in key
-                    color: '#6B21A8', // Purple for PublicAI
                     model: 'aisingapore/Qwen-SEA-LION-v4-32B-IT',
                     requiresKey: false
                 },
                 claude: {
                     name: 'Claude',
                     storageKey: 'claude_api_key',
-                    color: '#0645ad',
                     model: 'claude-sonnet-4-6',
                     requiresKey: true
                 },
                 gemini: {
                     name: 'Gemini',
                     storageKey: 'gemini_api_key',
-                    color: '#4285F4',
                     model: 'gemini-flash-latest',
                     requiresKey: true
                 },
                 openai: {
                     name: 'ChatGPT',
                     storageKey: 'openai_api_key',
-                    color: '#10a37f',
                     model: 'gpt-4o',
                     requiresKey: true
                 }
@@ -665,6 +660,16 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
             if (storedProvider === 'apertus') {
                 storedProvider = 'publicai';
                 localStorage.setItem('source_verifier_provider', 'publicai');
+            }
+            // One-time migration: move existing PublicAI users to the new
+            // Qwen-HF default. Runs once per browser so a later switch back
+            // to PublicAI sticks.
+            if (!localStorage.getItem('qwen_hf_default_migrated')) {
+                if (storedProvider === 'publicai') {
+                    storedProvider = 'huggingface';
+                    localStorage.setItem('source_verifier_provider', 'huggingface');
+                }
+                localStorage.setItem('qwen_hf_default_migrated', '1');
             }
             this.currentProvider = storedProvider || 'huggingface';
             this.sidebarWidth = localStorage.getItem('verifier_sidebar_width') || '400px';
@@ -733,7 +738,7 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
         }
         
         getCurrentColor() {
-            return this.providers[this.currentProvider].color;
+            return '#6B21A8';
         }
         
         providerRequiresKey() {
@@ -2250,7 +2255,6 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
                 this.currentProvider = item.getData();
                 localStorage.setItem('source_verifier_provider', this.currentProvider);
                 this.updateButtonVisibility();
-                this.updateTheme();
                 this.updateStatus(`Switched to ${this.providers[this.currentProvider].name}`);
             });
             
@@ -2294,19 +2298,6 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
             this.buttons.backToReport.on('click', () => {
                 this.showReportView();
             });
-        }
-        
-        updateTheme() {
-            const color = this.getCurrentColor();
-            // Remove old styles and re-create to pick up new provider color in dark theme
-            const oldStyle = document.querySelector('style[data-verifier-theme]');
-            if (oldStyle) oldStyle.remove();
-            // Re-create styles with updated color references
-            const existingStyles = document.head.querySelectorAll('style');
-            existingStyles.forEach(s => {
-                if (s.textContent.includes('#source-verifier-sidebar')) s.remove();
-            });
-            this.createStyles();
         }
         
         setApiKey() {


### PR DESCRIPTION
## Summary
This PR migrates the default source verifier provider from PublicAI to Qwen-HF (HuggingFace) while simplifying the theming system by removing per-provider color customization.

## Key Changes
- **Provider reordering**: Moved HuggingFace to the first position in the providers list and updated its name to "Qwen-HF (free)" with model `Qwen/Qwen3-32B`
- **One-time migration logic**: Added a migration mechanism that automatically switches existing PublicAI users to HuggingFace on first load, with a flag to prevent repeated migrations
- **Default provider change**: Updated the fallback default from `'publicai'` to `'huggingface'`
- **Removed color properties**: Eliminated per-provider `color` fields from all provider configurations (PublicAI, HuggingFace, Claude, Gemini, OpenAI)
- **Simplified color handling**: Changed `getCurrentColor()` to return a hardcoded purple color (`#6B21A8`) instead of looking up provider-specific colors
- **Removed theme update logic**: Deleted the `updateTheme()` method and its call when switching providers, eliminating dynamic theme recomputation
- **Updated proxy detection**: Extended proxy usage check to include both `'publicai'` and `'huggingface'` providers
- **Dynamic provider name in UI**: Updated the free provider info message to use the actual provider name instead of hardcoded "PublicAI"

## Implementation Details
- The migration uses localStorage flags to ensure it runs only once per browser, allowing users to manually switch back to PublicAI if desired
- The removal of per-provider colors simplifies the codebase while maintaining a consistent purple theme across all providers
- Both PublicAI and HuggingFace providers now use the same proxy-based request pattern with matching delay timing

https://claude.ai/code/session_01LafApzySUa7aXcXGRCoemF