### PR TITLE
Consolidate verdict canonicalization into core/verdicts.js

### DIFF
--- a/benchmark/analyze_results.js
+++ b/benchmark/analyze_results.js
@@ -23,6 +23,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { dirname } from 'path';
 import { loadRows } from './io.js';
+import { canonicalizeVerdict, toTitleCase, VERDICT_LIST } from '../core/verdicts.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -44,20 +45,19 @@ const RESULTS_PATH = path.resolve(__dirname, flagValue('--results') || 'results.
 const DATASET_PATH = path.resolve(__dirname, flagValue('--dataset') || 'dataset.json');
 const ANALYSIS_PATH = path.resolve(__dirname, flagValue('--analysis') || 'analysis.json');
 
-// Verdict categories for confusion matrix
-const VERDICT_CATEGORIES = ['Supported', 'Partially supported', 'Not supported', 'Source unavailable'];
+// Confusion-matrix categories — title-cased mirror of core's VERDICT_LIST.
+const VERDICT_CATEGORIES = VERDICT_LIST.map(toTitleCase);
 
-/**
- * Normalize verdict to standard categories
- */
+// Map any verdict-shaped value to the title-case category used in the
+// confusion matrix and accuracy metrics. Inputs the shared canonicalizer
+// rejects fall through to 'Error' (for the 'PARSE_ERROR' / 'ERROR'
+// sentinels emitted by core/parsing.js and benchmark/run_benchmark.js's
+// API-failure path) or 'Unknown' (for empty / unrecognized values).
 function normalizeVerdict(verdict) {
-    if (!verdict) return 'Unknown';
-    const v = verdict.toLowerCase().trim();
-    if (v.includes('not supported') || v.includes('not_supported')) return 'Not supported';
-    if (v.includes('partially')) return 'Partially supported';
-    if (v.includes('unavailable')) return 'Source unavailable';
-    if (v.includes('supported')) return 'Supported';
-    if (v.includes('error')) return 'Error';
+    const canonical = canonicalizeVerdict(verdict);
+    if (canonical) return toTitleCase(canonical);
+    if (verdict == null || !String(verdict).trim()) return 'Unknown';
+    if (String(verdict).toLowerCase().includes('error')) return 'Error';
     return 'Unknown';
 }
 

