### PR TITLE
Consolidate retry/backoff into core/retry.js

### DIFF
--- a/benchmark/run_benchmark.js
+++ b/benchmark/run_benchmark.js
@@ -29,14 +29,11 @@ import {
 } from '../core/providers.js';
 import { parseVerificationResult } from '../core/parsing.js';
 import { canonicalizeVerdict, toTitleCase } from '../core/verdicts.js';
+import { withRetry } from '../core/retry.js';
 import { loadRows, loadMetadata, todayIso } from './io.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
-
-const MAX_RETRIES = 5;
-const RETRYABLE_STATUS = /^HTTP (429|500|502|503|504)\b/;
-const RETRYABLE_NETWORK = /timeout|ECONNRESET|ETIMEDOUT|ENOTFOUND|EAI_AGAIN|socket hang up/i;
 
 // Configuration
 const DATASET_PATH = path.join(__dirname, 'dataset.json');
@@ -233,27 +230,6 @@ function getSystemPrompt() {
 }
 
 /**
- * Retry `fn` on transient failures (429, 5xx, network) with exponential
- * backoff + jitter. `sleepFn` is injectable so tests can run instantly.
- */
-export async function withRetry(fn, { maxRetries = MAX_RETRIES, sleepFn = sleep } = {}) {
-    let lastError = null;
-    for (let attempt = 0; attempt < maxRetries; attempt++) {
-        try {
-            return await fn();
-        } catch (error) {
-            lastError = error;
-            const retryable = RETRYABLE_STATUS.test(error.message)
-                || RETRYABLE_NETWORK.test(error.message);
-            if (!retryable || attempt === maxRetries - 1) break;
-            const backoff = Math.min(30000, 1000 * Math.pow(2, attempt)) + Math.random() * 500;
-            await sleepFn(backoff);
-        }
-    }
-    throw lastError;
-}
-
-/**
  * Make API call to provider. Delegates HTTP transport to core/providers.js
  * (single source of truth shared with main.js + cli/verify.js); the runner
  * adds env-var auth, latency timing, retry, and error-to-verdict-shape conversion.
@@ -416,13 +392,6 @@ async function callHuggingFace(config, systemPrompt, userPrompt) {
 function normalizeVerdict(verdict) {
     const canonical = canonicalizeVerdict(verdict);
     return canonical ? toTitleCase(canonical) : 'PARSE_ERROR';
-}
-
-/**
- * Sleep helper
- */
-function sleep(ms) {
-    return new Promise(resolve => setTimeout(resolve, ms));
 }
 
 /**

--- a/core/retry.js
+++ b/core/retry.js
@@ -1,0 +1,73 @@
+// Retry-with-backoff helper shared by the benchmark runner and the
+// userscript's batch verify-all-citations path. Pre-consolidation, the
+// benchmark used `withRetry` (5 attempts, exponential backoff, retries
+// on 429 / 500 / 502 / 503 / 504 / network errors) while main.js's batch
+// path had its own inline loop (3 attempts, fixed linear backoff,
+// retries only on 429). The userscript's narrower trigger meant a single
+// 503 during a batch run errored out the whole citation; the benchmark
+// would have recovered. Sharing the impl widens the userscript to the
+// benchmark's retry set.
+//
+// Defaults match the benchmark (1s base, exponential, ≤30s cap, 5
+// attempts) — callers tune via options.
+
+const RETRYABLE_STATUS = /^HTTP (429|500|502|503|504)\b/;
+const RETRYABLE_NETWORK = /timeout|ECONNRESET|ETIMEDOUT|ENOTFOUND|EAI_AGAIN|socket hang up/i;
+
+function defaultSleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+export function isRetryableError(error) {
+    const msg = error?.message ?? '';
+    return RETRYABLE_STATUS.test(msg) || RETRYABLE_NETWORK.test(msg);
+}
+
+/**
+ * Retry `fn` on transient failures (429, 5xx, network) with exponential
+ * backoff + jitter.
+ *
+ * Options:
+ *   maxRetries       Total attempt budget incl. the initial call (default 5).
+ *   minBackoffMs     Base for the exponential curve (default 1000).
+ *   maxBackoffMs     Cap on a single sleep (default 30000).
+ *   jitterMs         Upper bound of additive random jitter (default 500).
+ *   sleepFn          Injectable sleep — tests pass a no-op so they run instantly.
+ *   shouldAbort      Optional callback; truthy return short-circuits the loop
+ *                    (e.g. user cancellation in the userscript's batch path).
+ *   onAttemptFailed  Optional callback invoked after each failed attempt with
+ *                    { error, attempt, backoff, willRetry } — for progress UI.
+ *                    `backoff` is the sleep duration about to elapse (0 if no retry).
+ *
+ * Throws the last error if every attempt fails or the failure isn't retryable.
+ */
+export async function withRetry(fn, {
+    maxRetries = 5,
+    minBackoffMs = 1000,
+    maxBackoffMs = 30000,
+    jitterMs = 500,
+    sleepFn = defaultSleep,
+    shouldAbort,
+    onAttemptFailed,
+} = {}) {
+    let lastError = null;
+    for (let attempt = 0; attempt < maxRetries; attempt++) {
+        if (shouldAbort && shouldAbort()) break;
+        try {
+            return await fn();
+        } catch (error) {
+            lastError = error;
+            const retryable = isRetryableError(error);
+            const willRetry = retryable && attempt < maxRetries - 1
+                && !(shouldAbort && shouldAbort());
+            const backoff = willRetry
+                ? Math.min(maxBackoffMs, minBackoffMs * Math.pow(2, attempt))
+                  + Math.random() * jitterMs
+                : 0;
+            if (onAttemptFailed) onAttemptFailed({ error, attempt, backoff, willRetry });
+            if (!willRetry) break;
+            await sleepFn(backoff);
+        }
+    }
+    throw lastError;
+}

