### PR TITLE
Improve free provider UX with inline API key setup link

### DIFF
--- a/main.js
+++ b/main.js
@@ -923,6 +923,10 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
                     background: #e8f5e9;
                     color: #2e7d32;
                 }
+                #verifier-provider-info.free-provider a {
+                    color: inherit;
+                    text-decoration: underline;
+                }
                 #verifier-buttons-container {
                     display: flex;
                     flex-direction: column;
@@ -1879,13 +1883,22 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
             if (!infoEl) return;
             
             const provider = this.providers[this.currentProvider];
+            infoEl.textContent = '';
             if (!provider.requiresKey) {
                 if (provider.optionalKey && this.getCurrentApiKey()) {
-                    infoEl.textContent = `✓ Direct mode — using your ${provider.name} API key`;
+                    infoEl.textContent = `✓ Using your ${provider.name} API key`;
                 } else if (provider.optionalKey) {
-                    infoEl.textContent = `✓ Free via the proxy. Optional: set a ${provider.name} API key for direct access.`;
+                    infoEl.appendChild(document.createTextNode('✓ Free to use. Optional: '));
+                    const link = document.createElement('a');
+                    link.href = '#';
+                    link.textContent = `add your ${provider.name} API key`;
+                    link.addEventListener('click', (e) => {
+                        e.preventDefault();
+                        this.setApiKey();
+                    });
+                    infoEl.appendChild(link);
                 } else {
-                    infoEl.textContent = `✓ No API key required — ${provider.name} routed via the proxy`;
+                    infoEl.textContent = '✓ Free to use';
                 }
                 infoEl.className = 'free-provider';
             } else if (this.getCurrentApiKey()) {
@@ -1929,13 +1942,13 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
 
                 // Key-management buttons: required-key providers always show
                 // change/remove; optional-key providers show change/remove
-                // when a key is stored, or "set key" when not.
+                // when a key is stored. The "set key" affordance for the
+                // optional-no-key case lives as an inline link inside
+                // updateProviderInfo() so it doesn't compete with Verify.
                 if (!this.reportRunning) {
                     if (requiresKey || (optionalKey && hasKey)) {
                         container.appendChild(this.buttons.changeKey.$element[0]);
                         container.appendChild(this.buttons.removeKey.$element[0]);
-                    } else if (optionalKey) {
-                        container.appendChild(this.buttons.setKey.$element[0]);
                     }
                 }
             } else {


### PR DESCRIPTION
## Summary
Refactored the provider info display and key management UI to provide a better user experience for free providers with optional API keys. Instead of showing a separate "Set Key" button, users can now click an inline link within the provider info text to add their API key.

## Key Changes
- **Updated provider info messaging**: Simplified and clarified the text shown for different provider scenarios:
  - Direct mode with key: "✓ Using your [provider] API key"
  - Free with optional key: "✓ Free to use. Optional: [clickable link to add key]"
  - Free without optional key: "✓ Free to use"

- **Converted "Set Key" button to inline link**: For optional-key providers without a stored key, replaced the separate button with a clickable link embedded in the provider info text that triggers the key setup flow

- **Added styling for free provider links**: New CSS rule to style links within the free provider info section with underline and inherited color

- **Removed "Set Key" button from button container**: The button is no longer appended to the buttons container for optional-key providers, reducing UI clutter and focusing attention on the Verify button

## Implementation Details
- The inline link uses `preventDefault()` to intercept clicks and calls `this.setApiKey()` to open the key management dialog
- Provider info element is cleared before rebuilding to ensure clean state
- Updated code comments to document the new "set key" affordance location

https://claude.ai/code/session_01F83sEFQQXuPjd5HzsrQriv