### PR TITLE
Standardize provider color scheme to purple

### DIFF
--- a/main.js
+++ b/main.js
@@ -680,7 +680,7 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
                 publicai: {
                     name: 'PublicAI (Free)',
                     storageKey: null, // No key needed - uses built-in key
-                    color: '#6B21A8', // Purple for PublicAI
+                    color: '#6B21A8',
                     model: 'aisingapore/Qwen-SEA-LION-v4-32B-IT',
                     requiresKey: false
                 },
@@ -689,7 +689,7 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
                     // Optional key: free via the proxy without one; direct call
                     // to HF (any model) when stored.
                     storageKey: 'hf_api_key',
-                    color: '#FF9D00', // HF yellow-orange
+                    color: '#6B21A8',
                     model: 'openai/gpt-oss-20b',
                     requiresKey: false,
                     optionalKey: true
@@ -697,21 +697,21 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
                 claude: {
                     name: 'Claude',
                     storageKey: 'claude_api_key',
-                    color: '#0645ad',
+                    color: '#6B21A8',
                     model: 'claude-sonnet-4-6',
                     requiresKey: true
                 },
                 gemini: {
                     name: 'Gemini',
                     storageKey: 'gemini_api_key',
-                    color: '#4285F4',
+                    color: '#6B21A8',
                     model: 'gemini-flash-latest',
                     requiresKey: true
                 },
                 openai: {
                     name: 'ChatGPT',
                     storageKey: 'openai_api_key',
-                    color: '#10a37f',
+                    color: '#6B21A8',
                     model: 'gpt-4o',
                     requiresKey: true
                 }


### PR DESCRIPTION
## Summary
Standardized the color scheme across all AI provider configurations by updating all provider colors to use the same purple hex value (#6B21A8).

## Changes
- Updated HuggingFace provider color from orange (#FF9D00) to purple (#6B21A8)
- Updated Claude provider color from blue (#0645ad) to purple (#6B21A8)
- Updated Gemini provider color from Google blue (#4285F4) to purple (#6B21A8)
- Updated OpenAI provider color from teal (#10a37f) to purple (#6B21A8)
- Removed redundant color comment from PublicAI provider (already using #6B21A8)

## Notes
All providers now use a consistent purple color (#6B21A8) for the UI, creating a unified visual appearance across the provider selection interface.

https://claude.ai/code/session_01GfzcBPuFDeh1DwzDtSmrb1