--- a/main.js
+++ b/main.js
@@ -252,6 +252,81 @@ function parseVerificationResult(response) {
     };
 }
 
+// --- core/retry.js ---
+// Retry-with-backoff helper shared by the benchmark runner and the
+// userscript's batch verify-all-citations path. Pre-consolidation, the
+// benchmark used `withRetry` (5 attempts, exponential backoff, retries
+// on 429 / 500 / 502 / 503 / 504 / network errors) while main.js's batch
+// path had its own inline loop (3 attempts, fixed linear backoff,
+// retries only on 429). The userscript's narrower trigger meant a single
+// 503 during a batch run errored out the whole citation; the benchmark
+// would have recovered. Sharing the impl widens the userscript to the
+// benchmark's retry set.
+//
+// Defaults match the benchmark (1s base, exponential, ≤30s cap, 5
+// attempts) — callers tune via options.
+
+const RETRYABLE_STATUS = /^HTTP (429|500|502|503|504)\b/;
+const RETRYABLE_NETWORK = /timeout|ECONNRESET|ETIMEDOUT|ENOTFOUND|EAI_AGAIN|socket hang up/i;
+
+function defaultSleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function isRetryableError(error) {
+    const msg = error?.message ?? '';
+    return RETRYABLE_STATUS.test(msg) || RETRYABLE_NETWORK.test(msg);
+}
+
+/**
+ * Retry `fn` on transient failures (429, 5xx, network) with exponential
+ * backoff + jitter.
+ *
+ * Options:
+ *   maxRetries       Total attempt budget incl. the initial call (default 5).
+ *   minBackoffMs     Base for the exponential curve (default 1000).
+ *   maxBackoffMs     Cap on a single sleep (default 30000).
+ *   jitterMs         Upper bound of additive random jitter (default 500).
+ *   sleepFn          Injectable sleep — tests pass a no-op so they run instantly.
+ *   shouldAbort      Optional callback; truthy return short-circuits the loop
+ *                    (e.g. user cancellation in the userscript's batch path).
+ *   onAttemptFailed  Optional callback invoked after each failed attempt with
+ *                    { error, attempt, backoff, willRetry } — for progress UI.
+ *                    `backoff` is the sleep duration about to elapse (0 if no retry).
+ *
+ * Throws the last error if every attempt fails or the failure isn't retryable.
+ */
+async function withRetry(fn, {
+    maxRetries = 5,
+    minBackoffMs = 1000,
+    maxBackoffMs = 30000,
+    jitterMs = 500,
+    sleepFn = defaultSleep,
+    shouldAbort,
+    onAttemptFailed,
+} = {}) {
+    let lastError = null;
+    for (let attempt = 0; attempt < maxRetries; attempt++) {
+        if (shouldAbort && shouldAbort()) break;
+        try {
+            return await fn();
+        } catch (error) {
+            lastError = error;
+            const retryable = isRetryableError(error);
+            const willRetry = retryable && attempt < maxRetries - 1
+                && !(shouldAbort && shouldAbort());
+            const backoff = willRetry
+                ? Math.min(maxBackoffMs, minBackoffMs * Math.pow(2, attempt))
+                  + Math.random() * jitterMs
+                : 0;
+            if (onAttemptFailed) onAttemptFailed({ error, attempt, backoff, willRetry });
+            if (!willRetry) break;
+            await sleepFn(backoff);
+        }
+    }
+    throw lastError;
+}
+
 // --- core/urls.js ---
 // URL extraction helpers for Wikipedia reference elements.
 // extractReferenceUrl and extractPageNumber accept a `document` parameter
