### PR TITLE
Detect and surface citation groups (multi-source claims)

### DIFF
--- a/core/claim.js
+++ b/core/claim.js
@@ -3,6 +3,47 @@
 
 export const MAINTENANCE_MARKER_RE = /\[(failed verification|verification needed|citation needed|better source[^\]]*|dubious[^\]]*|unreliable source[^\]]*|clarification needed|disputed[^\]]*|page needed|when\??|where\??|who\??|why\??|by whom\??|according to whom\??|original research[^\]]*|specify[^\]]*|vague|opinion|fact)\]/gi;
 
+// True iff the DOM range strictly between two .reference wrapper elements (in
+// document order: refA before refB) contains no non-whitespace text. This is
+// the rule that defines whether two adjacent citations attach to the same
+// claim — a comma or any other punctuation between them counts as text and
+// breaks the group.
+export function hasTextBetween(refA, refB) {
+    const document = refA.ownerDocument;
+    const range = document.createRange();
+    range.setStartAfter(refA);
+    range.setEndBefore(refB);
+    const between = range.toString().replace(/\s+/g, '').trim();
+    return between.length > 0;
+}
+
+// Returns the contiguous run of .reference wrapper elements (in DOM order)
+// that all attach to the same claim as refElement — i.e. consecutive siblings
+// in the same container with no text between adjacent members. Always returns
+// at least the wrapper of refElement; an isolated citation yields a single-
+// element array.
+export function getCitationGroup(refElement) {
+    const currentRef = refElement.closest('.reference');
+    if (!currentRef) return [];
+
+    const container = currentRef.closest('p, li, td, div, section');
+    if (!container) return [currentRef];
+
+    const refsInContainer = Array.from(container.querySelectorAll('.reference'));
+    const idx = refsInContainer.indexOf(currentRef);
+    if (idx === -1) return [currentRef];
+
+    let start = idx;
+    while (start > 0 && !hasTextBetween(refsInContainer[start - 1], refsInContainer[start])) {
+        start--;
+    }
+    let end = idx;
+    while (end < refsInContainer.length - 1 && !hasTextBetween(refsInContainer[end], refsInContainer[end + 1])) {
+        end++;
+    }
+    return refsInContainer.slice(start, end + 1);
+}
+
 export function extractClaimText(refElement) {
     const document = refElement.ownerDocument;
     const container = refElement.closest('p, li, td, div, section');
@@ -27,30 +68,16 @@ export function extractClaimText(refElement) {
     let claimStartNode = null;
 
     if (currentIndexInContainer > 0) {
-        // There are previous references in this container
-        // Walk backwards to find where the claim actually starts
-
+        // Walk backwards through the consecutive same-claim run; the boundary
+        // is the first previous ref that has actual text between it and its
+        // successor (i.e. it cites a different claim).
         for (let i = currentIndexInContainer - 1; i >= 0; i--) {
             const prevRef = refsInContainer[i];
-
-            // Check if there's actual text between this ref and the next one
-            const range = document.createRange();
-            range.setStartAfter(prevRef);
-
-            if (i === currentIndexInContainer - 1) {
-                range.setEndBefore(currentRef);
-            } else {
-                range.setEndBefore(refsInContainer[i + 1]);
-            }
-
-            const textBetween = range.toString().replace(/\s+/g, '').trim();
-
-            if (textBetween.length > 0) {
-                // Found text before this point - the previous ref is our boundary
+            const nextRef = refsInContainer[i + 1] || currentRef;
+            if (hasTextBetween(prevRef, nextRef)) {
                 claimStartNode = prevRef;
                 break;
             }
-            // No text between these refs - they cite the same claim, keep looking back
         }
     }
 

--- a/main.js
+++ b/main.js
@@ -266,6 +266,47 @@ function isGoogleBooksUrl(url) {
 
 const MAINTENANCE_MARKER_RE = /\[(failed verification|verification needed|citation needed|better source[^\]]*|dubious[^\]]*|unreliable source[^\]]*|clarification needed|disputed[^\]]*|page needed|when\??|where\??|who\??|why\??|by whom\??|according to whom\??|original research[^\]]*|specify[^\]]*|vague|opinion|fact)\]/gi;
 
