### PR TITLE
benchmark: verdict parser fallback returns PARSE_ERROR for unmatched fragments

### DIFF
--- a/benchmark/run_benchmark.js
+++ b/benchmark/run_benchmark.js
@@ -429,7 +429,7 @@ function normalizeVerdict(verdict) {
     if (v.includes('PARTIALLY')) return 'Partially supported';
     if (v.includes('UNAVAILABLE')) return 'Source unavailable';
     if (v.includes('SUPPORTED')) return 'Supported';
-    return verdict;
+    return 'PARSE_ERROR';
 }
 
 /**


### PR DESCRIPTION
## Summary

`benchmark/run_benchmark.js`'s fallback verdict parser can return arbitrary text fragments as `predicted_verdict` when the model response doesn't contain a canonical verdict keyword. The fragments never match ground truth and silently inflate "incorrect" counts in benchmark accuracy.

## Reproducer

When `parseResponse` fails to JSON-parse the model output, it falls back to a regex match (line 414):

```js
const verdictMatch = content.match(/verdict["\s:]+([A-Z_ ]+)/i);
return {
  verdict: verdictMatch ? normalizeVerdict(verdictMatch[1]) : 'PARSE_ERROR',
  ...
};
```

The regex matches any letters/underscores/spaces after `verdict` (case-insensitive). For a response containing `"...the verdict OPTIONS being one of..."` the captured fragment is `OPTIONS being one of`. Then `normalizeVerdict`:

```js
function normalizeVerdict(verdict) {
  const v = verdict.toUpperCase().trim();
  if (v.includes('NOT SUPPORTED') || v.includes('NOT_SUPPORTED')) return 'Not supported';
  if (v.includes('PARTIALLY')) return 'Partially supported';
  if (v.includes('UNAVAILABLE')) return 'Source unavailable';
  if (v.includes('SUPPORTED')) return 'Supported';
  return verdict;   // ← bug: returns the unmatched fragment as-is
}
```

The fragment is stored as `predicted_verdict` — values like `"options"`, `"choices"`, `"to choose"`, `"based on the rules"`, `""` (empty), etc. None match any canonical ground-truth label, so they always count as wrong.

## Impact observed

Sampling a 6-provider benchmark run on the v1+v2+v3 dataset (~177 rows per provider):

| Provider | Fallback-fragment rate |
|---|---|
| `hf-deepseek-v3-2` | 17–32% (varies with prompt) |
| `hf-gpt-oss-20b` | 7–12% |
| `openrouter-granite-4.1-8b` | ~1% |
| `hf-qwen3-32b` | <2% |
| `openrouter-mistral-small-3.2`, `openrouter-gemma-4-26b-a4b` | 0% |

The HF endpoints' less-strict JSON wrapping in their typical response makes them disproportionately affected. The bug exists regardless of prompt, but prompt formats that don't enforce strict JSON output (e.g. dropping a structured `confidence` field) amplify it — a recent test saw deepseek's fallback-fragment rate go from 20 rows to 56 rows on the same dataset under such a prompt change.

## Fix

Return `'PARSE_ERROR'` (the existing semantic for unparseable responses) when the captured fragment doesn't match any canonical verdict keyword. One-line change.

## Risk

Low. The change only affects the fallback path:
- Canonical responses (well-formed JSON, or fallback regex matching `SUPPORTED`/`NOT SUPPORTED`/`PARTIALLY`/`UNAVAILABLE`) are unaffected.
- Fallback responses that previously surfaced as garbage labels now surface as `PARSE_ERROR` — visible in analysis, easy to diagnose.

## Test plan
- [ ] Existing benchmark runs continue to parse well-formed responses correctly (covered by `npm test`)
- [ ] After the fix, mock a non-JSON response containing `"...verdict OPTIONS..."` and verify `predicted_verdict === 'PARSE_ERROR'` rather than `'options'`
- [ ] Re-run a small benchmark slice and confirm garbage-fragment verdicts no longer appear in `results.json`