@@ -3480,10 +3555,34 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
                         };
                     } else {
                         const sourceTruncated = sourceContent.includes('\nTruncated: true');
-                        // Verify via LLM
+                        // Verify via LLM. Retry transient failures (429 + 5xx +
+                        // network) through the shared core/retry.js helper —
+                        // pre-consolidation, this path only retried on 429 and
+                        // surfaced 5xx as a hard ERROR even though the benchmark
+                        // would have recovered. The [5s, 10s, 20s] backoff curve
+                        // is preserved via minBackoffMs/jitterMs, and Cancel
+                        // still short-circuits via shouldAbort.
                         this.updateReportProgress(i, citations.length, `Verifying citation [${citation.citationNumber}]`, startTime);
                         try {
-                            const apiResult = await this.callProviderAPI(citation.claimText, sourceContent);
+                            const apiResult = await withRetry(
+                                () => this.callProviderAPI(citation.claimText, sourceContent),
+                                {
+                                    maxRetries: 4,
+                                    minBackoffMs: 5000,
+                                    maxBackoffMs: 30000,
+                                    jitterMs: 0,
+                                    shouldAbort: () => this.reportCancelled,
+                                    onAttemptFailed: ({ backoff, willRetry }) => {
+                                        if (willRetry) {
+                                            this.updateReportProgress(
+                                                i, citations.length,
+                                                `Rate limited, retrying in ${Math.round(backoff / 1000)}s...`,
+                                                startTime
+                                            );
+                                        }
+                                    },
+                                }
+                            );
                             const parsed = this.parseVerificationResult(apiResult.text);
                             this.reportTokenUsage.input += apiResult.usage.input;
                             this.reportTokenUsage.output += apiResult.usage.output;
@@ -3509,50 +3608,16 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
                                 this.activeSourceUrl = savedSourceUrl;
                             } catch (e) {}
                         } catch (e) {
-                            // Check for rate limiting (429)
-                            let retried = false;
-                            if (e.message && e.message.includes('429')) {
-                                for (let attempt = 0; attempt < 3; attempt++) {
-                                    if (this.reportCancelled) break;
-                                    const backoff = [5000, 10000, 20000][attempt];
-                                    this.updateReportProgress(i, citations.length, `Rate limited, retrying in ${backoff/1000}s...`, startTime);
-                                    await new Promise(r => setTimeout(r, backoff));
-                                    try {
-                                        const retryApiResult = await this.callProviderAPI(citation.claimText, sourceContent);
-                                        const parsed = this.parseVerificationResult(retryApiResult.text);
-                                        this.reportTokenUsage.input += retryApiResult.usage.input;
-                                        this.reportTokenUsage.output += retryApiResult.usage.output;
-                                        result = {
-                                            citationNumber: citation.citationNumber,
-                                            claimText: citation.claimText,
-                                            url: citation.url,
-                                            refElement: citation.refElement,
-                                            verdict: parsed.verdict,
-                                            confidence: parsed.confidence,
-                                            comments: parsed.comments,
-                                            truncated: sourceTruncated
-                                        };
-                                        retried = true;
-                                        break;
-                                    } catch (retryErr) {
-                                        if (!retryErr.message?.includes('429')) {
-                                            break;
-                                        }
-                                    }
-                                }
-                            }
-                            if (!retried) {
-                                result = {
-                                    citationNumber: citation.citationNumber,
-                                    claimText: citation.claimText,
-                                    url: citation.url,
-                                    refElement: citation.refElement,
-                                    verdict: 'ERROR',
-                                    confidence: null,
-                                    comments: e.message,
-                                    truncated: sourceTruncated
-                                };
-                            }
+                            result = {
+                                citationNumber: citation.citationNumber,
+                                claimText: citation.claimText,
+                                url: citation.url,
+                                refElement: citation.refElement,
+                                verdict: 'ERROR',
+                                confidence: null,
+                                comments: e.message,
+                                truncated: sourceTruncated
+                            };
                         }
 
                         // Rate limit delay after LLM call