+// True iff the DOM range strictly between two .reference wrapper elements (in
+// document order: refA before refB) contains no non-whitespace text. This is
+// the rule that defines whether two adjacent citations attach to the same
+// claim — a comma or any other punctuation between them counts as text and
+// breaks the group.
+function hasTextBetween(refA, refB) {
+    const document = refA.ownerDocument;
+    const range = document.createRange();
+    range.setStartAfter(refA);
+    range.setEndBefore(refB);
+    const between = range.toString().replace(/\s+/g, '').trim();
+    return between.length > 0;
+}
+
+// Returns the contiguous run of .reference wrapper elements (in DOM order)
+// that all attach to the same claim as refElement — i.e. consecutive siblings
+// in the same container with no text between adjacent members. Always returns
+// at least the wrapper of refElement; an isolated citation yields a single-
+// element array.
+function getCitationGroup(refElement) {
+    const currentRef = refElement.closest('.reference');
+    if (!currentRef) return [];
+
+    const container = currentRef.closest('p, li, td, div, section');
+    if (!container) return [currentRef];
+
+    const refsInContainer = Array.from(container.querySelectorAll('.reference'));
+    const idx = refsInContainer.indexOf(currentRef);
+    if (idx === -1) return [currentRef];
+
+    let start = idx;
+    while (start > 0 && !hasTextBetween(refsInContainer[start - 1], refsInContainer[start])) {
+        start--;
+    }
+    let end = idx;
+    while (end < refsInContainer.length - 1 && !hasTextBetween(refsInContainer[end], refsInContainer[end + 1])) {
+        end++;
+    }
+    return refsInContainer.slice(start, end + 1);
+}
+
 function extractClaimText(refElement) {
     const document = refElement.ownerDocument;
     const container = refElement.closest('p, li, td, div, section');
@@ -290,30 +331,16 @@ function extractClaimText(refElement) {
     let claimStartNode = null;
 
     if (currentIndexInContainer > 0) {
-        // There are previous references in this container
-        // Walk backwards to find where the claim actually starts
-
+        // Walk backwards through the consecutive same-claim run; the boundary
+        // is the first previous ref that has actual text between it and its
+        // successor (i.e. it cites a different claim).
         for (let i = currentIndexInContainer - 1; i >= 0; i--) {
             const prevRef = refsInContainer[i];
-
-            // Check if there's actual text between this ref and the next one
-            const range = document.createRange();
-            range.setStartAfter(prevRef);
-
-            if (i === currentIndexInContainer - 1) {
-                range.setEndBefore(currentRef);
-            } else {
-                range.setEndBefore(refsInContainer[i + 1]);
-            }
-
-            const textBetween = range.toString().replace(/\s+/g, '').trim();
-
-            if (textBetween.length > 0) {
-                // Found text before this point - the previous ref is our boundary
+            const nextRef = refsInContainer[i + 1] || currentRef;
+            if (hasTextBetween(prevRef, nextRef)) {
                 claimStartNode = prevRef;
                 break;
             }
-            // No text between these refs - they cite the same claim, keep looking back
         }
     }
 
@@ -820,6 +847,7 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
                     <div id="verifier-claim-section">
                         <h4>Selected Claim</h4>
                         <div id="verifier-claim-text">Click on a reference number [1] next to a claim to verify it against its source.</div>
+                        <div id="verifier-claim-group-indicator" style="display: none;"></div>
                     </div>
                     <div id="verifier-source-section">
                         <h4>Source Content</h4>
@@ -1299,6 +1327,93 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
                 .report-card-action .oo-ui-buttonElement-button {
                     font-size: 11px;
                     padding: 2px 4px;
+                }
+                .verifier-report-group {
+                    border: 1px solid #cdd5e0;
+                    border-left: 3px solid ${this.getCurrentColor()};
+                    border-radius: 4px;
+                    background: #f6f8fb;
+                    padding: 6px 8px;
+                    font-size: 12px;
+                }
+                .verifier-report-group-header {
+                    margin-bottom: 6px;
+                }
+                .verifier-report-group-title {
+                    display: flex;
+                    align-items: center;
+                    gap: 6px;
+                    margin-bottom: 4px;
+                }
+                .verifier-report-group-badge {
+                    font-weight: bold;
+                    font-size: 11px;
+                    color: ${this.getCurrentColor()};
+                }
+                .verifier-report-group-claim {
+                    color: #333;
+                    font-size: 12px;
+                    line-height: 1.4;
+                    margin-bottom: 4px;
+                }
+                .verifier-report-group-edit {
+                    margin-top: 2px;
+                }
+                .verifier-report-group-edit .oo-ui-buttonElement-button {
+                    font-size: 11px;
+                    padding: 2px 4px;
+                }
+                .verifier-report-group-rows {
+                    display: flex;
+                    flex-direction: column;
+                    gap: 4px;
+                }
+                .verifier-report-group-row {
+                    background: #fff;
+                    border: 1px solid #e0e4ea;
+                    border-left: 3px solid #ccc;
+                    border-radius: 3px;
+                    padding: 5px 8px;
+                    cursor: pointer;
+                }
+                .verifier-report-group-row:hover {
+                    background: #f0f4ff;
+                }
+                .verifier-report-group-row.verdict-supported { border-left-color: #28a745; }
+                .verifier-report-group-row.verdict-partial { border-left-color: #ffc107; }
+                .verifier-report-group-row.verdict-not-supported { border-left-color: #dc3545; }
+                .verifier-report-group-row.verdict-unavailable { border-left-color: #6c757d; }
+                .verifier-report-group-row.verdict-error { border-left-color: #adb5bd; }
+                .verifier-report-group-row-header {
+                    display: flex;
+                    justify-content: space-between;
+                    align-items: center;
+                    margin-bottom: 2px;
+                }
+                #verifier-claim-group-indicator {
+                    margin-top: 6px;
+                    font-size: 11px;
+                    color: #666;
+                    line-height: 1.4;
+                }
+                #verifier-claim-group-indicator .group-active {
+                    font-weight: bold;
+                    color: ${this.getCurrentColor()};
+                }
+                html.skin-theme-clientpref-night .verifier-report-group {
+                    background: #232336 !important;
+                    border-color: #3a3a4e !important;
+                }
+                html.skin-theme-clientpref-night .verifier-report-group-row {
+                    background: #1a1a2e !important;
+                    border-color: #3a3a4e !important;
+                    color: #e0e0e0 !important;
+                }
+                html.skin-theme-clientpref-night .verifier-report-group-claim {
+                    color: #d0d0d8 !important;
+                }
+                html.skin-theme-clientpref-night #verifier-claim-group-indicator {
+                    color: #b0b0c0 !important;
                 }
                 #source-verifier-sidebar .oo-ui-iconElement-icon + .oo-ui-labelElement-label {
                     margin-left: 4px;
@@ -2073,6 +2188,7 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
                 this.activeRefElement = refElement;
 
                 document.getElementById('verifier-claim-text').textContent = claim;
+                this.renderClaimGroupIndicator(refElement);
 
                 const refUrl = this.extractReferenceUrl(refElement);
                 this.activeSourceUrl = refUrl;
@@ -2218,7 +2334,11 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
         extractClaimText(refElement) {
             return extractClaimText(refElement);
         }
-        
+
+        getCitationGroup(refElement) {
+            return getCitationGroup(refElement);
+        }
+
         extractHttpUrl(element) {
             return extractHttpUrl(element);
         }
@@ -2626,7 +2746,44 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
                 citations.push({ refElement, citationNumber, claimText, url, pageNum, refId });
             });
 
+            // Attach group metadata: every citation in a contiguous run of refs
+            // attached to the same claim shares the same groupId (first
+            // member's refId), groupSize and groupCitationNumbers list. The
+            // groupIndex is the citation's 0-based position within its group.
+            this.attachGroupMetadata(citations);
+
             return citations;
+        }
+
+        attachGroupMetadata(citations) {
+            const byRefId = new Map(citations.map(c => [c.refId, c]));
+            const visited = new Set();
+            for (const citation of citations) {
+                if (visited.has(citation.refId)) continue;
+                const groupRefs = this.getCitationGroup(citation.refElement);
+                // Map .reference wrapper elements back to citation entries via
+                // the anchor's href; entries without a corresponding citation
+                // (e.g. refs that failed claim-text extraction) are dropped.
+                const groupCitations = [];
+                for (const wrapper of groupRefs) {
+                    const anchor = wrapper.querySelector('a[href^="#"]');
+                    if (!anchor) continue;
+                    const id = anchor.getAttribute('href').substring(1);
+                    const c = byRefId.get(id);
+                    if (c) groupCitations.push(c);
+                }
+                if (groupCitations.length === 0) continue;
+                const groupId = groupCitations[0].refId;
+                const groupSize = groupCitations.length;
+                const groupCitationNumbers = groupCitations.map(c => c.citationNumber);
+                groupCitations.forEach((c, idx) => {
+                    c.groupId = groupId;
+                    c.groupSize = groupSize;
+                    c.groupIndex = idx;
+                    c.groupCitationNumbers = groupCitationNumbers;
+                    visited.add(c.refId);
+                });
+            }
         }
 
         showReportView() {
@@ -2713,18 +2870,39 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
             const resultsEl = document.getElementById('verifier-report-results');
             if (!resultsEl) return;
             const classes = ['supported', 'partial', 'not-supported', 'unavailable', 'error'];
+            // Solo .verifier-report-card visibility is still driven by these
+            // CSS-only filter-hide-* classes (see #verifier-report-results
+            // CSS rules in createStyles).
             for (const cls of classes) {
                 resultsEl.classList.toggle(`filter-hide-${cls}`, !!this.reportFilters[cls]);
             }
 
-            // Show an empty-state hint when every rendered card is hidden by filters.
+            // Group blocks are visible iff at least one of their rows has a
+            // verdict whose chip is currently enabled. Inside a visible
+            // group, every row stays visible regardless of its verdict — the
+            // user needs to see how each source contributed to decide
+            // whether collective coverage is adequate.
+            const groups = resultsEl.querySelectorAll('.verifier-report-group');
+            groups.forEach(groupEl => {
+                const rows = groupEl.querySelectorAll('.verifier-report-group-row');
+                const hasVisibleRow = Array.from(rows).some(row => {
+                    const verdictClass = classes.find(cls => row.classList.contains(`verdict-${cls}`));
+                    return verdictClass && !this.reportFilters[verdictClass];
+                });
+                groupEl.style.display = hasVisibleRow ? '' : 'none';
+            });
+
+            // Show an empty-state hint when every rendered solo card and
+            // every group block is hidden by filters.
             let emptyEl = resultsEl.querySelector('.verifier-filter-empty');
-            const cards = resultsEl.querySelectorAll('.verifier-report-card');
-            const hasVisible = Array.from(cards).some(c => {
+            const soloCards = resultsEl.querySelectorAll('.verifier-report-card');
+            const hasVisibleSolo = Array.from(soloCards).some(c => {
                 const verdictClass = classes.find(cls => c.classList.contains(`verdict-${cls}`));
                 return verdictClass && !this.reportFilters[verdictClass];
             });
-            if (cards.length > 0 && !hasVisible) {
+            const hasVisibleGroup = Array.from(groups).some(g => g.style.display !== 'none');
+            const total = soloCards.length + groups.length;
+            if (total > 0 && !hasVisibleSolo && !hasVisibleGroup) {
                 if (!emptyEl) {
                     emptyEl = document.createElement('div');
                     emptyEl.className = 'verifier-filter-empty';
@@ -2770,6 +2948,18 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
                 (this.reportFilters.unavailable ? counts.unavailable : 0) +
                 (this.reportFilters.error ? counts.error : 0);
 
+            // Count distinct claims (groups). Solo citations are 1-member
+            // groups, so total claims = number of distinct groupIds among
+            // the results so far.
+            const claimIds = new Set();
+            for (const r of this.reportResults) {
+                claimIds.add(r.groupId || r.refId || `__solo_${claimIds.size}`);
+            }
+            const claimCount = claimIds.size;
+            const claimsLabel = claimCount === total
+                ? `${total} citations checked`
+                : `${total} citations across ${claimCount} claim${claimCount === 1 ? '' : 's'}`;
+
             summaryEl.innerHTML = `
                 <div class="verifier-summary-bar">
                     ${segHtml(counts.supported, 'seg-supported')}
@@ -2786,7 +2976,7 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
                     ${counts.error > 0 ? chip('error', counts.error, 'errors', '#adb5bd') : ''}
                 </div>
                 <div class="verifier-summary-meta">
-                    ${total} citations checked${hiddenCount > 0 ? ` · ${hiddenCount} hidden by filter` : ''}${this.reportTokenUsage.input + this.reportTokenUsage.output > 0 ? ` · ${this.reportTokenUsage.input.toLocaleString()} input + ${this.reportTokenUsage.output.toLocaleString()} output tokens` : ''}
+                    ${claimsLabel}${hiddenCount > 0 ? ` · ${hiddenCount} hidden by filter` : ''}${this.reportTokenUsage.input + this.reportTokenUsage.output > 0 ? ` · ${this.reportTokenUsage.input.toLocaleString()} input + ${this.reportTokenUsage.output.toLocaleString()} output tokens` : ''}
                 </div>
                 ${this.reportRevisionId ? `<div class="verifier-summary-meta">Revision: <a href="${this.escapeHtml(this.getRevisionPermalinkUrl(this.reportRevisionId) || '#')}" target="_blank" rel="noopener">${this.reportRevisionId}</a></div>` : ''}
             `;
@@ -2799,19 +2989,51 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
             });
         }
 
+        verdictClassFor(verdict) {
+            switch (verdict) {
+                case 'SUPPORTED': return { cls: 'supported', label: 'Supported' };
+                case 'PARTIALLY SUPPORTED': return { cls: 'partial', label: 'Partial' };
+                case 'NOT SUPPORTED': return { cls: 'not-supported', label: 'Not Supported' };
+                case 'SOURCE UNAVAILABLE': return { cls: 'unavailable', label: 'Unavailable' };
+                default: return { cls: 'error', label: verdict };
+            }
+        }
+
+        attachRefScrollHandler(el, refElement) {
+            if (!refElement) return;
+            el.addEventListener('click', (e) => {
+                if (e.target.closest('.report-card-action') || e.target.closest('.verifier-report-group-edit')) return;
+                refElement.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                this.clearHighlights();
+                const parentRef = refElement.closest('.reference');
+                if (parentRef) parentRef.classList.add('verifier-active');
+            });
+        }
+
         renderReportCard(result, index) {
             const resultsEl = document.getElementById('verifier-report-results');
             if (!resultsEl) return;
 
-            let verdictClass, verdictLabel;
-            switch (result.verdict) {
-                case 'SUPPORTED': verdictClass = 'supported'; verdictLabel = 'Supported'; break;
-                case 'PARTIALLY SUPPORTED': verdictClass = 'partial'; verdictLabel = 'Partial'; break;
-                case 'NOT SUPPORTED': verdictClass = 'not-supported'; verdictLabel = 'Not Supported'; break;
-                case 'SOURCE UNAVAILABLE': verdictClass = 'unavailable'; verdictLabel = 'Unavailable'; break;
-                default: verdictClass = 'error'; verdictLabel = result.verdict; break;
+            // Solo citation: render the original card layout unchanged.
+            if (!result.groupSize || result.groupSize <= 1) {
+                resultsEl.appendChild(this.buildSoloCard(result));
+                return;
             }
 
+            // Group of >1: the first citation in the group creates a group
+            // container; every subsequent citation appends a row into the
+            // existing container located by data-group-id.
+            let groupEl = resultsEl.querySelector(`.verifier-report-group[data-group-id="${CSS.escape(result.groupId)}"]`);
+            if (!groupEl) {
+                groupEl = this.buildGroupBlock(result);
+                resultsEl.appendChild(groupEl);
+            }
+            const rowsEl = groupEl.querySelector('.verifier-report-group-rows');
+            rowsEl.appendChild(this.buildGroupRow(result));
+        }
+
+        buildSoloCard(result) {
+            const { cls: verdictClass, label: verdictLabel } = this.verdictClassFor(result.verdict);
             const card = document.createElement('div');
             card.className = `verifier-report-card verdict-${verdictClass}`;
             const claimExcerpt = result.claimText.length > 80 ? result.claimText.substring(0, 80) + '…' : result.claimText;
@@ -2828,15 +3050,7 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
                 ${truncationHtml}
             `;
 
-            if (result.refElement) {
-                card.addEventListener('click', (e) => {
-                    if (e.target.closest('.report-card-action')) return;
-                    result.refElement.scrollIntoView({ behavior: 'smooth', block: 'center' });
-                    this.clearHighlights();
-                    const parentRef = result.refElement.closest('.reference');
-                    if (parentRef) parentRef.classList.add('verifier-active');
-                });
-            }
+            this.attachRefScrollHandler(card, result.refElement);
 
             if (result.refElement && (result.verdict === 'NOT SUPPORTED' || result.verdict === 'PARTIALLY SUPPORTED' || result.verdict === 'SOURCE UNAVAILABLE')) {
                 const actionDiv = document.createElement('div');
@@ -2852,8 +3066,59 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
                 actionDiv.appendChild(editBtn.$element[0]);
                 card.appendChild(actionDiv);
             }
+            return card;
+        }
 
-            resultsEl.appendChild(card);
+        buildGroupBlock(firstResult) {
+            const groupEl = document.createElement('div');
+            groupEl.className = 'verifier-report-group';
+            groupEl.dataset.groupId = firstResult.groupId;
+            const claimExcerpt = firstResult.claimText.length > 120 ? firstResult.claimText.substring(0, 120) + '…' : firstResult.claimText;
+            const numbers = (firstResult.groupCitationNumbers || []).map(n => `[${n}]`).join('');
+            groupEl.innerHTML = `
+                <div class="verifier-report-group-header">
+                    <div class="verifier-report-group-title">
+                        <span class="verifier-report-group-badge">Group of ${firstResult.groupSize} · ${numbers}</span>
+                    </div>
+                    <div class="verifier-report-group-claim">${this.escapeHtml(claimExcerpt)}</div>
+                    <div class="verifier-report-group-edit"></div>
+                </div>
+                <div class="verifier-report-group-rows"></div>
+            `;
+            // One shared "Edit Section" button per group: every member is in
+            // the same article section by definition, so a per-row button
+            // would just be repetition. Wire it to the first member's ref.
+            if (firstResult.refElement) {
+                const editBtn = new OO.ui.ButtonWidget({
+                    label: 'Edit Section',
+                    flags: ['progressive'],
+                    icon: 'edit',
+                    href: this.buildEditUrl(firstResult.refElement),
+                    target: '_blank',
+                    framed: false
+                });
+                groupEl.querySelector('.verifier-report-group-edit').appendChild(editBtn.$element[0]);
+            }
+            return groupEl;
+        }
+
+        buildGroupRow(result) {
+            const { cls: verdictClass, label: verdictLabel } = this.verdictClassFor(result.verdict);
+            const row = document.createElement('div');
+            row.className = `verifier-report-group-row verdict-${verdictClass}`;
+            const truncationHtml = (result.truncated && result.verdict !== 'SUPPORTED')
+                ? '<div class="report-card-truncated">⚠ Source is long, only partially checked.</div>'
+                : '';
+            row.innerHTML = `
+                <div class="verifier-report-group-row-header">
+                    <span class="report-card-citation">[${result.citationNumber}]</span>
+                    <span class="report-card-verdict ${verdictClass}">${verdictLabel}</span>
+                </div>
+                ${result.comments ? `<div class="report-card-comment">${this.escapeHtml(result.comments)}</div>` : ''}
+                ${truncationHtml}
+            `;
+            this.attachRefScrollHandler(row, result.refElement);
+            return row;
         }
 
         escapeHtml(str) {
@@ -2928,9 +3193,16 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
                 // in the display text so they don't confuse MediaWiki's wikilink parser.
                 const refHref = r.refElement && r.refElement.getAttribute('href');
                 const refAnchor = refHref && refHref.startsWith('#') ? refHref.substring(1) : null;
-                const citationCell = (revId && refAnchor)
+                let citationCell = (revId && refAnchor)
                     ? `[[Special:PermanentLink/${revId}#${refAnchor}|&#91;${r.citationNumber}&#93;]]`
                     : `[${r.citationNumber}]`;
+                // Flag grouped citations so editors reading the wikitext can
+                // see which rows belong to the same multi-source claim. Using
+                // a group token rather than rowspan keeps the table sortable.
+                if (r.groupSize && r.groupSize > 1 && r.groupCitationNumbers) {
+                    const groupToken = r.groupCitationNumbers.map(n => `[${n}]`).join('');
+                    citationCell += ` <small>(group ${groupToken})</small>`;
+                }
                 wikitext += `|-\n| ${citationCell} || ${verdictWiki} || ${sourceStr} || ${commentsClean}\n`;
             }
 
@@ -3189,6 +3461,13 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
                 }
 
                 if (result) {
+                    // Carry the group metadata from the citation onto the
+                    // result so the renderer and the wikitext exporter can
+                    // cluster sibling citations without re-deriving groups.
+                    result.groupId = citation.groupId;
+                    result.groupSize = citation.groupSize;
+                    result.groupIndex = citation.groupIndex;
+                    result.groupCitationNumbers = citation.groupCitationNumbers;
                     this.reportResults.push(result);
                     this.renderReportCard(result, this.reportResults.length - 1);
                     this.renderReportSummary();
@@ -3265,7 +3544,7 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
         clearResult() {
             const verdictEl = document.getElementById('verifier-verdict');
             const commentsEl = document.getElementById('verifier-comments');
-            
+
             if (verdictEl) {
                 verdictEl.textContent = '';
                 verdictEl.className = '';
@@ -3277,6 +3556,32 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
             if (actionContainer) {
                 actionContainer.innerHTML = '';
             }
+            const groupEl = document.getElementById('verifier-claim-group-indicator');
+            if (groupEl) {
+                groupEl.style.display = 'none';
+                groupEl.innerHTML = '';
+            }
+        }
+
+        renderClaimGroupIndicator(refElement) {
+            const indicatorEl = document.getElementById('verifier-claim-group-indicator');
+            if (!indicatorEl) return;
+            const group = this.getCitationGroup(refElement);
+            if (!group || group.length <= 1) {
+                indicatorEl.style.display = 'none';
+                indicatorEl.innerHTML = '';
+                return;
+            }
+            const activeWrapper = refElement.closest('.reference');
+            const numbers = group.map(wrapper => {
+                const anchor = wrapper.querySelector('a');
+                const text = anchor ? anchor.textContent.replace(/[\[\]]/g, '').trim() : '?';
+                const isActive = wrapper === activeWrapper;
+                const span = `<span class="${isActive ? 'group-active' : ''}">[${this.escapeHtml(text)}]</span>`;
+                return span;
+            }).join(' ');
+            indicatorEl.innerHTML = `Part of a group of ${group.length} citations: ${numbers}`;
+            indicatorEl.style.display = '';
         }
     }
     

--- a/tests/claim.test.js
+++ b/tests/claim.test.js
@@ -1,10 +1,14 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { JSDOM } from 'jsdom';
-import { extractClaimText, MAINTENANCE_MARKER_RE } from '../core/claim.js';
+import { extractClaimText, getCitationGroup, MAINTENANCE_MARKER_RE } from '../core/claim.js';
 
 function mkDoc(html) {
   return new JSDOM(`<!DOCTYPE html><body>${html}</body>`).window.document;
+}
+
+function refIds(group) {
+  return group.map(el => el.id);
 }
 
 test('MAINTENANCE_MARKER_RE strips failed-verification marker', () => {
@@ -72,4 +76,67 @@ test('extractClaimText collapses whitespace left behind after stripping a marker
   const claim = extractClaimText(ref);
   assert.ok(!/\s{2,}/.test(claim), `claim contains run of whitespace: ${JSON.stringify(claim)}`);
   assert.ok(claim.includes('Elvis is still alive in Memphis'));
+});
+
+test('extractClaimText returns the same claim for every citation in a [1][2][3] run', () => {
+  // Adjacent citations with no separating text all attach to the same claim.
+  const doc = mkDoc(`
+    <p>The boiling point of water is 100 degrees Celsius.<sup id="cite_ref-1" class="reference"><a href="#cite_note-1">[1]</a></sup><sup id="cite_ref-2" class="reference"><a href="#cite_note-2">[2]</a></sup><sup id="cite_ref-3" class="reference"><a href="#cite_note-3">[3]</a></sup></p>
+  `);
+  const claim1 = extractClaimText(doc.getElementById('cite_ref-1'));
+  const claim2 = extractClaimText(doc.getElementById('cite_ref-2'));
+  const claim3 = extractClaimText(doc.getElementById('cite_ref-3'));
+  assert.equal(claim1, claim2);
+  assert.equal(claim2, claim3);
+  assert.ok(claim1.includes('boiling point of water is 100 degrees Celsius'));
+});
+
+test('getCitationGroup returns all three refs for a [1][2][3] run regardless of which is passed', () => {
+  const doc = mkDoc(`
+    <p>The boiling point of water is 100 degrees Celsius.<sup id="cite_ref-1" class="reference"><a href="#cite_note-1">[1]</a></sup><sup id="cite_ref-2" class="reference"><a href="#cite_note-2">[2]</a></sup><sup id="cite_ref-3" class="reference"><a href="#cite_note-3">[3]</a></sup></p>
+  `);
+  for (const id of ['cite_ref-1', 'cite_ref-2', 'cite_ref-3']) {
+    const group = getCitationGroup(doc.getElementById(id));
+    assert.deepEqual(refIds(group), ['cite_ref-1', 'cite_ref-2', 'cite_ref-3'],
+      `wrong group when starting from ${id}`);
+  }
+});
+
+test('getCitationGroup returns a single-element array for an isolated citation', () => {
+  const doc = mkDoc(`
+    <p>Paris is the capital of France.<sup id="cite_ref-1" class="reference"><a href="#cite_note-1">[1]</a></sup> It is on the Seine.<sup id="cite_ref-2" class="reference"><a href="#cite_note-2">[2]</a></sup></p>
+  `);
+  assert.deepEqual(refIds(getCitationGroup(doc.getElementById('cite_ref-1'))), ['cite_ref-1']);
+  assert.deepEqual(refIds(getCitationGroup(doc.getElementById('cite_ref-2'))), ['cite_ref-2']);
+});
+
+test('getCitationGroup ignores whitespace between adjacent references', () => {
+  // Editors sometimes leave a space between adjacent <sup> tags in the source;
+  // the rendered text node is whitespace-only and should not split the group.
+  const doc = mkDoc(`
+    <p>Some claim.<sup id="cite_ref-1" class="reference"><a href="#cite_note-1">[1]</a></sup> <sup id="cite_ref-2" class="reference"><a href="#cite_note-2">[2]</a></sup></p>
+  `);
+  assert.deepEqual(refIds(getCitationGroup(doc.getElementById('cite_ref-1'))), ['cite_ref-1', 'cite_ref-2']);
+});
+
+test('getCitationGroup splits when punctuation appears between citations', () => {
+  // A comma between adjacent citations is non-whitespace text and breaks the
+  // group. Each citation forms its own group of one.
+  const doc = mkDoc(`
+    <p>Some claim.<sup id="cite_ref-1" class="reference"><a href="#cite_note-1">[1]</a></sup>, <sup id="cite_ref-2" class="reference"><a href="#cite_note-2">[2]</a></sup></p>
+  `);
+  assert.deepEqual(refIds(getCitationGroup(doc.getElementById('cite_ref-1'))), ['cite_ref-1']);
+  assert.deepEqual(refIds(getCitationGroup(doc.getElementById('cite_ref-2'))), ['cite_ref-2']);
+});
+
+test('getCitationGroup handles mixed groups and singletons in the same paragraph', () => {
+  // text [1][2] more text [3] more text [4][5]  →  three groups: {1,2}, {3}, {4,5}.
+  const doc = mkDoc(`
+    <p>First fact.<sup id="cite_ref-1" class="reference"><a href="#cite_note-1">[1]</a></sup><sup id="cite_ref-2" class="reference"><a href="#cite_note-2">[2]</a></sup> Second fact.<sup id="cite_ref-3" class="reference"><a href="#cite_note-3">[3]</a></sup> Third fact.<sup id="cite_ref-4" class="reference"><a href="#cite_note-4">[4]</a></sup><sup id="cite_ref-5" class="reference"><a href="#cite_note-5">[5]</a></sup></p>
+  `);
+  assert.deepEqual(refIds(getCitationGroup(doc.getElementById('cite_ref-1'))), ['cite_ref-1', 'cite_ref-2']);
+  assert.deepEqual(refIds(getCitationGroup(doc.getElementById('cite_ref-2'))), ['cite_ref-1', 'cite_ref-2']);
+  assert.deepEqual(refIds(getCitationGroup(doc.getElementById('cite_ref-3'))), ['cite_ref-3']);
+  assert.deepEqual(refIds(getCitationGroup(doc.getElementById('cite_ref-4'))), ['cite_ref-4', 'cite_ref-5']);
+  assert.deepEqual(refIds(getCitationGroup(doc.getElementById('cite_ref-5'))), ['cite_ref-4', 'cite_ref-5']);
 });


### PR DESCRIPTION
Wikipedia editors often back a single claim with several adjacent citations (e.g. [1][2][3]). Verifying each citation independently produces verdicts that, in isolation, can mislead the user — a "Not Supported" for one source doesn't mean the claim is uncovered when its siblings haven't been checked.

This change detects contiguous citation groups (adjacent .reference siblings with no non-whitespace text between them) and surfaces the grouping in the UI without computing or showing any aggregate verdict, since per-source verdicts can be misleading when collapsed:

- core/claim.js: add hasTextBetween + getCitationGroup, refactor extractClaimText to share the same "no text between refs" rule.
- tests/claim.test.js: cover [1][2][3] runs, isolated citations, whitespace vs. punctuation between refs, mixed groups in one paragraph.
- main.js / collectAllCitations: attach groupId, groupSize, groupIndex, groupCitationNumbers to each citation; thread them onto report results.
- main.js / report view: split renderReportCard into solo cards and group blocks. Grouped citations cluster into one block with a shared claim header and one shared "Edit Section" button (every group member is in the same article section by definition).
- main.js / filters: chips stay per-citation, but a group block is visible whenever at least one of its rows has a verdict whose chip is enabled. Inside a visible group, every row stays visible — no aggregate verdict is computed. Summary meta gains an "X citations across Y claims" line.
- main.js / sidebar: when the clicked citation belongs to a group, display a group indicator under the claim text showing the group's citation numbers with the active one bolded.
- main.js / wikitext report: flag grouped rows with a small "(group [N][M])" token in the citation cell.

https://claude.ai/code/session_01D4paSBmbnwBsXV9XKAQ38N