### PR TITLE
Switch default HuggingFace model from Qwen3-32B to gpt-oss-20b

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Inspired by [User:Polygnotus/Scripts/AI_Source_Verification.js](https://en.wikip
 - Click any `[N]` citation in an article to verify the associated claim
 - Batch-verify every citation in an article and generate a wiki-markup report of failed citations
 - Multiple LLM providers with a unified interface:
-  - **HuggingFace** (default, free, no API key — Qwen3-32B by default; set an HF API key to use any HF-hosted model)
+  - **HuggingFace** (default, free, no API key — gpt-oss-20b by default; set an HF API key to use any HF-hosted model)
   - **PublicAI** (free, no API key — Qwen-SEA-LION / OLMo / Apertus)
   - **Claude** (Anthropic)
   - **Gemini** (Google)

--- a/cli/verify.js
+++ b/cli/verify.js
@@ -145,7 +145,7 @@ export function classifyProviderError(err) {
 
 const PROVIDER_MODELS = {
     publicai:    'aisingapore/Qwen-SEA-LION-v4-32B-IT',
-    huggingface: 'Qwen/Qwen3-32B',
+    huggingface: 'openai/gpt-oss-20b',
     claude:      'claude-sonnet-4-6',
     gemini:      'gemini-flash-latest',
     openai:      'gpt-4o',

--- a/main.js
+++ b/main.js
@@ -717,7 +717,7 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
                     // to HF (any model) when stored.
                     storageKey: 'hf_api_key',
                     color: '#6B21A8', // HF yellow-orange
-                    model: 'Qwen/Qwen3-32B',
+                    model: 'openai/gpt-oss-20b',
                     requiresKey: false,
                     optionalKey: true
                 },


### PR DESCRIPTION
## Summary
Updates the default HuggingFace model used for citation verification from Qwen/Qwen3-32B to openai/gpt-oss-20b across the codebase and documentation.

## Changes
- Updated default model identifier in `cli/verify.js` PROVIDER_MODELS configuration
- Updated default model identifier in `main.js` HuggingFace provider configuration
- Updated README.md documentation to reflect the new default model

## Details
This change affects the default LLM model used when no HuggingFace API key is provided. Users can still override this by setting an HF API key to use any HF-hosted model. The gpt-oss-20b model replaces Qwen3-32B as the default choice for free, unauthenticated HuggingFace inference.

https://claude.ai/code/session_01HgqkD7KV5VRsB8BsnKyhCM