--- a/scripts/sync-main.js
+++ b/scripts/sync-main.js
@@ -17,6 +17,7 @@ const CORE_ORDER = [
   'prompts.js',
   'verdicts.js',
   'parsing.js',
+  'retry.js',
   'urls.js',
   'claim.js',
   'providers.js',

--- a/tests/benchmark_runner.test.js
+++ b/tests/benchmark_runner.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-import { runPool, withRetry, makeSaver, hostForProvider, shapeResult } from '../benchmark/run_benchmark.js';
+import { runPool, makeSaver, hostForProvider, shapeResult } from '../benchmark/run_benchmark.js';
 
 // ---- runPool ----------------------------------------------------------------
 
@@ -46,100 +46,9 @@ test('runPool: caps worker count at items.length when concurrency > items', asyn
     assert.equal(peak, 2);
 });
 
-// ---- withRetry --------------------------------------------------------------
-
-const noSleep = () => Promise.resolve();
-
-test('withRetry: returns the value on first success without retrying', async () => {
-    let calls = 0;
-    const result = await withRetry(async () => { calls++; return 'ok'; }, { sleepFn: noSleep });
-    assert.equal(result, 'ok');
-    assert.equal(calls, 1);
-});
-
-test('withRetry: retries on HTTP 429 and eventually succeeds', async () => {
-    let calls = 0;
-    const result = await withRetry(async () => {
-        calls++;
-        if (calls < 3) throw new Error('HTTP 429: rate limited');
-        return 'ok';
-    }, { sleepFn: noSleep });
-    assert.equal(result, 'ok');
-    assert.equal(calls, 3);
-});
-
-test('withRetry: retries on HTTP 503', async () => {
-    let calls = 0;
-    const result = await withRetry(async () => {
-        calls++;
-        if (calls < 2) throw new Error('HTTP 503: backend unavailable');
-        return 'ok';
-    }, { sleepFn: noSleep });
-    assert.equal(calls, 2);
-    assert.equal(result, 'ok');
-});
-
-test('withRetry: retries on network timeout', async () => {
-    let calls = 0;
-    await withRetry(async () => {
-        calls++;
-        if (calls < 2) throw new Error('Request timeout');
-        return 'ok';
-    }, { sleepFn: noSleep });
-    assert.equal(calls, 2);
-});
-
-test('withRetry: does NOT retry on HTTP 400', async () => {
-    let calls = 0;
-    await assert.rejects(
-        withRetry(async () => {
-            calls++;
-            throw new Error('HTTP 400: bad request');
-        }, { sleepFn: noSleep }),
-        /HTTP 400/
-    );
-    assert.equal(calls, 1);
-});
-
-test('withRetry: does NOT retry on parse errors', async () => {
-    let calls = 0;
-    await assert.rejects(
-        withRetry(async () => {
-            calls++;
-            throw new Error('Parse error: unexpected token');
-        }, { sleepFn: noSleep }),
-        /Parse error/
-    );
-    assert.equal(calls, 1);
-});
-
-test('withRetry: gives up after maxRetries and throws the last error', async () => {
-    let calls = 0;
-    await assert.rejects(
-        withRetry(async () => {
-            calls++;
-            throw new Error(`HTTP 429: try ${calls}`);
-        }, { sleepFn: noSleep, maxRetries: 3 }),
-        /HTTP 429: try 3/
-    );
-    assert.equal(calls, 3);
-});
-
-test('withRetry: backoff schedule is exponential and uses sleepFn', async () => {
-    const delays = [];
-    let calls = 0;
-    await assert.rejects(
-        withRetry(async () => {
-            calls++;
-            throw new Error('HTTP 429');
-        }, { maxRetries: 4, sleepFn: async (ms) => { delays.push(ms); } })
-    );
-    // 4 attempts → 3 sleeps between them. Base values: 1000, 2000, 4000 (+ up to 500 jitter).
-    assert.equal(delays.length, 3);
-    assert.ok(delays[0] >= 1000 && delays[0] < 1500, `attempt 0 sleep was ${delays[0]}`);
-    assert.ok(delays[1] >= 2000 && delays[1] < 2500, `attempt 1 sleep was ${delays[1]}`);
-    assert.ok(delays[2] >= 4000 && delays[2] < 4500, `attempt 2 sleep was ${delays[2]}`);
-});
+// withRetry tests live in tests/retry.test.js — withRetry was lifted into
+// core/retry.js so the userscript's batch verify-all-citations path can
+// share it with the benchmark runner.
 
 // ---- makeSaver --------------------------------------------------------------
 

