### PR TITLE
Consolidate verdict parser; handle markdown-emphasized responses

### DIFF
--- a/benchmark/run_benchmark.js
+++ b/benchmark/run_benchmark.js
@@ -27,6 +27,7 @@ import {
     callOpenRouterAPI,
     callHuggingFaceAPI,
 } from '../core/providers.js';
+import { parseVerificationResult } from '../core/parsing.js';
 import { loadRows, loadMetadata, todayIso } from './io.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -287,10 +288,25 @@ export async function callProvider(provider, systemPrompt, userPrompt) {
     }
 }
 
-// Shim helper: parse the raw response text into the verdict shape and
-// attach the usage object captured by core/providers.js.
-function shapeResult({ text, usage }) {
-    return { ...parseResponse(text), usage };
+// Shim helper: parse the raw response text into the benchmark's verdict
+// shape and attach the usage object captured by core/providers.js.
+//
+// Verdict parsing is delegated to core/parsing.js (single source of truth
+// shared with main.js + cli/verify.js). The runner then post-processes the
+// core parser's output: title-cases the verdict via the benchmark-local
+// normalizeVerdict ('SUPPORTED' → 'Supported') for results.json schema
+// compatibility, defaults missing confidence to 0 (the benchmark's
+// historical default; core returns null), and stitches in raw_response /
+// usage for downstream analysis.
+export function shapeResult({ text, usage }) {
+    const parsed = parseVerificationResult(text);
+    return {
+        verdict: normalizeVerdict(parsed.verdict),
+        confidence: parsed.confidence ?? 0,
+        comments: parsed.comments,
+        raw_response: text,
+        usage,
+    };
 }
 
 // Benchmark-side knobs preserved verbatim from the pre-consolidation runner.
@@ -391,46 +407,11 @@ async function callHuggingFace(config, systemPrompt, userPrompt) {
 }
 
 /**
- * Parse LLM response to extract verdict
- */
-function parseResponse(content) {
-    // Try to extract JSON from response
-    let jsonStr = content;
-
-    // Handle markdown code blocks
-    const jsonMatch = content.match(/```(?:json)?\s*([\s\S]*?)```/);
-    if (jsonMatch) {
-        jsonStr = jsonMatch[1];
-    }
-
-    // Try to find JSON object
-    const objMatch = jsonStr.match(/\{[\s\S]*\}/);
-    if (objMatch) {
-        jsonStr = objMatch[0];
-    }
-
-    try {
-        const parsed = JSON.parse(jsonStr);
-        return {
-            verdict: normalizeVerdict(parsed.verdict || ''),
-            confidence: parsed.confidence || 0,
-            comments: parsed.comments || '',
-            raw_response: content
-        };
-    } catch (e) {
-        // Fallback: try to extract verdict from text
-        const verdictMatch = content.match(/verdict["\s:]+([A-Z_ ]+)/i);
-        return {
-            verdict: verdictMatch ? normalizeVerdict(verdictMatch[1]) : 'PARSE_ERROR',
-            confidence: 0,
-            comments: 'Failed to parse JSON response',
-            raw_response: content
-        };
-    }
-}
-
-/**
- * Normalize verdict string
+ * Normalize verdict string to the benchmark's title-case categories.
+ * Kept local to the runner because the benchmark's results.json schema
+ * stores verdicts as 'Supported' / 'Not supported' / ... while the
+ * userscript and CLI consume the canonical UPPERCASE form returned by
+ * core/parsing.js. shapeResult bridges the two.
  */
 function normalizeVerdict(verdict) {
     const v = verdict.toUpperCase().trim();

--- a/cli/verify.js
+++ b/cli/verify.js
@@ -347,7 +347,7 @@ export async function runVerify(opts, { stdout = process.stdout, stderr = proces
 
     // 10. Parse the verdict.
     const verdict = parseVerificationResult(providerResult.text);
-    if (verdict.verdict === 'ERROR') {
+    if (verdict.verdict === 'PARSE_ERROR') {
         stderr.write(`ccs: LLM returned malformed JSON. Raw (first 200 chars): ${providerResult.text.slice(0, 200)}\n`);
         return 11;
     }

--- a/core/parsing.js
+++ b/core/parsing.js
@@ -1,21 +1,40 @@
 // Parses raw LLM response text into a structured verdict object.
+//
+// Happy path: JSON, optionally inside a ```json code fence or surrounded by
+// prose. Falls back to a markdown-emphasis recovery regex for small
+// open-weight models (e.g. Granite 4.1 8B) that occasionally emit
+// "**Verdict:** SUPPORTED" prose instead of the requested JSON. On total
+// failure, returns the 'PARSE_ERROR' sentinel — chosen to match what the
+// benchmark already records for unrecoverable responses.
+
+const FALLBACK_VERDICT_PATTERNS = [
+    { prefix: 'NOT SUPPORTED',      canonical: 'NOT SUPPORTED' },
+    { prefix: 'PARTIALLY',          canonical: 'PARTIALLY SUPPORTED' },
+    { prefix: 'SOURCE UNAVAILABLE', canonical: 'SOURCE UNAVAILABLE' },
+    { prefix: 'UNAVAILABLE',        canonical: 'SOURCE UNAVAILABLE' },
+    { prefix: 'SUPPORTED',          canonical: 'SUPPORTED' },
+];
+
+function canonicalizeFallbackVerdict(raw) {
+    const v = raw.toUpperCase().replace(/_/g, ' ').replace(/\s+/g, ' ').trim();
+    for (const { prefix, canonical } of FALLBACK_VERDICT_PATTERNS) {
+        if (v.startsWith(prefix)) return canonical;
+    }
+    return null;
+}
 
 export function parseVerificationResult(response) {
-    try {
-        let jsonStr = response.trim();
+    const trimmed = response.trim();
 
+    try {
+        let jsonStr = trimmed;
         const codeBlockMatch = jsonStr.match(/```(?:json)?\s*([\s\S]*?)\s*```/);
         if (codeBlockMatch) {
             jsonStr = codeBlockMatch[1].trim();
-        }
-
-        if (!codeBlockMatch) {
+        } else {
             const jsonMatch = jsonStr.match(/\{[\s\S]*\}/);
-            if (jsonMatch) {
-                jsonStr = jsonMatch[0];
-            }
+            if (jsonMatch) jsonStr = jsonMatch[0];
         }
-
         const result = JSON.parse(jsonStr);
         return {
             verdict: result.verdict || 'UNKNOWN',
@@ -23,6 +42,23 @@ export function parseVerificationResult(response) {
             comments: result.comments || ''
         };
     } catch (e) {
-        return { verdict: 'ERROR', confidence: null, comments: `Failed to parse AI response: ${response.substring(0, 200)}` };
+        // fall through to the markdown-emphasis recovery
     }
+
+    // Strip "**" and "__"-style emphasis so e.g. "**Verdict:** SUPPORTED"
+    // becomes "Verdict: SUPPORTED", then capture the canonical word(s).
+    const stripped = trimmed.replace(/\*+|__+/g, '');
+    const match = stripped.match(/verdict[\s:"']+([A-Z][A-Z _]*)/i);
+    if (match) {
+        const verdict = canonicalizeFallbackVerdict(match[1]);
+        if (verdict) {
+            return { verdict, confidence: null, comments: '<extracted from non-JSON response>' };
+        }
+    }
+
+    return {
+        verdict: 'PARSE_ERROR',
+        confidence: null,
+        comments: `Failed to parse AI response: ${response.substring(0, 200)}`
+    };
 }

--- a/main.js
+++ b/main.js
@@ -131,23 +131,42 @@ ${sourceText}`;
 
 // --- core/parsing.js ---
 // Parses raw LLM response text into a structured verdict object.
+//
+// Happy path: JSON, optionally inside a ```json code fence or surrounded by
+// prose. Falls back to a markdown-emphasis recovery regex for small
+// open-weight models (e.g. Granite 4.1 8B) that occasionally emit
+// "**Verdict:** SUPPORTED" prose instead of the requested JSON. On total
+// failure, returns the 'PARSE_ERROR' sentinel — chosen to match what the
+// benchmark already records for unrecoverable responses.
+
+const FALLBACK_VERDICT_PATTERNS = [
+    { prefix: 'NOT SUPPORTED',      canonical: 'NOT SUPPORTED' },
+    { prefix: 'PARTIALLY',          canonical: 'PARTIALLY SUPPORTED' },
+    { prefix: 'SOURCE UNAVAILABLE', canonical: 'SOURCE UNAVAILABLE' },
+    { prefix: 'UNAVAILABLE',        canonical: 'SOURCE UNAVAILABLE' },
+    { prefix: 'SUPPORTED',          canonical: 'SUPPORTED' },
+];
+
+function canonicalizeFallbackVerdict(raw) {
+    const v = raw.toUpperCase().replace(/_/g, ' ').replace(/\s+/g, ' ').trim();
+    for (const { prefix, canonical } of FALLBACK_VERDICT_PATTERNS) {
+        if (v.startsWith(prefix)) return canonical;
+    }
+    return null;
+}
 
 function parseVerificationResult(response) {
-    try {
-        let jsonStr = response.trim();
+    const trimmed = response.trim();
 
+    try {
+        let jsonStr = trimmed;
         const codeBlockMatch = jsonStr.match(/```(?:json)?\s*([\s\S]*?)\s*```/);
         if (codeBlockMatch) {
             jsonStr = codeBlockMatch[1].trim();
-        }
-
-        if (!codeBlockMatch) {
+        } else {
             const jsonMatch = jsonStr.match(/\{[\s\S]*\}/);
-            if (jsonMatch) {
-                jsonStr = jsonMatch[0];
-            }
+            if (jsonMatch) jsonStr = jsonMatch[0];
         }
-
         const result = JSON.parse(jsonStr);
         return {
             verdict: result.verdict || 'UNKNOWN',
@@ -155,8 +174,25 @@ function parseVerificationResult(response) {
             comments: result.comments || ''
         };
     } catch (e) {
-        return { verdict: 'ERROR', confidence: null, comments: `Failed to parse AI response: ${response.substring(0, 200)}` };
+        // fall through to the markdown-emphasis recovery
     }
+
+    // Strip "**" and "__"-style emphasis so e.g. "**Verdict:** SUPPORTED"
+    // becomes "Verdict: SUPPORTED", then capture the canonical word(s).
+    const stripped = trimmed.replace(/\*+|__+/g, '');
+    const match = stripped.match(/verdict[\s:"']+([A-Z][A-Z _]*)/i);
+    if (match) {
+        const verdict = canonicalizeFallbackVerdict(match[1]);
+        if (verdict) {
+            return { verdict, confidence: null, comments: '<extracted from non-JSON response>' };
+        }
+    }
+
+    return {
+        verdict: 'PARSE_ERROR',
+        confidence: null,
+        comments: `Failed to parse AI response: ${response.substring(0, 200)}`
+    };
 }
 
 // --- core/urls.js ---
@@ -2713,7 +2749,7 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
 	        verdictEl.classList.add('partially-supported');
 	    } else if (result.verdict === 'NOT SUPPORTED') {
 	        verdictEl.classList.add('not-supported');
-	    } else if (result.verdict === 'SOURCE UNAVAILABLE' || result.verdict === 'ERROR') {
+	    } else if (result.verdict === 'SOURCE UNAVAILABLE' || result.verdict === 'PARSE_ERROR') {
 	        verdictEl.classList.add('source-unavailable');
 	    }
 

--- a/tests/benchmark_runner.test.js
+++ b/tests/benchmark_runner.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-import { runPool, withRetry, makeSaver, hostForProvider } from '../benchmark/run_benchmark.js';
+import { runPool, withRetry, makeSaver, hostForProvider, shapeResult } from '../benchmark/run_benchmark.js';
 
 // ---- runPool ----------------------------------------------------------------
 
@@ -259,4 +259,31 @@ test('hostForProvider: real PROVIDERS — PublicAI models share one host', () =>
 test('hostForProvider: Anthropic and Gemini are independent hosts', () => {
     assert.equal(hostForProvider('claude-sonnet-4-5'), 'api.anthropic.com');
     assert.equal(hostForProvider('gemini-2.5-flash'), 'generativelanguage.googleapis.com');
+});
+
+// ---- shapeResult (parse delegation to core/parsing.js) ----------------------
+// Behavioral wiring tests — full parser coverage lives in tests/parsing.test.js.
+
+test('shapeResult: delegates JSON parsing to core and title-cases the verdict', () => {
+    const text = JSON.stringify({ verdict: 'SUPPORTED', confidence: 90, comments: 'ok' });
+    const out = shapeResult({ text, usage: { input: 10, output: 5, cost_usd: null } });
+    assert.equal(out.verdict, 'Supported');
+    assert.equal(out.confidence, 90);
+    assert.equal(out.raw_response, text);
+    assert.deepEqual(out.usage, { input: 10, output: 5, cost_usd: null });
+});
+
+test('shapeResult: recovers verdict from the Granite-style markdown fallback', () => {
+    // Regression guard: pre-consolidation, the benchmark's local regex
+    // (/verdict["\s:]+([A-Z_ ]+)/i) could not advance past "**" in
+    // "**Verdict:** SUPPORTED". The shared parser now strips emphasis first.
+    const text = '**Verdict:** SUPPORTED\n**Comments:** matches the source.';
+    const out = shapeResult({ text, usage: null });
+    assert.equal(out.verdict, 'Supported');
+});
+
+test('shapeResult: returns PARSE_ERROR sentinel on unrecoverable prose', () => {
+    const out = shapeResult({ text: 'I cannot determine this.', usage: null });
+    assert.equal(out.verdict, 'PARSE_ERROR');
+    assert.equal(out.confidence, 0);
 });

--- a/tests/parsing.test.js
+++ b/tests/parsing.test.js
@@ -15,9 +15,66 @@ test('parses JSON inside ```json code fence', () => {
   assert.equal(out.verdict, 'NOT SUPPORTED');
 });
 
-test('throws or returns error shape on malformed input', () => {
-  const out = parseVerificationResult('not json at all');
-  assert.equal(out.verdict, 'ERROR');
+test('parses JSON surrounded by prose (legacy {...} extraction)', () => {
+  const raw = 'Here is my answer:\n{"verdict":"SUPPORTED","confidence":80,"comments":"matches"}\nThanks.';
+  const out = parseVerificationResult(raw);
+  assert.equal(out.verdict, 'SUPPORTED');
+  assert.equal(out.confidence, 80);
+});
+
+test('recovers verdict from Granite-style **Verdict:** SUPPORTED prose', () => {
+  const raw = `**Step-by-step verification**
+
+1. **Identify the claim's specific assertions**
+   - …
+
+2. **Locate the relevant passage in the article body**
+   > "…"
+
+**Verdict:** SUPPORTED
+**Comments:** "…" Both the date and the founder match.
+`;
+  const out = parseVerificationResult(raw);
+  assert.equal(out.verdict, 'SUPPORTED');
   assert.equal(out.confidence, null);
-  assert.ok(out.comments.includes('Failed to parse'));
+  assert.match(out.comments, /non-JSON/);
+});
+
+test('fallback recovery is case-insensitive on the "verdict" keyword (lowercase)', () => {
+  const raw = '**verdict:** SUPPORTED\n**comments:** ok';
+  const out = parseVerificationResult(raw);
+  assert.equal(out.verdict, 'SUPPORTED');
+});
+
+test('fallback recovery is case-insensitive on the "verdict" keyword (uppercase)', () => {
+  const raw = '**VERDICT:** SUPPORTED\n**COMMENTS:** ok';
+  const out = parseVerificationResult(raw);
+  assert.equal(out.verdict, 'SUPPORTED');
+});
+
+test('fallback preserves two-word verdict (NOT SUPPORTED)', () => {
+  const raw = `**Verdict:** NOT SUPPORTED
+**Comments:** The source contradicts the claim.`;
+  const out = parseVerificationResult(raw);
+  assert.equal(out.verdict, 'NOT SUPPORTED');
+});
+
+test('fallback preserves PARTIALLY SUPPORTED', () => {
+  const raw = '**Verdict:** PARTIALLY SUPPORTED\nReasoning: hedged.';
+  const out = parseVerificationResult(raw);
+  assert.equal(out.verdict, 'PARTIALLY SUPPORTED');
+});
+
+test('returns PARSE_ERROR sentinel on pure prose with no verdict marker', () => {
+  const out = parseVerificationResult('I cannot determine whether this claim is accurate.');
+  assert.equal(out.verdict, 'PARSE_ERROR');
+  assert.equal(out.confidence, null);
+  assert.match(out.comments, /Failed to parse/);
+});
+
+test('returns PARSE_ERROR sentinel on completely malformed input', () => {
+  const out = parseVerificationResult('not json at all');
+  assert.equal(out.verdict, 'PARSE_ERROR');
+  assert.equal(out.confidence, null);
+  assert.match(out.comments, /Failed to parse/);
 });


### PR DESCRIPTION
## Why

Two implementations of "parse a verdict response from the LLM" had drifted in this repo:

1. **`core/parsing.js` `parseVerificationResult`** — canonical location, inlined into `main.js` via `scripts/sync-main.js`, also called by `cli/verify.js`. JSON-only; on parse failure returned `{verdict: 'ERROR', ...}`. No recovery.
2. **`benchmark/run_benchmark.js` `parseResponse`** — its own JSON-extraction logic *plus* a fallback regex `/verdict["\s:]+([A-Z_ ]+)/i`. On parse failure returned `{verdict: 'PARSE_ERROR', ...}`.

Per the project's single-source-of-truth pattern (precedent: #195 `core/compare`, #203 `core/prompts`), the benchmark should be importing from `core/`, not maintaining a divergent copy.

## The failure mode this consolidation fixes

Small open-weight models — **Granite 4.1 8B** specifically — sometimes emit markdown-formatted reasoning instead of the requested JSON:

```
**Step-by-step verification**

1. **Identify the claim's specific assertions**
   - …

**Verdict:** SUPPORTED
**Comments:** "…" Both the date and the founder match.
```

`JSON.parse` fails (no `{…}`). The benchmark's existing fallback regex `/verdict["\s:]+([A-Z_ ]+)/i` *also* fails because after the `:` in `**Verdict:**` comes `**`, and `*` isn't in the `["\s:]` character class — the regex can't advance to the verdict word.

**Empirical impact:** in a 181-row × 9-provider benchmark run, Granite produced 21 of these parse failures (11.6%, vs 0.6% on a prior prompt). Tightening the recovery reclaims the bulk of them; expected post-fix parse-error rate is ~1%.

## What changes

### `core/parsing.js`

- `parseVerificationResult(response)` stays the single export.
- After JSON.parse fails (post code-fence and `{…}` extraction), strip markdown emphasis (`*+` and `__+`) and run a tolerant regex `/verdict[\s:"']+([A-Z][A-Z _]*)/i`.
- A private `canonicalizeFallbackVerdict` maps the captured word(s) to the prompt's UPPERCASE canonical form (`SUPPORTED` / `NOT SUPPORTED` / `PARTIALLY SUPPORTED` / `SOURCE UNAVAILABLE`).
- Sentinel verdict on total failure is now `'PARSE_ERROR'` (was `'ERROR'`) — matches the benchmark's existing convention.

### `benchmark/run_benchmark.js`

- Imports `parseVerificationResult` from `../core/parsing.js`.
- Deletes the local JSON-extraction + fallback regex (`parseResponse`).
- `shapeResult` (now exported for testability) wraps the core parser, applies the benchmark-local title-case `normalizeVerdict` (`'SUPPORTED'` → `'Supported'`) for results.json schema compatibility, defaults missing confidence to 0, and attaches `raw_response` / `usage`.
- `normalizeVerdict` stays local to the runner — the benchmark's results.json stores title-case, while the userscript and CLI consume UPPERCASE.

### Why not lift `normalizeVerdict` into `core/`?

Considered it (and the task description suggested it as the likely call). The blocker is casing: the userscript expects UPPERCASE verdicts (`if (result.verdict === 'SUPPORTED')` etc.), the benchmark's results.json stores title case. Putting one normalization in `core/` would force one of those formats to change. Keeping the title-case mapping in the benchmark runner — and letting `shapeResult` bridge — is the smaller, lower-risk move and preserves the existing results.json schema. The core parser returns the prompt-canonical UPPERCASE form, which both consumers can adapt to as needed.

### Caller updates for the sentinel rename

`'ERROR'` → `'PARSE_ERROR'` for the *parse-failure* sentinel only:

- `cli/verify.js:350` — `if (verdict.verdict === 'PARSE_ERROR')` (exit code 11).
- `main.js:2716` (displayResult) — `result.verdict === 'PARSE_ERROR'` case in the verdict-styling switch.
- `main.js` is re-synced via `npm run build`, so the inlined parser picks up `'PARSE_ERROR'` automatically.

**Kept as `'ERROR'` (intentionally):**
- `main.js:3457` — synthetic verdict from the report-card API-call catch. That's a transport failure, not a parse failure; matches `benchmark/run_benchmark.js`'s `callProvider` API-error sentinel and `compare_results.js`'s `'ERROR'` skip filter.
- `main.js:2669` — DOM `textContent = 'ERROR'` in the catch path; pure UI string.

## Tests

`tests/parsing.test.js` (7 new + 1 updated):

- Bare JSON parses correctly (regression guard).
- Code-fenced JSON parses correctly.
- JSON surrounded by prose still extracted by legacy `{…}` matcher.
- Granite-style `**Verdict:** SUPPORTED` recovers as `SUPPORTED`.
- Recovery is case-insensitive on the `verdict` keyword: `**verdict:**` and `**VERDICT:**` both work.
- Two-word verdict `**Verdict:** NOT SUPPORTED` preserved.
- `**Verdict:** PARTIALLY SUPPORTED` preserved.
- Pure prose with no verdict marker → `PARSE_ERROR` sentinel.
- Completely malformed input → `PARSE_ERROR` sentinel.

`tests/benchmark_runner.test.js` (3 new wiring smoke tests, no duplication with `parsing.test.js`):

- `shapeResult` title-cases the core parser's output and forwards `raw_response` / `usage`.
- `shapeResult` recovers the Granite markdown case end-to-end (the regression that motivated this PR).
- `shapeResult` returns `PARSE_ERROR` with `confidence: 0` on unrecoverable prose.

## Acceptance

- [x] `npm test` — 229/229 passing (was 219; +10 cases).
- [x] `npm run build -- --check` — `main.js` in sync with `core/`.
- [x] Single commit.
- [ ] Benchmark rerun — out of scope for this PR (the spec calls it out as a separate measurement); this change is verifiable from unit tests alone.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SVeBUGGSgh3ViAT2cRtMcM)_