--- a/benchmark/compare_results.js
+++ b/benchmark/compare_results.js
@@ -1,15 +1,14 @@
+import { canonicalizeVerdict, toShortCode } from '../core/verdicts.js';
+
 /**
  * Normalize a verdict string to its canonical short form.
  * Returns one of: 'support' | 'partial' | 'not' | 'unavailable' | <other-lowercased>.
  * Handles null/undefined and case/whitespace variations.
  */
 export function normalizeVerdict(v) {
-    const s = String(v ?? '').toLowerCase().trim();
-    if (s.includes('partial')) return 'partial';
-    if (s.includes('not support') || s.includes('not-support') || s.includes('not_support')) return 'not';
-    if (s.includes('support')) return 'support';
-    if (s.includes('unavailable')) return 'unavailable';
-    return s;
+    const canonical = canonicalizeVerdict(v);
+    if (canonical) return toShortCode(canonical);
+    return String(v ?? '').toLowerCase().trim();
 }
 
 export function verdictsEqualExact(a, b) {

--- a/benchmark/extract_dataset.js
+++ b/benchmark/extract_dataset.js
@@ -27,6 +27,7 @@ import { JSDOM } from 'jsdom';
 import { fileURLToPath } from 'url';
 import { dirname } from 'path';
 import { extractClaimText as extractClaimTextFromRef } from '../core/claim.js';
+import { canonicalizeVerdict, toTitleCase } from '../core/verdicts.js';
 import { writeWithMetadata, todayIso } from './io.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -294,15 +295,14 @@ function sleep(ms) {
 }
 
 /**
- * Normalize ground truth values
+ * Normalize ground-truth values from the CSV. Returns title case for any
+ * recognized verdict; unrecognized input passes through unchanged so that
+ * dataset extraction surfaces unexpected GT values visibly rather than
+ * silently coercing them.
  */
 function normalizeVerdict(verdict) {
-    const v = verdict.toLowerCase().trim();
-    if (v.includes('not supported') || v === 'not_supported') return 'Not supported';
-    if (v.includes('partially')) return 'Partially supported';
-    if (v.includes('supported')) return 'Supported';
-    if (v.includes('unavailable')) return 'Source unavailable';
-    return verdict;
+    const canonical = canonicalizeVerdict(verdict);
+    return canonical ? toTitleCase(canonical) : verdict;
 }
 
 /**

--- a/benchmark/run_benchmark.js
+++ b/benchmark/run_benchmark.js
@@ -28,6 +28,7 @@ import {
     callHuggingFaceAPI,
 } from '../core/providers.js';
 import { parseVerificationResult } from '../core/parsing.js';
+import { canonicalizeVerdict, toTitleCase } from '../core/verdicts.js';
 import { loadRows, loadMetadata, todayIso } from './io.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -406,20 +407,15 @@ async function callHuggingFace(config, systemPrompt, userPrompt) {
     }));
 }
 
-/**
- * Normalize verdict string to the benchmark's title-case categories.
- * Kept local to the runner because the benchmark's results.json schema
- * stores verdicts as 'Supported' / 'Not supported' / ... while the
- * userscript and CLI consume the canonical UPPERCASE form returned by
- * core/parsing.js. shapeResult bridges the two.
- */
+// Title-case the canonical verdict for the benchmark's results.json schema,
+// preserving the runner's historical 'PARSE_ERROR' fallback for inputs the
+// shared canonicalizer doesn't recognize (e.g. the 'UNKNOWN' / 'PARSE_ERROR'
+// sentinels emitted by core/parsing.js, or a raw LLM string like 'options'
+// that the pre-1a12753 code would have silently propagated as a predicted
+// verdict — see the commit for the rationale).
 function normalizeVerdict(verdict) {
-    const v = verdict.toUpperCase().trim();
-    if (v.includes('NOT SUPPORTED') || v.includes('NOT_SUPPORTED')) return 'Not supported';
-    if (v.includes('PARTIALLY')) return 'Partially supported';
-    if (v.includes('UNAVAILABLE')) return 'Source unavailable';
-    if (v.includes('SUPPORTED')) return 'Supported';
-    return 'PARSE_ERROR';
+    const canonical = canonicalizeVerdict(verdict);
+    return canonical ? toTitleCase(canonical) : 'PARSE_ERROR';
 }
 
 /**

--- a/core/parsing.js
+++ b/core/parsing.js
@@ -7,21 +7,7 @@
 // failure, returns the 'PARSE_ERROR' sentinel — chosen to match what the
 // benchmark already records for unrecoverable responses.
 
-const FALLBACK_VERDICT_PATTERNS = [
-    { prefix: 'NOT SUPPORTED',      canonical: 'NOT SUPPORTED' },
-    { prefix: 'PARTIALLY',          canonical: 'PARTIALLY SUPPORTED' },
-    { prefix: 'SOURCE UNAVAILABLE', canonical: 'SOURCE UNAVAILABLE' },
-    { prefix: 'UNAVAILABLE',        canonical: 'SOURCE UNAVAILABLE' },
-    { prefix: 'SUPPORTED',          canonical: 'SUPPORTED' },
-];
-
-function canonicalizeFallbackVerdict(raw) {
-    const v = raw.toUpperCase().replace(/_/g, ' ').replace(/\s+/g, ' ').trim();
-    for (const { prefix, canonical } of FALLBACK_VERDICT_PATTERNS) {
-        if (v.startsWith(prefix)) return canonical;
-    }
-    return null;
-}
+import { canonicalizeVerdict } from './verdicts.js';
 
 export function parseVerificationResult(response) {
     const trimmed = response.trim();
@@ -50,7 +36,7 @@ export function parseVerificationResult(response) {
     const stripped = trimmed.replace(/\*+|__+/g, '');
     const match = stripped.match(/verdict[\s:"']+([A-Z][A-Z _]*)/i);
     if (match) {
-        const verdict = canonicalizeFallbackVerdict(match[1]);
+        const verdict = canonicalizeVerdict(match[1]);
         if (verdict) {
             return { verdict, confidence: null, comments: '<extracted from non-JSON response>' };
         }

--- a/core/verdicts.js
+++ b/core/verdicts.js
@@ -1,0 +1,70 @@
+// Single source of truth for the four canonical verdict categories and
+// the case/short-form conversions that the userscript, CLI, and benchmark
+// pipeline each consume. Pre-consolidation, normalizeVerdict was
+// reimplemented separately in run_benchmark.js, analyze_results.js,
+// compare_results.js, and extract_dataset.js — each with a different
+// return-value shape and a different fallback for unrecognized input.
+// This module centralizes the recognition logic; callers compose it with
+// the presenter that matches their downstream schema.
+
+// Canonical UPPERCASE form. Matches the prompt's verdict spec and the
+// userscript's existing inline comparisons.
+export const VERDICTS = Object.freeze({
+    SUPPORTED:           'SUPPORTED',
+    PARTIALLY_SUPPORTED: 'PARTIALLY SUPPORTED',
+    NOT_SUPPORTED:       'NOT SUPPORTED',
+    SOURCE_UNAVAILABLE:  'SOURCE UNAVAILABLE',
+});
+
+// Ordered by the confidence guide in core/prompts.js. Confusion-matrix
+// rows/columns in analyze_results.js iterate this list.
+export const VERDICT_LIST = Object.freeze([
+    VERDICTS.SUPPORTED,
+    VERDICTS.PARTIALLY_SUPPORTED,
+    VERDICTS.NOT_SUPPORTED,
+    VERDICTS.SOURCE_UNAVAILABLE,
+]);
+
+// Map any reasonable variant ('not_supported', 'Not Supported', 'PARTIALLY',
+// 'unavailable', 'partial', ...) to one of the four canonical UPPERCASE
+// values. Returns null for unrecognized input — callers decide whether to
+// substitute a sentinel, pass through, or treat as 'Unknown'.
+export function canonicalizeVerdict(raw) {
+    if (raw == null) return null;
+    const v = String(raw).toUpperCase().replace(/_/g, ' ').replace(/\s+/g, ' ').trim();
+    if (!v) return null;
+    // NOT-prefix matches both 'NOT' (compare_results short code) and
+    // 'NOT SUPPORTED'. Order doesn't matter for correctness here because
+    // the canonical forms start with distinct letters; the ordering below
+    // mirrors the historical order in run_benchmark.js for readability.
+    if (v.startsWith('NOT'))     return VERDICTS.NOT_SUPPORTED;
+    if (v.startsWith('PARTIAL')) return VERDICTS.PARTIALLY_SUPPORTED;
+    if (v.startsWith('UNAVAIL')) return VERDICTS.SOURCE_UNAVAILABLE;
+    if (v.startsWith('SOURCE'))  return VERDICTS.SOURCE_UNAVAILABLE;
+    if (v.startsWith('SUPPORT')) return VERDICTS.SUPPORTED;
+    return null;
+}
+
+// Presenter: canonical UPPERCASE -> title case ('Supported', 'Not supported', ...).
+// Used by benchmark results.json schema and analyze_results.js's confusion matrix.
+const TITLE_CASE = Object.freeze({
+    [VERDICTS.SUPPORTED]:           'Supported',
+    [VERDICTS.PARTIALLY_SUPPORTED]: 'Partially supported',
+    [VERDICTS.NOT_SUPPORTED]:       'Not supported',
+    [VERDICTS.SOURCE_UNAVAILABLE]:  'Source unavailable',
+});
+export function toTitleCase(canonical) {
+    return TITLE_CASE[canonical] ?? canonical;
+}
+
+// Presenter: canonical UPPERCASE -> short lowercase code ('support', 'not', ...).
+// Used by compare_results.js for run-vs-run comparison.
+const SHORT_CODE = Object.freeze({
+    [VERDICTS.SUPPORTED]:           'support',
+    [VERDICTS.PARTIALLY_SUPPORTED]: 'partial',
+    [VERDICTS.NOT_SUPPORTED]:       'not',
+    [VERDICTS.SOURCE_UNAVAILABLE]:  'unavailable',
+});
+export function toShortCode(canonical) {
+    return SHORT_CODE[canonical] ?? canonical;
+}

--- a/main.js
+++ b/main.js
@@ -129,6 +129,78 @@ Source text:
 ${sourceText}`;
 }
 
+// --- core/verdicts.js ---
+// Single source of truth for the four canonical verdict categories and
+// the case/short-form conversions that the userscript, CLI, and benchmark
+// pipeline each consume. Pre-consolidation, normalizeVerdict was
+// reimplemented separately in run_benchmark.js, analyze_results.js,
+// compare_results.js, and extract_dataset.js — each with a different
+// return-value shape and a different fallback for unrecognized input.
+// This module centralizes the recognition logic; callers compose it with
+// the presenter that matches their downstream schema.
+
+// Canonical UPPERCASE form. Matches the prompt's verdict spec and the
+// userscript's existing inline comparisons.
+const VERDICTS = Object.freeze({
+    SUPPORTED:           'SUPPORTED',
+    PARTIALLY_SUPPORTED: 'PARTIALLY SUPPORTED',
+    NOT_SUPPORTED:       'NOT SUPPORTED',
+    SOURCE_UNAVAILABLE:  'SOURCE UNAVAILABLE',
+});
+
+// Ordered by the confidence guide in core/prompts.js. Confusion-matrix
+// rows/columns in analyze_results.js iterate this list.
+const VERDICT_LIST = Object.freeze([
+    VERDICTS.SUPPORTED,
+    VERDICTS.PARTIALLY_SUPPORTED,
+    VERDICTS.NOT_SUPPORTED,
+    VERDICTS.SOURCE_UNAVAILABLE,
+]);
+
+// Map any reasonable variant ('not_supported', 'Not Supported', 'PARTIALLY',
+// 'unavailable', 'partial', ...) to one of the four canonical UPPERCASE
+// values. Returns null for unrecognized input — callers decide whether to
+// substitute a sentinel, pass through, or treat as 'Unknown'.
+function canonicalizeVerdict(raw) {
+    if (raw == null) return null;
+    const v = String(raw).toUpperCase().replace(/_/g, ' ').replace(/\s+/g, ' ').trim();
+    if (!v) return null;
+    // NOT-prefix matches both 'NOT' (compare_results short code) and
+    // 'NOT SUPPORTED'. Order doesn't matter for correctness here because
+    // the canonical forms start with distinct letters; the ordering below
+    // mirrors the historical order in run_benchmark.js for readability.
+    if (v.startsWith('NOT'))     return VERDICTS.NOT_SUPPORTED;
+    if (v.startsWith('PARTIAL')) return VERDICTS.PARTIALLY_SUPPORTED;
+    if (v.startsWith('UNAVAIL')) return VERDICTS.SOURCE_UNAVAILABLE;
+    if (v.startsWith('SOURCE'))  return VERDICTS.SOURCE_UNAVAILABLE;
+    if (v.startsWith('SUPPORT')) return VERDICTS.SUPPORTED;
+    return null;
+}
+
+// Presenter: canonical UPPERCASE -> title case ('Supported', 'Not supported', ...).
+// Used by benchmark results.json schema and analyze_results.js's confusion matrix.
+const TITLE_CASE = Object.freeze({
+    [VERDICTS.SUPPORTED]:           'Supported',
+    [VERDICTS.PARTIALLY_SUPPORTED]: 'Partially supported',
+    [VERDICTS.NOT_SUPPORTED]:       'Not supported',
+    [VERDICTS.SOURCE_UNAVAILABLE]:  'Source unavailable',
+});
+function toTitleCase(canonical) {
+    return TITLE_CASE[canonical] ?? canonical;
+}
+
+// Presenter: canonical UPPERCASE -> short lowercase code ('support', 'not', ...).
+// Used by compare_results.js for run-vs-run comparison.
+const SHORT_CODE = Object.freeze({
+    [VERDICTS.SUPPORTED]:           'support',
+    [VERDICTS.PARTIALLY_SUPPORTED]: 'partial',
+    [VERDICTS.NOT_SUPPORTED]:       'not',
+    [VERDICTS.SOURCE_UNAVAILABLE]:  'unavailable',
+});
+function toShortCode(canonical) {
+    return SHORT_CODE[canonical] ?? canonical;
+}
+
 // --- core/parsing.js ---
 // Parses raw LLM response text into a structured verdict object.
 //
@@ -139,21 +211,6 @@ ${sourceText}`;
 // failure, returns the 'PARSE_ERROR' sentinel — chosen to match what the
 // benchmark already records for unrecoverable responses.
 
-const FALLBACK_VERDICT_PATTERNS = [
-    { prefix: 'NOT SUPPORTED',      canonical: 'NOT SUPPORTED' },
-    { prefix: 'PARTIALLY',          canonical: 'PARTIALLY SUPPORTED' },
-    { prefix: 'SOURCE UNAVAILABLE', canonical: 'SOURCE UNAVAILABLE' },
-    { prefix: 'UNAVAILABLE',        canonical: 'SOURCE UNAVAILABLE' },
-    { prefix: 'SUPPORTED',          canonical: 'SUPPORTED' },
-];
-
-function canonicalizeFallbackVerdict(raw) {
-    const v = raw.toUpperCase().replace(/_/g, ' ').replace(/\s+/g, ' ').trim();
-    for (const { prefix, canonical } of FALLBACK_VERDICT_PATTERNS) {
-        if (v.startsWith(prefix)) return canonical;
-    }
-    return null;
-}
 
 function parseVerificationResult(response) {
     const trimmed = response.trim();
@@ -182,7 +239,7 @@ function parseVerificationResult(response) {
     const stripped = trimmed.replace(/\*+|__+/g, '');
     const match = stripped.match(/verdict[\s:"']+([A-Z][A-Z _]*)/i);
     if (match) {
-        const verdict = canonicalizeFallbackVerdict(match[1]);
+        const verdict = canonicalizeVerdict(match[1]);
         if (verdict) {
             return { verdict, confidence: null, comments: '<extracted from non-JSON response>' };
         }

--- a/scripts/sync-main.js
+++ b/scripts/sync-main.js
@@ -15,6 +15,7 @@ const END = '// </core-injected>';
 // Order matters: declarations must precede uses within the IIFE.
 const CORE_ORDER = [
   'prompts.js',
+  'verdicts.js',
   'parsing.js',
   'urls.js',
   'claim.js',

--- a/tests/verdicts.test.js
+++ b/tests/verdicts.test.js
@@ -1,0 +1,88 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    VERDICTS,
+    VERDICT_LIST,
+    canonicalizeVerdict,
+    toTitleCase,
+    toShortCode,
+} from '../core/verdicts.js';
+
+test('VERDICTS exposes the four canonical UPPERCASE strings', () => {
+    assert.equal(VERDICTS.SUPPORTED,           'SUPPORTED');
+    assert.equal(VERDICTS.PARTIALLY_SUPPORTED, 'PARTIALLY SUPPORTED');
+    assert.equal(VERDICTS.NOT_SUPPORTED,       'NOT SUPPORTED');
+    assert.equal(VERDICTS.SOURCE_UNAVAILABLE,  'SOURCE UNAVAILABLE');
+});
+
+test('VERDICT_LIST iterates in confidence-guide order', () => {
+    assert.deepEqual(VERDICT_LIST, [
+        'SUPPORTED',
+        'PARTIALLY SUPPORTED',
+        'NOT SUPPORTED',
+        'SOURCE UNAVAILABLE',
+    ]);
+});
+
+test('canonicalizeVerdict accepts the canonical UPPERCASE form', () => {
+    assert.equal(canonicalizeVerdict('SUPPORTED'),           VERDICTS.SUPPORTED);
+    assert.equal(canonicalizeVerdict('PARTIALLY SUPPORTED'), VERDICTS.PARTIALLY_SUPPORTED);
+    assert.equal(canonicalizeVerdict('NOT SUPPORTED'),       VERDICTS.NOT_SUPPORTED);
+    assert.equal(canonicalizeVerdict('SOURCE UNAVAILABLE'),  VERDICTS.SOURCE_UNAVAILABLE);
+});
+
+test('canonicalizeVerdict accepts title case', () => {
+    assert.equal(canonicalizeVerdict('Supported'),           VERDICTS.SUPPORTED);
+    assert.equal(canonicalizeVerdict('Partially supported'), VERDICTS.PARTIALLY_SUPPORTED);
+    assert.equal(canonicalizeVerdict('Not supported'),       VERDICTS.NOT_SUPPORTED);
+    assert.equal(canonicalizeVerdict('Source unavailable'),  VERDICTS.SOURCE_UNAVAILABLE);
+});
+
+test('canonicalizeVerdict accepts underscores and mixed whitespace', () => {
+    assert.equal(canonicalizeVerdict('not_supported'),  VERDICTS.NOT_SUPPORTED);
+    assert.equal(canonicalizeVerdict('NOT_SUPPORTED'),  VERDICTS.NOT_SUPPORTED);
+    assert.equal(canonicalizeVerdict('  partially  '), VERDICTS.PARTIALLY_SUPPORTED);
+    assert.equal(canonicalizeVerdict('not\tsupported'), VERDICTS.NOT_SUPPORTED);
+});
+
+test('canonicalizeVerdict accepts short codes (compare_results conventions)', () => {
+    assert.equal(canonicalizeVerdict('support'),     VERDICTS.SUPPORTED);
+    assert.equal(canonicalizeVerdict('partial'),     VERDICTS.PARTIALLY_SUPPORTED);
+    assert.equal(canonicalizeVerdict('not'),         VERDICTS.NOT_SUPPORTED);
+    assert.equal(canonicalizeVerdict('unavailable'), VERDICTS.SOURCE_UNAVAILABLE);
+});
+
+test('canonicalizeVerdict returns null for unrecognized / empty / null input', () => {
+    assert.equal(canonicalizeVerdict(null),          null);
+    assert.equal(canonicalizeVerdict(undefined),     null);
+    assert.equal(canonicalizeVerdict(''),            null);
+    assert.equal(canonicalizeVerdict('   '),         null);
+    assert.equal(canonicalizeVerdict('PARSE_ERROR'), null);
+    assert.equal(canonicalizeVerdict('ERROR'),       null);
+    assert.equal(canonicalizeVerdict('options'),     null);   // regression: 1a12753
+    assert.equal(canonicalizeVerdict('to choose'),   null);
+});
+
+test('canonicalizeVerdict tolerates non-string input via String() coercion', () => {
+    assert.equal(canonicalizeVerdict(42), null);
+    // Number coerces cleanly; verifies we don't throw on .toUpperCase()
+});
+
+test('toTitleCase maps canonical to results.json schema strings', () => {
+    assert.equal(toTitleCase(VERDICTS.SUPPORTED),           'Supported');
+    assert.equal(toTitleCase(VERDICTS.PARTIALLY_SUPPORTED), 'Partially supported');
+    assert.equal(toTitleCase(VERDICTS.NOT_SUPPORTED),       'Not supported');
+    assert.equal(toTitleCase(VERDICTS.SOURCE_UNAVAILABLE),  'Source unavailable');
+});
+
+test('toTitleCase passes unknown input through (callers may pass sentinels)', () => {
+    assert.equal(toTitleCase('PARSE_ERROR'), 'PARSE_ERROR');
+    assert.equal(toTitleCase('Anything'),    'Anything');
+});
+
+test('toShortCode maps canonical to compare_results short codes', () => {
+    assert.equal(toShortCode(VERDICTS.SUPPORTED),           'support');
+    assert.equal(toShortCode(VERDICTS.PARTIALLY_SUPPORTED), 'partial');
+    assert.equal(toShortCode(VERDICTS.NOT_SUPPORTED),       'not');
+    assert.equal(toShortCode(VERDICTS.SOURCE_UNAVAILABLE),  'unavailable');
+});


### PR DESCRIPTION
Follow-up to #214. While unifying the verdict parser in that PR, I noticed the benchmark has four separate `normalizeVerdict` implementations with three different output shapes and four different no-match behaviors — same family of drift, different function.

## What lived where, before

| File:line | Output shape | No-match behavior |
|---|---|---|
| `benchmark/run_benchmark.js:416` | title case (`'Supported'`) | `'PARSE_ERROR'` |
| `benchmark/analyze_results.js:53` | title case | `'Unknown'`, or `'Error'` if input contains "error" |
| `benchmark/compare_results.js:6` | short lowercase (`'support'`) | input lowercased + trimmed |
| `benchmark/extract_dataset.js:299` | title case | input passed through raw |

Plus a fifth: `core/parsing.js` (after #214) kept its own private `FALLBACK_VERDICT_PATTERNS` / `canonicalizeFallbackVerdict` for the markdown-emphasis recovery path. Five places all recognizing the same `'not_supported'` / `'Partially'` / `'unavailable'` / `'PARTIAL'` / etc. variants — every time someone tweaks one, the others can silently fall out of sync.

`analyze_results.js:48` also defined `VERDICT_CATEGORIES` inline; no shared list to coordinate the four benchmark-side files plus `main.js`'s four inline verdict-styling switches.

## What changes

New module **`core/verdicts.js`** — single source of truth for the four canonical categories:

```js
export const VERDICTS = { SUPPORTED, PARTIALLY_SUPPORTED, NOT_SUPPORTED, SOURCE_UNAVAILABLE };
export const VERDICT_LIST = [...];                    // ordered, replaces VERDICT_CATEGORIES
export function canonicalizeVerdict(raw)              // any variant -> UPPERCASE or null
export function toTitleCase(canonical)                // -> 'Supported' / 'Not supported' / ...
export function toShortCode(canonical)                // -> 'support' / 'partial' / 'not' / ...
```

The recognition logic — handle case, underscores, whitespace, short codes, truncated forms like `'PARTIAL'` — lives once. Each consumer composes `canonicalizeVerdict` with the presenter that matches its downstream schema, plus its own no-match policy as a one-line shim:

- `run_benchmark.js`: `canonical ? toTitleCase(canonical) : 'PARSE_ERROR'`
- `analyze_results.js`: `canonical ? toTitleCase(canonical) : (empty ? 'Unknown' : (/error/.test ? 'Error' : 'Unknown'))`
- `compare_results.js`: `canonical ? toShortCode(canonical) : String(v ?? '').toLowerCase().trim()`
- `extract_dataset.js`: `canonical ? toTitleCase(canonical) : verdict` (raw passthrough on no-match)
- `core/parsing.js`: drops the private helper, imports `canonicalizeVerdict` directly

All four fallback behaviors are preserved at the call sites, so `results.json`, `analysis.json`, and `compare` output formats are byte-compatible with pre-PR runs.

`analyze_results.js`'s `VERDICT_CATEGORIES` now derives from `VERDICT_LIST.map(toTitleCase)` instead of being a separate hardcoded list.

`scripts/sync-main.js`'s `CORE_ORDER` adds `'verdicts.js'` ahead of `'parsing.js'` (parsing depends on it), so the `VERDICTS` / `canonicalizeVerdict` exports are available inside `main.js`'s IIFE — useful if the userscript later switches its inline verdict comparisons (4 places, line ~2746 / 2932 / 3064 / 3222) to named constants. Not done in this PR to keep scope tight; the strings are stable today and the userscript-side refactor is independent.

## Why not unify into `core/parsing.js` directly?

`parsing.js` is about LLM response parsing — JSON extraction, code-fence handling, error sentinels. The canonicalization + presenters are a separate concern shared by callers that never touch raw LLM output (the GT-importing path in `extract_dataset.js`, the run-vs-run comparison in `compare_results.js`). New file keeps each module narrowly scoped.

## Tests

`tests/verdicts.test.js` — 11 new cases covering:

- All four canonical UPPERCASE forms recognized as-is.
- Title-case input round-trips through `canonicalizeVerdict` + `toTitleCase`.
- Underscore / mixed whitespace input normalized.
- Short codes (`'support'`, `'partial'`, `'not'`, `'unavailable'`) recognized — same module powers `compare_results.js`'s inputs and `run_benchmark.js`'s outputs.
- Unrecognized / empty / null input returns `null` — including the explicit regression case from commit `1a12753` ("benchmark: fallback verdict parser returns PARSE_ERROR for unmatched fragments"; `'options'`, `'to choose'`).
- Non-string input tolerated via `String()` coercion.
- `toTitleCase` / `toShortCode` pass unknown input through (callers pass sentinels like `'PARSE_ERROR'`).
- `VERDICT_LIST` is in the confidence-guide order from `core/prompts.js`.

Existing tests cover the shim integrations:
- `tests/parsing.test.js` (10 cases) — fallback path still recognizes Granite-style markdown emphasis, still returns `'PARSE_ERROR'` sentinel.
- `tests/benchmark_runner.test.js` (3 wiring cases) — `shapeResult` still title-cases and falls back to `'PARSE_ERROR'`.
- `tests/compare_results.test.js` (15 cases) — `normalizeVerdict` shim preserves short-code output and lowercased passthrough.

I also smoke-tested `analyze_results.js` end-to-end against the frozen `results_v1.json` / `dataset_v1.json` snapshot — accuracy numbers match (Claude-sonnet-4-5 75.0%, Qwen-sealion 73.3%, Gemini-2.5-flash 71.4%, etc.).

## Out of scope, but noticed while doing this

Two adjacent duplications I left for a follow-up — flagging so you know they exist:

- **`isSupportClass`** is defined separately in `benchmark/voting.js:21` and `benchmark/compare_results.js:18`. Same concept ("Supported or Partially supported?"); the voting.js version does strict title-case equality, the compare_results version normalizes first. Could move into `core/verdicts.js` as a tolerant shared helper.
- **`compareVerdicts`** is defined separately in `benchmark/run_benchmark.js:656` (used to mark `correct: 'exact' | 'partial' | 'wrong'` in results.json) and `benchmark/compute_ensemble.js:115` (synthesizes the same field for ensemble rows). The compute_ensemble version's comment literally says *"Mirror run_benchmark.js compareVerdicts"* — acknowledged duplication.

## Acceptance

- [x] `npm test` — 240/240 passing (was 229; +11 cases).
- [x] `npm run build -- --check` — `main.js` in sync with `core/`.
- [x] End-to-end smoke: `analyze_results.js` against v1 snapshot produces matching accuracy numbers.
- [x] Single commit.