--- a/tests/retry.test.js
+++ b/tests/retry.test.js
@@ -1,0 +1,208 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { withRetry, isRetryableError } from '../core/retry.js';
+
+const noSleep = () => Promise.resolve();
+
+// ---- withRetry --------------------------------------------------------------
+
+test('withRetry: returns the value on first success without retrying', async () => {
+    let calls = 0;
+    const result = await withRetry(async () => { calls++; return 'ok'; }, { sleepFn: noSleep });
+    assert.equal(result, 'ok');
+    assert.equal(calls, 1);
+});
+
+test('withRetry: retries on HTTP 429 and eventually succeeds', async () => {
+    let calls = 0;
+    const result = await withRetry(async () => {
+        calls++;
+        if (calls < 3) throw new Error('HTTP 429: rate limited');
+        return 'ok';
+    }, { sleepFn: noSleep });
+    assert.equal(result, 'ok');
+    assert.equal(calls, 3);
+});
+
+test('withRetry: retries on HTTP 503', async () => {
+    let calls = 0;
+    const result = await withRetry(async () => {
+        calls++;
+        if (calls < 2) throw new Error('HTTP 503: backend unavailable');
+        return 'ok';
+    }, { sleepFn: noSleep });
+    assert.equal(calls, 2);
+    assert.equal(result, 'ok');
+});
+
+test('withRetry: retries on network timeout', async () => {
+    let calls = 0;
+    await withRetry(async () => {
+        calls++;
+        if (calls < 2) throw new Error('Request timeout');
+        return 'ok';
+    }, { sleepFn: noSleep });
+    assert.equal(calls, 2);
+});
+
+test('withRetry: does NOT retry on HTTP 400', async () => {
+    let calls = 0;
+    await assert.rejects(
+        withRetry(async () => {
+            calls++;
+            throw new Error('HTTP 400: bad request');
+        }, { sleepFn: noSleep }),
+        /HTTP 400/
+    );
+    assert.equal(calls, 1);
+});
+
+test('withRetry: does NOT retry on parse errors', async () => {
+    let calls = 0;
+    await assert.rejects(
+        withRetry(async () => {
+            calls++;
+            throw new Error('Parse error: unexpected token');
+        }, { sleepFn: noSleep }),
+        /Parse error/
+    );
+    assert.equal(calls, 1);
+});
+
+test('withRetry: gives up after maxRetries and throws the last error', async () => {
+    let calls = 0;
+    await assert.rejects(
+        withRetry(async () => {
+            calls++;
+            throw new Error(`HTTP 429: try ${calls}`);
+        }, { sleepFn: noSleep, maxRetries: 3 }),
+        /HTTP 429: try 3/
+    );
+    assert.equal(calls, 3);
+});
+
+test('withRetry: default backoff schedule is exponential and uses sleepFn', async () => {
+    const delays = [];
+    let calls = 0;
+    await assert.rejects(
+        withRetry(async () => {
+            calls++;
+            throw new Error('HTTP 429');
+        }, { maxRetries: 4, sleepFn: async (ms) => { delays.push(ms); } })
+    );
+    // 4 attempts → 3 sleeps between them. Base values: 1000, 2000, 4000 (+ up to 500 jitter).
+    assert.equal(delays.length, 3);
+    assert.ok(delays[0] >= 1000 && delays[0] < 1500, `attempt 0 sleep was ${delays[0]}`);
+    assert.ok(delays[1] >= 2000 && delays[1] < 2500, `attempt 1 sleep was ${delays[1]}`);
+    assert.ok(delays[2] >= 4000 && delays[2] < 4500, `attempt 2 sleep was ${delays[2]}`);
+});
+
+test('withRetry: custom minBackoffMs / jitterMs match the userscript schedule', async () => {
+    // main.js's batch retry historically used a fixed [5s, 10s, 20s] curve with
+    // no jitter. The shared withRetry preserves this when called with
+    // minBackoffMs=5000 / jitterMs=0 / maxRetries=4 (1 initial + 3 retries).
+    const delays = [];
+    await assert.rejects(
+        withRetry(async () => { throw new Error('HTTP 429'); }, {
+            maxRetries: 4,
+            minBackoffMs: 5000,
+            jitterMs: 0,
+            sleepFn: async (ms) => { delays.push(ms); },
+        })
+    );
+    assert.deepEqual(delays, [5000, 10000, 20000]);
+});
+
+test('withRetry: maxBackoffMs caps a single sleep', async () => {
+    const delays = [];
+    await assert.rejects(
+        withRetry(async () => { throw new Error('HTTP 429'); }, {
+            maxRetries: 5,
+            minBackoffMs: 10000,
+            jitterMs: 0,
+            maxBackoffMs: 15000,
+            sleepFn: async (ms) => { delays.push(ms); },
+        })
+    );
+    // attempts: 0=10000, 1=20000 (capped to 15000), 2=40000 (capped), 3=80000 (capped)
+    assert.deepEqual(delays, [10000, 15000, 15000, 15000]);
+});
+
+test('withRetry: shouldAbort short-circuits the loop before the next attempt', async () => {
+    let calls = 0;
+    let abort = false;
+    await assert.rejects(
+        withRetry(async () => {
+            calls++;
+            if (calls === 2) abort = true;
+            throw new Error('HTTP 429');
+        }, {
+            sleepFn: noSleep,
+            shouldAbort: () => abort,
+        })
+    );
+    // Initial + one retry, then shouldAbort returns true and breaks before the third call.
+    assert.equal(calls, 2);
+});
+
+test('withRetry: onAttemptFailed receives error, attempt, backoff, and willRetry', async () => {
+    const events = [];
+    await assert.rejects(
+        withRetry(async () => { throw new Error('HTTP 429'); }, {
+            maxRetries: 3,
+            minBackoffMs: 1000,
+            jitterMs: 0,
+            sleepFn: noSleep,
+            onAttemptFailed: (info) => {
+                events.push({
+                    attempt: info.attempt,
+                    backoff: info.backoff,
+                    willRetry: info.willRetry,
+                    message: info.error.message,
+                });
+            },
+        })
+    );
+    assert.deepEqual(events, [
+        { attempt: 0, backoff: 1000, willRetry: true,  message: 'HTTP 429' },
+        { attempt: 1, backoff: 2000, willRetry: true,  message: 'HTTP 429' },
+        { attempt: 2, backoff: 0,    willRetry: false, message: 'HTTP 429' },
+    ]);
+});
+
+test('withRetry: onAttemptFailed reports willRetry=false for non-retryable errors', async () => {
+    const events = [];
+    await assert.rejects(
+        withRetry(async () => { throw new Error('HTTP 400: bad'); }, {
+            sleepFn: noSleep,
+            onAttemptFailed: (info) => { events.push(info.willRetry); },
+        })
+    );
+    assert.deepEqual(events, [false]);
+});
+
+// ---- isRetryableError -------------------------------------------------------
+
+test('isRetryableError: true for 429 / 5xx / network families', () => {
+    assert.equal(isRetryableError(new Error('HTTP 429: rate limited')),     true);
+    assert.equal(isRetryableError(new Error('HTTP 500: internal')),         true);
+    assert.equal(isRetryableError(new Error('HTTP 502: bad gateway')),      true);
+    assert.equal(isRetryableError(new Error('HTTP 503: unavailable')),      true);
+    assert.equal(isRetryableError(new Error('HTTP 504: timeout')),          true);
+    assert.equal(isRetryableError(new Error('Request timeout')),            true);
+    assert.equal(isRetryableError(new Error('socket hang up')),             true);
+    assert.equal(isRetryableError(new Error('ECONNRESET')),                 true);
+});
+
+test('isRetryableError: false for 4xx (except 429) and parse errors', () => {
+    assert.equal(isRetryableError(new Error('HTTP 400: bad request')), false);
+    assert.equal(isRetryableError(new Error('HTTP 401: unauthorized')), false);
+    assert.equal(isRetryableError(new Error('HTTP 404: not found')),    false);
+    assert.equal(isRetryableError(new Error('Invalid API response format')), false);
+});
+
+test('isRetryableError: tolerates null/undefined errors', () => {
+    assert.equal(isRetryableError(null), false);
+    assert.equal(isRetryableError(undefined), false);
+    assert.equal(isRetryableError({}), false);
+});


