### PR TITLE
Fix citation group metadata for named-ref reuses

### DIFF
--- a/main.js
+++ b/main.js
@@ -2756,24 +2756,32 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
         }
 
         attachGroupMetadata(citations) {
-            const byRefId = new Map(citations.map(c => [c.refId, c]));
+            // Key by the <sup class="reference"> wrapper element, not refId:
+            // named refs (e.g. {{r|Foo}} cited twice) share the same cite_note
+            // href, so a refId-keyed map collides and the second occurrence
+            // overwrites the first. Wrapper elements are unique per occurrence.
+            const byWrapper = new Map();
+            for (const c of citations) {
+                const wrapper = c.refElement.closest('.reference');
+                if (wrapper) byWrapper.set(wrapper, c);
+            }
             const visited = new Set();
             for (const citation of citations) {
-                if (visited.has(citation.refId)) continue;
+                if (visited.has(citation)) continue;
                 const groupRefs = this.getCitationGroup(citation.refElement);
-                // Map .reference wrapper elements back to citation entries via
-                // the anchor's href; entries without a corresponding citation
-                // (e.g. refs that failed claim-text extraction) are dropped.
                 const groupCitations = [];
                 for (const wrapper of groupRefs) {
-                    const anchor = wrapper.querySelector('a[href^="#"]');
-                    if (!anchor) continue;
-                    const id = anchor.getAttribute('href').substring(1);
-                    const c = byRefId.get(id);
+                    const c = byWrapper.get(wrapper);
                     if (c) groupCitations.push(c);
                 }
                 if (groupCitations.length === 0) continue;
-                const groupId = groupCitations[0].refId;
+                // Use the first wrapper's id (cite_ref-X-Y, unique per
+                // occurrence) as the group id so two groups whose first
+                // member is the same named source — e.g. "[3][4]" and a
+                // separate "[3][5]" later in the article — don't collide on
+                // the data-group-id used by the report renderer.
+                const firstWrapper = groupCitations[0].refElement.closest('.reference');
+                const groupId = (firstWrapper && firstWrapper.id) || groupCitations[0].refId;
                 const groupSize = groupCitations.length;
                 const groupCitationNumbers = groupCitations.map(c => c.citationNumber);
                 groupCitations.forEach((c, idx) => {
@@ -2781,7 +2789,7 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
                     c.groupSize = groupSize;
                     c.groupIndex = idx;
                     c.groupCitationNumbers = groupCitationNumbers;
-                    visited.add(c.refId);
+                    visited.add(c);
                 });
             }
         }

--- a/tests/claim.test.js
+++ b/tests/claim.test.js
@@ -129,6 +129,28 @@ test('getCitationGroup splits when punctuation appears between citations', () =>
   assert.deepEqual(refIds(getCitationGroup(doc.getElementById('cite_ref-2'))), ['cite_ref-2']);
 });
 
+test('getCitationGroup returns distinct wrappers for named-ref reuses', () => {
+  // Wikipedia's named refs (e.g. <ref name="Foo"/> cited twice) produce two
+  // distinct <sup class="reference"> wrappers whose <a> elements share the
+  // same href (#cite_note-Foo). getCitationGroup must return wrapper
+  // elements, not href targets, so a downstream mapping back to per-
+  // occurrence citation entries can stay 1:1 — otherwise mapping by href
+  // collides and one occurrence's group metadata gets dropped or
+  // overwritten by the other group's. Regression: this is the shape that
+  // produced "[1] (group [1][2])" with no group annotation on the [2] row
+  // and a stale [3,5] group on what should have been [3,4].
+  const doc = mkDoc(`
+    <p>Fact A.<sup id="cite_ref-Foo_0" class="reference"><a href="#cite_note-Foo">[1]</a></sup><sup id="cite_ref-2" class="reference"><a href="#cite_note-2">[2]</a></sup> Fact B.<sup id="cite_ref-Foo_1" class="reference"><a href="#cite_note-Foo">[1]</a></sup><sup id="cite_ref-3" class="reference"><a href="#cite_note-3">[3]</a></sup></p>
+  `);
+  const groupA = getCitationGroup(doc.getElementById('cite_ref-Foo_0'));
+  const groupB = getCitationGroup(doc.getElementById('cite_ref-Foo_1'));
+  assert.deepEqual(refIds(groupA), ['cite_ref-Foo_0', 'cite_ref-2']);
+  assert.deepEqual(refIds(groupB), ['cite_ref-Foo_1', 'cite_ref-3']);
+  // The two reuses must surface as distinct DOM wrappers — not the same
+  // element — so downstream code can pair each one with its own citation row.
+  assert.notEqual(groupA[0], groupB[0]);
+});
+
 test('getCitationGroup handles mixed groups and singletons in the same paragraph', () => {
   // text [1][2] more text [3] more text [4][5]  →  three groups: {1,2}, {3}, {4,5}.
   const doc = mkDoc(`


### PR DESCRIPTION
attachGroupMetadata keyed its lookup map by refId (the cite_note href), but Wikipedia's named refs share that href across every occurrence. The Map collided, the last occurrence won, and the first occurrence was left without any group metadata while the surviving entry got overwritten by whichever group was processed last. On articles with named refs this showed up as missing badges and stale group memberships in the report.

Key by the <sup class="reference"> wrapper element instead — those are unique per occurrence — and use the wrapper's id as groupId so two groups whose first member is the same named source don't collide on the data-group-id the streaming report renderer uses to find existing group blocks.