### PR TITLE
Switch default LLM provider from PublicAI to HuggingFace

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Inspired by [User:Polygnotus/Scripts/AI_Source_Verification.js](https://en.wikip
 - Click any `[N]` citation in an article to verify the associated claim
 - Batch-verify every citation in an article and generate a wiki-markup report of failed citations
 - Multiple LLM providers with a unified interface:
+  - **HuggingFace** (default, free, no API key — Qwen3-32B by default; set an HF API key to use any HF-hosted model)
   - **PublicAI** (free, no API key — Qwen-SEA-LION / OLMo / Apertus)
   - **Claude** (Anthropic)
   - **Gemini** (Google)
@@ -26,7 +27,7 @@ To install, add the following line to your [`common.js`](https://en.wikipedia.or
 importScript('User:Alaexis/AI_Source_Verification.js');
 ```
 
-API keys for paid providers are stored in `localStorage` and configured from the sidebar UI. PublicAI works out of the box with no key.
+API keys for paid providers are stored in `localStorage` and configured from the sidebar UI. HuggingFace (the default) and PublicAI both work out of the box with no key.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ Run `npx ccs --help` for the full option and exit-code table.
 
 | Provider | Flag value | Env var required |
 | --- | --- | --- |
-| PublicAI (default) | `--provider publicai` | none (routed via the worker proxy) |
+| HuggingFace (default) | `--provider huggingface` | none (routed via the worker proxy; `HF_API_KEY` opts into direct calls) |
+| PublicAI | `--provider publicai` | none (routed via the worker proxy) |
 | Claude | `--provider claude` | `CLAUDE_API_KEY` |
 | Gemini | `--provider gemini` | `GEMINI_API_KEY` |
 | OpenAI | `--provider openai` | `OPENAI_API_KEY` |

--- a/cli/verify.js
+++ b/cli/verify.js
@@ -24,7 +24,7 @@ export function parseCliArgs(argv) {
     const { values, positionals } = parseArgs({
         args: raw,
         options: {
-            provider: { type: 'string', default: 'publicai' },
+            provider: { type: 'string', default: 'huggingface' },
             'no-log': { type: 'boolean', default: false },
             help:     { type: 'boolean', short: 'h', default: false },
         },
@@ -145,7 +145,7 @@ export function classifyProviderError(err) {
 
 const PROVIDER_MODELS = {
     publicai:    'aisingapore/Qwen-SEA-LION-v4-32B-IT',
-    huggingface: 'openai/gpt-oss-20b',
+    huggingface: 'Qwen/Qwen3-32B',
     claude:      'claude-sonnet-4-6',
     gemini:      'gemini-flash-latest',
     openai:      'gpt-4o',
@@ -178,11 +178,12 @@ Arguments:
 
 Options:
   --provider <name>  LLM provider to use. One of:
-                       publicai    (default; routed via the worker proxy,
+                       huggingface (default; routed via the worker proxy,
+                                    no API key needed; set HF_API_KEY to
+                                    call HF directly and unlock any
+                                    HF-hosted model)
+                       publicai    (routed via the worker proxy,
                                     no API key needed)
-                       huggingface (routed via the worker proxy by default;
-                                    set HF_API_KEY to call HF directly and
-                                    unlock any HF-hosted model)
                        claude      (requires CLAUDE_API_KEY)
                        gemini      (requires GEMINI_API_KEY)
                        openai      (requires OPENAI_API_KEY)

--- a/main.js
+++ b/main.js
@@ -678,7 +678,7 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
         constructor() {
             this.providers = {
                 publicai: {
-                    name: 'PublicAI (Free)',
+                    name: 'PublicAI',
                     storageKey: null, // No key needed - uses built-in key
                     color: '#6B21A8', // Purple for PublicAI
                     model: 'aisingapore/Qwen-SEA-LION-v4-32B-IT',
@@ -2949,6 +2949,8 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
             let modelDesc;
             if (this.currentProvider === 'publicai') {
                 modelDesc = 'a PublicAI-hosted open-source LLM';
+            } else if (this.currentProvider === 'huggingface') {
+                modelDesc = `a HuggingFace-hosted open-source LLM (${provider.model})`;
             } else {
                 modelDesc = provider.model;
             }

--- a/main.js
+++ b/main.js
@@ -690,7 +690,7 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
                     // to HF (any model) when stored.
                     storageKey: 'hf_api_key',
                     color: '#FF9D00', // HF yellow-orange
-                    model: 'openai/gpt-oss-20b',
+                    model: 'Qwen/Qwen3-32B',
                     requiresKey: false,
                     optionalKey: true
                 },
@@ -723,7 +723,7 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
                 storedProvider = 'publicai';
                 localStorage.setItem('source_verifier_provider', 'publicai');
             }
-            this.currentProvider = storedProvider || 'publicai';
+            this.currentProvider = storedProvider || 'huggingface';
             this.sidebarWidth = localStorage.getItem('verifier_sidebar_width') || '400px';
             this.isVisible = localStorage.getItem('verifier_sidebar_visible') === 'true';
             this.buttons = {};

--- a/main.js
+++ b/main.js
@@ -717,11 +717,12 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
                 }
             };
             
-            // Handle migration from old 'apertus' name to 'publicai'
+            // Migrate legacy provider selections ('apertus', 'publicai') to
+            // the current default ('huggingface').
             let storedProvider = localStorage.getItem('source_verifier_provider');
-            if (storedProvider === 'apertus') {
-                storedProvider = 'publicai';
-                localStorage.setItem('source_verifier_provider', 'publicai');
+            if (storedProvider === 'apertus' || storedProvider === 'publicai') {
+                storedProvider = 'huggingface';
+                localStorage.setItem('source_verifier_provider', 'huggingface');
             }
             this.currentProvider = storedProvider || 'huggingface';
             this.sidebarWidth = localStorage.getItem('verifier_sidebar_width') || '400px';

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -28,7 +28,7 @@ test('parseCliArgs: verify subcommand with url and citation number', () => {
   assert.equal(result.subcommand, 'verify');
   assert.equal(result.url, 'https://en.wikipedia.org/wiki/Foo');
   assert.equal(result.citationNumber, 3);
-  assert.equal(result.provider, 'publicai');
+  assert.equal(result.provider, 'huggingface');
   assert.equal(result.noLog, false);
 });
 


### PR DESCRIPTION
## Summary
This PR changes the default LLM provider from PublicAI to HuggingFace across the codebase, and updates the HuggingFace model from `openai/gpt-oss-20b` to `Qwen/Qwen3-32B`.

## Key Changes

- **Default provider migration**: Changed default provider from `publicai` to `huggingface` in both the browser extension (main.js) and CLI (cli/verify.js)
- **Model update**: Updated HuggingFace provider model from `openai/gpt-oss-20b` to `Qwen/Qwen3-32B`
- **Provider naming**: Removed "(Free)" suffix from PublicAI display name for consistency
- **Legacy migration logic**: Updated localStorage migration to handle both `apertus` and `publicai` legacy selections, migrating them to `huggingface` as the new default
- **Documentation updates**: 
  - Updated README to reflect HuggingFace as the default provider
  - Updated CLI help text to list HuggingFace first with updated description
  - Updated provider documentation table to show HuggingFace as default
- **Model description**: Added specific model description for HuggingFace provider in verification output
- **Tests**: Updated test expectations to reflect new default provider

## Implementation Details

The migration preserves backward compatibility by automatically converting stored provider preferences from the old defaults to the new HuggingFace default. Users with explicit provider selections will be migrated on their next session load.

https://claude.ai/code/session_01RVMHZVwCHeUR66QsvPBZLK