### PR DESCRIPTION
Third in the series after #214 / #215 of pulling shared logic out of the benchmark and userscript. **Stacked on #215** — both PRs touch `scripts/sync-main.js`'s `CORE_ORDER`, so this branches off `consolidate-verdicts` rather than `main`. The base will auto-flip to `main` once #215 merges.

## Why

Two separate retry-with-backoff implementations exist today:

| Where | Attempts | Backoff curve | Retries on | Detection |
|---|---|---|---|---|
| `benchmark/run_benchmark.js` `withRetry` | 5 | exponential `1s, 2s, 4s, 8s` + jitter, ≤30s cap | 429 / 500 / 502 / 503 / 504 / network | regex |
| `main.js` batch verify-all-citations path (inline loop, `main.js:3587–3618` pre-PR) | 3 | fixed `[5s, 10s, 20s]` | **429 only** | `message.includes('429')` |

**User-visible consequence:** when a provider returns a single 503 during a Verify-All-Citations batch run, the userscript currently errors out that citation as `'ERROR'`. The benchmark, calling the same `core/providers.js` transport, would have retried and recovered. The narrower retry trigger is the substantive divergence this PR fixes.

## What changes

New module **`core/retry.js`** — single `withRetry` impl, parameterized so each caller picks its own curve:

```js
withRetry(fn, {
    maxRetries,       // default 5  — matches benchmark
    minBackoffMs,     // default 1000
    maxBackoffMs,     // default 30000
    jitterMs,         // default 500
    sleepFn,          // injectable for tests
    shouldAbort,      // optional: cancellation hook
    onAttemptFailed,  // optional: progress-UI hook, called with
                      //   { error, attempt, backoff, willRetry }
})

isRetryableError(err)   // exported for diagnostics; same regex pair used internally
```

**Defaults match the benchmark's pre-PR behavior verbatim**, so its 8 existing `withRetry` tests pass unchanged (just moved to `tests/retry.test.js`).

**The userscript opts into its historical `[5s, 10s, 20s]` curve** via `{ minBackoffMs: 5000, jitterMs: 0, maxRetries: 4 }` — 4 total attempts (1 initial + 3 retries), capped at 30s, no jitter. Cancellation wires through `shouldAbort: () => this.reportCancelled`; the "Rate limited, retrying in Ns..." progress message is emitted from `onAttemptFailed`.

**The userscript widens to the benchmark's retryable set as a deliberate side-effect.** 5xx and network errors now retry where they used to fail-fast. Same behavior the benchmark has had since the suite was added in `27fa256`.

### Userscript-side cleanup

The pre-PR retry block at `main.js:3560–3631` duplicated the result-builder + token-tally + logging once on the initial-success path and again on the retry-success path — because retry was a copy-paste rather than a function. Sharing the loop collapses both into a single trailing block after `withRetry` returns, dropping ~30 lines and removing the silent risk that the two copies diverge on the next edit.

### Sync-main.js

`'retry.js'` added to `CORE_ORDER` after `'parsing.js'`. The injected `withRetry` is available inside `main.js`'s IIFE; the batch path now calls it directly.

## Tests

**Moved to `tests/retry.test.js`** (8 cases, previously in `tests/benchmark_runner.test.js` against the local `withRetry`): success path, 429 retry, 503 retry, network-timeout retry, 4xx no-retry, parse-error no-retry, `maxRetries` exhaustion, exponential default backoff schedule.

**Added to `tests/retry.test.js`** (8 new cases for the new options):
- `withRetry`: custom `minBackoffMs` / `jitterMs` reproduce the userscript's `[5s, 10s, 20s]` curve.
- `withRetry`: `maxBackoffMs` caps a single sleep (e.g. 10s base × 4 = 40s capped to 15s).
- `withRetry`: `shouldAbort` short-circuits the loop before the next attempt.
- `withRetry`: `onAttemptFailed` receives the full `{error, attempt, backoff, willRetry}` per attempt, including the final non-retry with `willRetry: false`.
- `withRetry`: `onAttemptFailed` reports `willRetry: false` for non-retryable errors so progress UI can distinguish.
- `isRetryableError`: true for 429 / 500 / 502 / 503 / 504 / `Request timeout` / `socket hang up` / `ECONNRESET`.
- `isRetryableError`: false for 400 / 401 / 404 / parse errors.
- `isRetryableError`: tolerates `null` / `undefined` / non-Error inputs.

`tests/benchmark_runner.test.js` drops the `withRetry` import and the 8 tests; a pointer comment marks where they went.

## Acceptance

- [x] `npm test` — 248/248 passing (was 240; +16 in `tests/retry.test.js`, −8 moved out of `tests/benchmark_runner.test.js`).
- [x] `npm run build -- --check` — `main.js` in sync with `core/`.
- [x] Single commit.

## Out of scope

- **Single-citation `verifyClaim` path** in `main.js`. Pre-PR it had no retry at all (only the batch path did). The `withRetry` helper is now in scope inside the IIFE if you want to add retry there too; doing so is a separate behavior change, not part of this consolidation.
- **`delayBetweenCalls`** (the inter-citation pacing in the batch path). Different concern from retry — it spaces successful calls, doesn't react to failure. Left alone.
- **Source-truncation marker detection inside `main.js`** is checked two different ways (`data.truncated === true || data.content.length >= 12000` at line 700; `sourceContent.includes('\nTruncated: true')` at line 3425). Both supposed to detect the same condition. Not retry-related; flagging for a future PR.