### PR TITLE
Add body-usability classifier: pipeline-side SU detection for structurally bad source bodies

### DIFF
--- a/benchmark/analyze_results.js
+++ b/benchmark/analyze_results.js
@@ -180,7 +180,12 @@ function generateMarkdownReport(analysis) {
     md += '## Overview\n\n';
     md += `- Total entries: ${analysis.overview.totalEntries}\n`;
     md += `- Providers tested: ${analysis.overview.providers.join(', ')}\n`;
-    md += `- Total API calls: ${analysis.overview.totalCalls}\n\n`;
+    md += `- Total API calls: ${analysis.overview.totalCalls}\n`;
+    if (analysis.overview.pipelineCoverage) {
+        const pc = analysis.overview.pipelineCoverage;
+        md += `- Pipeline coverage: ${(pc.ratio * 100).toFixed(1)}% (${pc.usableEntries}/${analysis.overview.totalEntries} usable; ${pc.pipelineAttributedEntries} pipeline-attributed SU)\n`;
+    }
+    md += '\n';
 
     // Comparison table
     md += '## Provider Comparison\n\n';
@@ -210,7 +215,11 @@ function generateMarkdownReport(analysis) {
         md += `### ${data.name} (${data.model})\n\n`;
 
         md += '**Accuracy Metrics:**\n';
-        md += `- Exact match: ${m.exactMatches}/${m.valid} (${(m.exactAccuracy * 100).toFixed(1)}%)\n`;
+        md += `- Exact match (all): ${m.exactMatches}/${m.valid} (${(m.exactAccuracy * 100).toFixed(1)}%)\n`;
+        if (data.metricsOnUsable && analysis.overview.pipelineCoverage?.pipelineAttributedEntries > 0) {
+            const mu = data.metricsOnUsable;
+            md += `- Exact match (model-attributed, excl. pipeline SU): ${mu.exactMatches}/${mu.valid} (${(mu.exactAccuracy * 100).toFixed(1)}%)\n`;
+        }
         md += `- Lenient (includes partial): ${m.exactMatches + m.partialMatches}/${m.valid} (${(m.lenientAccuracy * 100).toFixed(1)}%)\n`;
         md += `- Binary (support vs not): ${(m.binaryAccuracy * 100).toFixed(1)}%\n`;
         md += `- Errors: ${m.errors}\n\n`;
@@ -307,21 +316,47 @@ function main() {
     const providers = Object.keys(byProvider);
     console.log(`Providers: ${providers.join(', ')}\n`);
 
+    // Pipeline-coverage stats: how many rows have a deterministic SU verdict
+    // synthesized by the body-classifier rather than computed from an LLM call.
+    // Pipeline-attributed rows are excluded from `metricsOnUsable` so per-provider
+    // model accuracy isn't contaminated by deterministic pipeline-level outcomes.
+    // See benchmark/run_benchmark.js (synthesizePipelineSU) and
+    // core/body-classifier.js for how the pipeline_attributed flag is set.
+    const totalEntryIds = new Set(results.map(r => r.entry_id));
+    const pipelineAttributedEntryIds = new Set(
+        results.filter(r => r.pipeline_attributed === true).map(r => r.entry_id)
+    );
+    const usableEntryCount = totalEntryIds.size - pipelineAttributedEntryIds.size;
+    const pipelineCoverage = totalEntryIds.size > 0
+        ? usableEntryCount / totalEntryIds.size
+        : 0;
+
     // Calculate metrics per provider
     const analysis = {
         generated: new Date().toISOString(),
         overview: {
             datasetVersion: VERSION_FILTER,
-            totalEntries: new Set(results.map(r => r.entry_id)).size,
+            totalEntries: totalEntryIds.size,
             totalCalls: results.length,
-            providers: providers
+            providers: providers,
+            pipelineCoverage: {
+                ratio: pipelineCoverage,
+                usableEntries: usableEntryCount,
+                pipelineAttributedEntries: pipelineAttributedEntryIds.size,
+            }
         },
         providers: {}
     };
 
+    console.log(`Pipeline coverage: ${(pipelineCoverage * 100).toFixed(1)}% (${usableEntryCount}/${totalEntryIds.size} entries usable; ${pipelineAttributedEntryIds.size} pipeline-attributed SU)\n`);
+
     for (const provider of providers) {
         const providerResults = byProvider[provider];
+        const usableProviderResults = providerResults.filter(r => !r.pipeline_attributed);
         const metrics = calculateMetrics(providerResults);
+        const metricsOnUsable = usableProviderResults.length > 0
+            ? calculateMetrics(usableProviderResults)
+            : null;
 
         // Get provider info from first result
         const firstResult = providerResults[0];
@@ -330,14 +365,18 @@ function main() {
             name: provider.charAt(0).toUpperCase() + provider.slice(1),
             model: firstResult.model,
             sampleCount: providerResults.length,
-            metrics
+            metrics,
+            metricsOnUsable,
         };
 
         // Print summary
         console.log(`${provider.toUpperCase()} (${firstResult.model}):`);
-        console.log(`  Exact accuracy: ${(metrics.exactAccuracy * 100).toFixed(1)}%`);
+        console.log(`  Exact accuracy (all):    ${(metrics.exactAccuracy * 100).toFixed(1)}%`);
+        if (metricsOnUsable && pipelineAttributedEntryIds.size > 0) {
+            console.log(`  Exact accuracy (model):  ${(metricsOnUsable.exactAccuracy * 100).toFixed(1)}% on ${metricsOnUsable.valid} usable rows`);
+        }
         console.log(`  Lenient accuracy: ${(metrics.lenientAccuracy * 100).toFixed(1)}%`);
-        console.log(`  Binary accuracy: ${(metrics.binaryAccuracy * 100).toFixed(1)}%`);
+        console.log(`  Binary accuracy:  ${(metrics.binaryAccuracy * 100).toFixed(1)}%`);
         console.log(`  Avg latency: ${metrics.latency.avg.toFixed(0)}ms`);
         console.log(`  Errors: ${metrics.errors}/${metrics.total}`);
         console.log('');

--- a/benchmark/extract_dataset.js
+++ b/benchmark/extract_dataset.js
@@ -27,6 +27,7 @@ import { JSDOM } from 'jsdom';
 import { fileURLToPath } from 'url';
 import { dirname } from 'path';
 import { extractClaimText as extractClaimTextFromRef } from '../core/claim.js';
+import { classifyBody } from '../core/body-classifier.js';
 import { writeWithMetadata, todayIso } from './io.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -443,9 +444,22 @@ async function main() {
 
             // Fetch source content
             let sourceText = '';
+            let bodyUnusableReason = null;
             if (sourceUrl && !DRY_RUN) {
                 console.log(`    Fetching source: ${sourceUrl.substring(0, 60)}...`);
                 sourceText = await fetchSourceContent(sourceUrl) || '';
+                if (sourceText) {
+                    // Mechanically detect structurally-bad bodies (Wayback chrome,
+                    // CSS leak, JSON-LD blob, anti-bot challenge, etc.) so the
+                    // benchmark records SU deterministically without invoking
+                    // an LLM. The bad text is preserved in source_text for
+                    // future audit / pattern re-tuning.
+                    const classification = classifyBody(sourceText);
+                    if (!classification.usable) {
+                        bodyUnusableReason = classification.reason;
+                        console.log(`    Body classified unusable: ${classification.reason} (${sourceText.length} chars preserved for audit)`);
+                    }
+                }
                 await sleep(500); // Rate limiting
             }
 
@@ -462,8 +476,11 @@ async function main() {
                 source_text: sourceText,
                 ground_truth: normalizeVerdict(row['Ground truth']),
                 dataset_version: row['Dataset version'] || 'v1',
-                extraction_status: determineStatus(claimText, sourceUrl, sourceText),
-                needs_manual_review: !claimText || !sourceText,
+                extraction_status: bodyUnusableReason
+                    ? 'body_unusable'
+                    : determineStatus(claimText, sourceUrl, sourceText),
+                ...(bodyUnusableReason ? { body_unusable_reason: bodyUnusableReason } : {}),
+                needs_manual_review: !claimText || (!sourceText && !bodyUnusableReason),
                 ...(wmfProvenance ? { provenance: wmfProvenance } : {}),
             };
 
@@ -493,11 +510,25 @@ async function main() {
     // Summary
     const needsReview = dataset.filter(d => d.needs_manual_review).length;
     const complete = dataset.filter(d => !d.needs_manual_review).length;
+    const bodyUnusable = dataset.filter(d => d.extraction_status === 'body_unusable').length;
+    const bodyUnusableByReason = dataset
+        .filter(d => d.extraction_status === 'body_unusable')
+        .reduce((acc, d) => {
+            const r = d.body_unusable_reason || 'unknown';
+            acc[r] = (acc[r] || 0) + 1;
+            return acc;
+        }, {});
 
     console.log('\n=== Summary ===');
     console.log(`Total entries: ${dataset.length}`);
     console.log(`Complete: ${complete}`);
     console.log(`Needs manual review: ${needsReview}`);
+    console.log(`Body unusable (pipeline-attributed SU): ${bodyUnusable}`);
+    if (bodyUnusable > 0) {
+        for (const [reason, count] of Object.entries(bodyUnusableByReason)) {
+            console.log(`  - ${reason}: ${count}`);
+        }
+    }
 
     if (needsReview > 0) {
         console.log(`\nReview the entries in ${OUTPUT_REVIEW_CSV} before running benchmarks.`);
@@ -505,7 +536,9 @@ async function main() {
 }
 
 /**
- * Determine extraction status
+ * Determine extraction status. Note: 'body_unusable' is set by the caller
+ * before this is consulted, when the body-classifier flags structurally-bad
+ * extracted content (Wayback chrome, CSS leak, etc.).
  */
 function determineStatus(claimText, sourceUrl, sourceText) {
     if (!claimText) return 'claim_extraction_failed';

--- a/benchmark/run_benchmark.js
+++ b/benchmark/run_benchmark.js
@@ -28,6 +28,7 @@ import {
     callHuggingFaceAPI,
 } from '../core/providers.js';
 import { parseVerificationResult } from '../core/parsing.js';
+import { sourceUnavailableComment } from '../core/worker.js';
 import { loadRows, loadMetadata, todayIso } from './io.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -506,22 +507,7 @@ async function main() {
     const datasetMetadata = loadMetadata(DATASET_PATH);
     console.log(`Loaded ${dataset.length} entries from dataset`);
 
-    // Filter to entries ready for benchmarking. Three buckets:
-    //   - extraction_status === 'complete'             — feeds normal LLM flow
-    //   - extraction_status === 'body_unusable'        — synthetic SU (no LLM call);
-    //                                                    reason from body_unusable_reason
-    //   - extraction_status === 'source_fetch_failed'  — synthetic SU (no LLM call);
-    //                                                    reason 'fetch_failed'. Mirrors
-    //                                                    production userscript behavior
-    //                                                    where worker.js returns the
-    //                                                    same { sourceUnavailable } shape
-    //                                                    on proxy/network failure.
-    let entries = dataset.filter(
-        e => (e.extraction_status === 'complete'
-              || e.extraction_status === 'body_unusable'
-              || e.extraction_status === 'source_fetch_failed')
-             && !e.needs_manual_review
-    );
+    let entries = filterBenchmarkableEntries(dataset);
     const usableCount = entries.filter(e => e.extraction_status === 'complete').length;
     const unusableCount = entries.filter(e => e.extraction_status === 'body_unusable').length;
     const fetchFailedCount = entries.filter(e => e.extraction_status === 'source_fetch_failed').length;
@@ -689,6 +675,31 @@ async function main() {
 }
 
 /**
+ * Decide which dataset rows are eligible for benchmarking. Three admit buckets:
+ *   - extraction_status === 'complete'             — normal LLM flow.
+ *   - extraction_status === 'body_unusable'        — synthetic SU via
+ *                                                    synthesizePipelineSU (no LLM call);
+ *                                                    reason comes from
+ *                                                    entry.body_unusable_reason.
+ *   - extraction_status === 'source_fetch_failed'  — synthetic SU via
+ *                                                    synthesizePipelineSU (no LLM call);
+ *                                                    reason defaults to 'fetch_failed'.
+ *                                                    Mirrors production worker.js, which
+ *                                                    returns { sourceUnavailable, reason }
+ *                                                    on proxy/network failure.
+ * Rows with needs_manual_review === true are rejected regardless of status —
+ * GT for those rows is held out of metrics until a human reconciles.
+ */
+export function filterBenchmarkableEntries(dataset) {
+    return dataset.filter(
+        e => (e.extraction_status === 'complete'
+              || e.extraction_status === 'body_unusable'
+              || e.extraction_status === 'source_fetch_failed')
+             && !e.needs_manual_review
+    );
+}
+
+/**
  * Synthesize a deterministic "Source unavailable" result for a dataset row
  * that won't reach the LLM. Used by the runner for two cases:
  *  - extraction_status === 'body_unusable': body-classifier flagged
@@ -710,7 +721,7 @@ export function synthesizePipelineSU(entry, provider, model) {
         ground_truth: entry.ground_truth,
         predicted_verdict: verdict,
         confidence: 'High',
-        comments: `Pipeline-attributed (${reason})`,
+        comments: sourceUnavailableComment(reason),
         latency_ms: 0,
         error: null,
         correct: compareVerdicts(verdict, entry.ground_truth),

--- a/benchmark/run_benchmark.js
+++ b/benchmark/run_benchmark.js
@@ -516,9 +516,17 @@ async function main() {
     const datasetMetadata = loadMetadata(DATASET_PATH);
     console.log(`Loaded ${dataset.length} entries from dataset`);
 
-    // Filter to complete entries only
-    let entries = dataset.filter(e => e.extraction_status === 'complete' && !e.needs_manual_review);
-    console.log(`${entries.length} entries are complete and ready for benchmarking`);
+    // Filter to entries ready for benchmarking. Includes both:
+    //   - extraction_status === 'complete'        — feeds normal LLM flow
+    //   - extraction_status === 'body_unusable'   — feeds the synthetic-SU
+    //     path below (no LLM call, deterministic SU verdict per provider)
+    let entries = dataset.filter(
+        e => (e.extraction_status === 'complete' || e.extraction_status === 'body_unusable')
+             && !e.needs_manual_review
+    );
+    const usableCount = entries.filter(e => e.extraction_status === 'complete').length;
+    const unusableCount = entries.length - usableCount;
+    console.log(`${entries.length} entries ready for benchmarking (${usableCount} usable, ${unusableCount} body_unusable → synthetic SU)`);
 
     if (VERSION_FILTER !== 'all') {
         const before = entries.length;
@@ -627,6 +635,18 @@ async function main() {
     await Promise.all(
         [...tasksByHost.entries()].map(([host, hostTasks]) =>
             runPool(hostTasks, CONCURRENCY, async ({ entry, provider }) => {
+                // body_unusable rows synthesize a "Source unavailable" verdict
+                // for every provider without invoking the LLM. The body-classifier
+                // (in extract_dataset.js) already determined the answer; the
+                // benchmark just records it.
+                if (entry.extraction_status === 'body_unusable') {
+                    results.push(synthesizePipelineSU(entry, provider, PROVIDERS[provider].model));
+                    completed++;
+                    console.log(`[${completed}/${totalTasks}] ${entry.id} / ${provider} (pipeline_attributed=${entry.body_unusable_reason})`);
+                    requestSave();
+                    return;
+                }
+
                 const userPrompt = generateUserPrompt(entry.claim_text, entry.source_text);
 
                 const result = await callProvider(provider, systemPrompt, userPrompt);
@@ -665,9 +685,35 @@ async function main() {
 }
 
 /**
+ * Synthesize a deterministic "Source unavailable" result for a body_unusable
+ * dataset row, without invoking the LLM. Used by the runner for rows where
+ * the body-classifier flagged structurally-bad extracted content (Wayback
+ * chrome, CSS leak, anti-bot challenge, etc.). The `pipeline_attributed`
+ * flag lets analyze_results.js split pipeline-vs-model attribution in the
+ * per-provider accuracy metric.
+ */
+export function synthesizePipelineSU(entry, provider, model) {
+    const verdict = 'Source unavailable';
+    return {
+        entry_id: entry.id,
+        provider,
+        model,
+        ground_truth: entry.ground_truth,
+        predicted_verdict: verdict,
+        confidence: 'High',
+        comments: `Pipeline-attributed (${entry.body_unusable_reason || 'unknown'})`,
+        latency_ms: 0,
+        error: null,
+        correct: compareVerdicts(verdict, entry.ground_truth),
+        pipeline_attributed: true,
+        timestamp: new Date().toISOString(),
+    };
+}
+
+/**
  * Compare predicted verdict with ground truth
  */
-function compareVerdicts(predicted, groundTruth) {
+export function compareVerdicts(predicted, groundTruth) {
     const p = predicted.toLowerCase();
     const g = groundTruth.toLowerCase();
 

--- a/benchmark/run_benchmark.js
+++ b/benchmark/run_benchmark.js
@@ -506,17 +506,26 @@ async function main() {
     const datasetMetadata = loadMetadata(DATASET_PATH);
     console.log(`Loaded ${dataset.length} entries from dataset`);
 
-    // Filter to entries ready for benchmarking. Includes both:
-    //   - extraction_status === 'complete'        — feeds normal LLM flow
-    //   - extraction_status === 'body_unusable'   — feeds the synthetic-SU
-    //     path below (no LLM call, deterministic SU verdict per provider)
+    // Filter to entries ready for benchmarking. Three buckets:
+    //   - extraction_status === 'complete'             — feeds normal LLM flow
+    //   - extraction_status === 'body_unusable'        — synthetic SU (no LLM call);
+    //                                                    reason from body_unusable_reason
+    //   - extraction_status === 'source_fetch_failed'  — synthetic SU (no LLM call);
+    //                                                    reason 'fetch_failed'. Mirrors
+    //                                                    production userscript behavior
+    //                                                    where worker.js returns the
+    //                                                    same { sourceUnavailable } shape
+    //                                                    on proxy/network failure.
     let entries = dataset.filter(
-        e => (e.extraction_status === 'complete' || e.extraction_status === 'body_unusable')
+        e => (e.extraction_status === 'complete'
+              || e.extraction_status === 'body_unusable'
+              || e.extraction_status === 'source_fetch_failed')
              && !e.needs_manual_review
     );
     const usableCount = entries.filter(e => e.extraction_status === 'complete').length;
-    const unusableCount = entries.length - usableCount;
-    console.log(`${entries.length} entries ready for benchmarking (${usableCount} usable, ${unusableCount} body_unusable → synthetic SU)`);
+    const unusableCount = entries.filter(e => e.extraction_status === 'body_unusable').length;
+    const fetchFailedCount = entries.filter(e => e.extraction_status === 'source_fetch_failed').length;
+    console.log(`${entries.length} entries ready for benchmarking (${usableCount} usable, ${unusableCount} body_unusable → synthetic SU, ${fetchFailedCount} source_fetch_failed → synthetic SU)`);
 
     if (VERSION_FILTER !== 'all') {
         const before = entries.length;
@@ -625,14 +634,19 @@ async function main() {
     await Promise.all(
         [...tasksByHost.entries()].map(([host, hostTasks]) =>
             runPool(hostTasks, CONCURRENCY, async ({ entry, provider }) => {
-                // body_unusable rows synthesize a "Source unavailable" verdict
-                // for every provider without invoking the LLM. The body-classifier
-                // (in extract_dataset.js) already determined the answer; the
-                // benchmark just records it.
-                if (entry.extraction_status === 'body_unusable') {
+                // body_unusable + source_fetch_failed rows synthesize a
+                // "Source unavailable" verdict for every provider without invoking the
+                // LLM. body_unusable is the body-classifier path; source_fetch_failed
+                // is the pre-LLM-fetch path (proxy/network failure). Mirrors
+                // production worker.js behavior where both surface as the same
+                // { sourceUnavailable, reason } shape.
+                if (entry.extraction_status === 'body_unusable'
+                    || entry.extraction_status === 'source_fetch_failed') {
                     results.push(synthesizePipelineSU(entry, provider, PROVIDERS[provider].model));
                     completed++;
-                    console.log(`[${completed}/${totalTasks}] ${entry.id} / ${provider} (pipeline_attributed=${entry.body_unusable_reason})`);
+                    const reason = entry.body_unusable_reason
+                        || (entry.extraction_status === 'source_fetch_failed' ? 'fetch_failed' : 'unknown');
+                    console.log(`[${completed}/${totalTasks}] ${entry.id} / ${provider} (pipeline_attributed=${reason})`);
                     requestSave();
                     return;
                 }
@@ -675,15 +689,20 @@ async function main() {
 }
 
 /**
- * Synthesize a deterministic "Source unavailable" result for a body_unusable
- * dataset row, without invoking the LLM. Used by the runner for rows where
- * the body-classifier flagged structurally-bad extracted content (Wayback
- * chrome, CSS leak, anti-bot challenge, etc.). The `pipeline_attributed`
- * flag lets analyze_results.js split pipeline-vs-model attribution in the
- * per-provider accuracy metric.
+ * Synthesize a deterministic "Source unavailable" result for a dataset row
+ * that won't reach the LLM. Used by the runner for two cases:
+ *  - extraction_status === 'body_unusable': body-classifier flagged
+ *    structurally-bad extracted content (Wayback chrome, CSS leak, anti-bot
+ *    challenge, etc.); reason is in entry.body_unusable_reason.
+ *  - extraction_status === 'source_fetch_failed': the proxy never produced
+ *    usable content (network/proxy failure); reason defaults to 'fetch_failed'.
+ * The `pipeline_attributed` flag lets analyze_results.js split pipeline-vs-
+ * model attribution in the per-provider accuracy metric.
  */
 export function synthesizePipelineSU(entry, provider, model) {
     const verdict = 'Source unavailable';
+    const reason = entry.body_unusable_reason
+        || (entry.extraction_status === 'source_fetch_failed' ? 'fetch_failed' : 'unknown');
     return {
         entry_id: entry.id,
         provider,
@@ -691,7 +710,7 @@ export function synthesizePipelineSU(entry, provider, model) {
         ground_truth: entry.ground_truth,
         predicted_verdict: verdict,
         confidence: 'High',
-        comments: `Pipeline-attributed (${entry.body_unusable_reason || 'unknown'})`,
+        comments: `Pipeline-attributed (${reason})`,
         latency_ms: 0,
         error: null,
         correct: compareVerdicts(verdict, entry.ground_truth),

--- a/cli/verify.js
+++ b/cli/verify.js
@@ -314,13 +314,14 @@ export async function runVerify(opts, { stdout = process.stdout, stderr = proces
     // 8. Fetch the source content via the worker proxy.
     const sourceInfo = await fetchSourceContent(sourceUrl, pageNum);
     if (!sourceInfo) {
+        // Defensive: worker.js no longer returns null; only retained in case a
+        // future caller path or test mock returns null.
         stderr.write(`ccs: source unavailable: ${sourceUrl}\n`);
         return 7;
     }
     if (typeof sourceInfo === 'object' && sourceInfo.sourceUnavailable) {
-        // Body classifier flagged extracted content as structurally unusable
-        // (Wayback chrome, JS-only skeleton, anti-bot challenge, etc.). The
-        // verdict is pipeline-attributed; no LLM call needed.
+        // Source cannot be verified deterministically — fetch failure, skip-listed
+        // URL (Google Books), or body-classifier rejection. No LLM call needed.
         stderr.write(`ccs: source unavailable (${sourceInfo.reason}): ${sourceUrl}\n`);
         return 7;
     }

--- a/cli/verify.js
+++ b/cli/verify.js
@@ -299,6 +299,13 @@ export async function runVerify(opts, { stdout = process.stdout, stderr = proces
         stderr.write(`ccs: source unavailable: ${sourceUrl}\n`);
         return 7;
     }
+    if (typeof sourceInfo === 'object' && sourceInfo.sourceUnavailable) {
+        // Body classifier flagged extracted content as structurally unusable
+        // (Wayback chrome, JS-only skeleton, anti-bot challenge, etc.). The
+        // verdict is pipeline-attributed; no LLM call needed.
+        stderr.write(`ccs: source unavailable (${sourceInfo.reason}): ${sourceUrl}\n`);
+        return 7;
+    }
 
     // 9. Build prompts and call the LLM.
     //    fetchSourceContent returns a string shaped "Source URL: <u>\n\n

--- a/core/body-classifier.js
+++ b/core/body-classifier.js
@@ -1,0 +1,100 @@
+// Classify whether an extracted source body is usable for downstream LLM
+// verification. Returns { usable: true, reason: 'ok' } for content that should
+// proceed, or { usable: false, reason: <pattern-name> } for structurally-bad
+// bodies (Wayback chrome, CSS leak, JSON-LD blob, anti-bot challenge, etc.).
+//
+// When the classifier returns usable:false, the caller (userscript / benchmark)
+// should short-circuit to a "Source unavailable" verdict without invoking an
+// LLM. This pulls the SU-vs-Not-Supported decision out of the LLM's
+// responsibility in cases where the answer is mechanically determinable — the
+// LLM only needs to handle support-or-not-support on usable content.
+//
+// Patterns are derived from real failure cases observed in a 185-row × 9-provider
+// citation-verification benchmark (combined-integration treatment), where both
+// Claude Sonnet 4.5 and Claude Opus 4.7 agreed on a wrong "Source unavailable"
+// verdict against a ground-truth "Not supported" label. Each pattern has at
+// least one matching regression-test fixture in tests/body_classifier.test.js.
+
+const SIGNATURE_LEN = 500;
+const SHORT_BODY_FLOOR = 300;
+// Upper length bound for "chrome-dominated" detectors. Above this, even if a
+// chrome marker is present at the top, we assume substantive content follows
+// (e.g., row_9: 912 chars of "The Wayback Machine - …" prefix + USCIS article).
+// Tuned conservatively to favor false negatives (let body through, LLM handles)
+// over false positives (real content discarded as unusable).
+const CHROME_LENGTH_CAP = 600;
+
+const PATTERNS = [
+  {
+    reason: 'json_ld_leak',
+    // Body is a JSON-LD blob (schema.org structured data picked up by Defuddle
+    // instead of the article body).
+    test: (text) =>
+      /^\s*\{[^{}]{0,200}"@(context|type|graph)"\s*:/.test(text),
+  },
+  {
+    reason: 'css_leak',
+    // Body is CSS rules (Defuddle picked up a <style> element).
+    // Confirmed with CSS-glyph density in the signature window.
+    test: (text) => {
+      const head = text.slice(0, SIGNATURE_LEN);
+      if (!/^[\s.#@\w-]+\{[^{}]{10,}/.test(head)) return false;
+      const cssGlyphs = (head.match(/[{};:]/g) || []).length;
+      return cssGlyphs / head.length > 0.05;
+    },
+  },
+  {
+    reason: 'anti_bot_challenge',
+    // Cloudflare / Anubis / generic JS-challenge interstitials.
+    test: (text) =>
+      /(Making sure you('|&#39;)re not a bot|Anubis uses a Proof-of-Work|Just a moment\.\.\.|Verifying you are human|Please enable JavaScript and cookies|Checking your browser before accessing)/i
+        .test(text.slice(0, 1500)),
+  },
+  {
+    reason: 'wayback_redirect_notice',
+    // Wayback "page redirected at crawl time" interstitial.
+    test: (text) =>
+      /Got an HTTP \d{3} response at crawl time/.test(text.slice(0, 1500)),
+  },
+  {
+    reason: 'wayback_chrome',
+    // Wayback Machine wrapper captured without the inner archived content.
+    // Fire only when the body is too short to contain substantive content
+    // after the chrome — a Wayback prefix on a long body indicates the real
+    // article follows (see row_9: 912 chars, USCIS glossary entry).
+    // The id_-flag URL rewrite in PAP reduces incidence but doesn't eliminate
+    // it (PDF-too-large, JS-only archives still produce chrome).
+    test: (text) => {
+      if (text.length >= CHROME_LENGTH_CAP) return false;
+      const head = text.slice(0, SIGNATURE_LEN);
+      return (
+        /^The Wayback Machine - https?:\/\//.test(head) ||
+        /\d+ captures\s+\d{1,2} \w+ \d{4}/.test(head) ||
+        /\bCOLLECTED BY\s+Collection:/.test(head)
+      );
+    },
+  },
+  {
+    reason: 'amazon_stub',
+    // Amazon listing page rendered without product details (JS-loaded).
+    test: (text) =>
+      /Conditions of Use(?: & Sale)?\s*\n?\s*Privacy Notice\s*\n?\s*©\s*\d{4}-\d{4},?\s*Amazon\.com/i
+        .test(text),
+  },
+  {
+    reason: 'short_body',
+    // Catch-all for bodies too short to be substantive. Conservative floor —
+    // false positives (real short content flagged as unusable) directly hurt
+    // accuracy; false negatives are recoverable (LLM still handles).
+    test: (text) => text.length < SHORT_BODY_FLOOR,
+  },
+];
+
+export function classifyBody(text) {
+  if (text == null) return { usable: false, reason: 'short_body' };
+  const trimmed = text.trim();
+  for (const { reason, test } of PATTERNS) {
+    if (test(trimmed)) return { usable: false, reason };
+  }
+  return { usable: true, reason: 'ok' };
+}

--- a/core/worker.js
+++ b/core/worker.js
@@ -6,16 +6,23 @@ import { classifyBody } from './body-classifier.js';
 // fetchSourceContent return shapes:
 //   string                                  — usable body, formatted as
 //                                             "Source URL: <u>\n\nSource Content:\n<body>"
-//   null                                    — fetch failed (network/proxy/Google Books skip)
-//   { sourceUnavailable, reason }           — body is structurally bad (Wayback chrome,
-//                                             CSS leak, JSON-LD blob, anti-bot challenge,
-//                                             etc.). Callers should record a deterministic
-//                                             "Source unavailable" verdict without invoking
-//                                             the LLM. See core/body-classifier.js.
+//   { sourceUnavailable, reason }           — source cannot be verified deterministically.
+//                                             Callers should record a "Source unavailable"
+//                                             verdict without invoking the LLM. Reasons:
+//                                               'google_books_skip' — Google Books URL,
+//                                                                    intentionally not fetched
+//                                               'fetch_failed'      — proxy error, empty response,
+//                                                                    or network exception
+//                                               '<classifier code>' — body fetched but flagged
+//                                                                    structurally bad by
+//                                                                    core/body-classifier.js
+//                                                                    (wayback_chrome, short_body,
+//                                                                    json_ld_leak, css_leak,
+//                                                                    amazon_stub, anti_bot_challenge)
 export async function fetchSourceContent(url, pageNum, { workerBase = 'https://publicai-proxy.alaexis.workers.dev' } = {}) {
     if (isGoogleBooksUrl(url)) {
         console.log('[CitationVerifier] Skipping Google Books URL:', url);
-        return null;
+        return { sourceUnavailable: true, reason: 'google_books_skip' };
     }
 
     try {
@@ -28,7 +35,7 @@ export async function fetchSourceContent(url, pageNum, { workerBase = 'https://p
 
         if (data.error) {
             console.warn('[CitationVerifier] Proxy error:', data.error);
-            return null;
+            return { sourceUnavailable: true, reason: 'fetch_failed' };
         }
 
         if (data.content && data.content.length > 100) {
@@ -61,7 +68,9 @@ export async function fetchSourceContent(url, pageNum, { workerBase = 'https://p
     } catch (error) {
         console.error('Proxy fetch failed:', error);
     }
-    return null; // Falls back to manual input
+    // Reached when content is missing/too-short or an exception was caught.
+    // Both are forms of "couldn't get usable content" → fetch_failed SU.
+    return { sourceUnavailable: true, reason: 'fetch_failed' };
 }
 
 export function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis.workers.dev' } = {}) {

--- a/core/worker.js
+++ b/core/worker.js
@@ -73,6 +73,31 @@ export async function fetchSourceContent(url, pageNum, { workerBase = 'https://p
     return { sourceUnavailable: true, reason: 'fetch_failed' };
 }
 
+// User-facing status text for an SU return shape. Used by main.js's
+// single-citation Verify path. fetch_failed preserves the pre-unification
+// wording ("Could not fetch source…") since users see "fetched nothing"
+// as different in tone from "fetched but body is bad," even though the
+// runtime treats them identically. All other reasons surface the reason
+// code in parentheses so the user can distinguish patterns over time.
+export function sourceUnavailableStatusText(reason) {
+    if (reason === 'fetch_failed') {
+        return 'Could not fetch source. Please paste the source text below.';
+    }
+    return `Source unavailable (${reason}). Paste the source text below if you have it.`;
+}
+
+// Report-comment text for an SU return shape. Used by main.js's batch-report
+// path and by benchmark/run_benchmark.js's synthesizePipelineSU. fetch_failed
+// preserves the pre-unification "Could not fetch source content" wording;
+// other reasons use the Pipeline-attributed prefix so analyze_results.js
+// (and human reviewers) can pattern-match on it.
+export function sourceUnavailableComment(reason) {
+    if (reason === 'fetch_failed') {
+        return 'Could not fetch source content';
+    }
+    return `Pipeline-attributed (${reason})`;
+}
+
 export function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis.workers.dev' } = {}) {
     // Wrap the fetch POST in try/catch exactly as main.js does.
     // `payload` replaces the constructed object in main.js — caller supplies

--- a/core/worker.js
+++ b/core/worker.js
@@ -1,7 +1,17 @@
 // Calls to the Cloudflare Worker proxy: source fetching and verification logging.
 
 import { isGoogleBooksUrl } from './urls.js';
+import { classifyBody } from './body-classifier.js';
 
+// fetchSourceContent return shapes:
+//   string                                  — usable body, formatted as
+//                                             "Source URL: <u>\n\nSource Content:\n<body>"
+//   null                                    — fetch failed (network/proxy/Google Books skip)
+//   { sourceUnavailable, reason }           — body is structurally bad (Wayback chrome,
+//                                             CSS leak, JSON-LD blob, anti-bot challenge,
+//                                             etc.). Callers should record a deterministic
+//                                             "Source unavailable" verdict without invoking
+//                                             the LLM. See core/body-classifier.js.
 export async function fetchSourceContent(url, pageNum, { workerBase = 'https://publicai-proxy.alaexis.workers.dev' } = {}) {
     if (isGoogleBooksUrl(url)) {
         console.log('[CitationVerifier] Skipping Google Books URL:', url);
@@ -22,6 +32,10 @@ export async function fetchSourceContent(url, pageNum, { workerBase = 'https://p
         }
 
         if (data.content && data.content.length > 100) {
+            const classification = classifyBody(data.content);
+            if (!classification.usable) {
+                return { sourceUnavailable: true, reason: classification.reason };
+            }
             // Proxy caps fetched content around 12k chars. If we're at or
             // above that, the source was almost certainly truncated and
             // only partially sent to the model.

--- a/main.js
+++ b/main.js
@@ -846,6 +846,31 @@ async function fetchSourceContent(url, pageNum, { workerBase = 'https://publicai
     return { sourceUnavailable: true, reason: 'fetch_failed' };
 }
 
+// User-facing status text for an SU return shape. Used by main.js's
+// single-citation Verify path. fetch_failed preserves the pre-unification
+// wording ("Could not fetch source…") since users see "fetched nothing"
+// as different in tone from "fetched but body is bad," even though the
+// runtime treats them identically. All other reasons surface the reason
+// code in parentheses so the user can distinguish patterns over time.
+function sourceUnavailableStatusText(reason) {
+    if (reason === 'fetch_failed') {
+        return 'Could not fetch source. Please paste the source text below.';
+    }
+    return `Source unavailable (${reason}). Paste the source text below if you have it.`;
+}
+
+// Report-comment text for an SU return shape. Used by main.js's batch-report
+// path and by benchmark/run_benchmark.js's synthesizePipelineSU. fetch_failed
+// preserves the pre-unification "Could not fetch source content" wording;
+// other reasons use the Pipeline-attributed prefix so analyze_results.js
+// (and human reviewers) can pattern-match on it.
+function sourceUnavailableComment(reason) {
+    if (reason === 'fetch_failed') {
+        return 'Could not fetch source content';
+    }
+    return `Pipeline-attributed (${reason})`;
+}
+
 function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis.workers.dev' } = {}) {
     // Wrap the fetch POST in try/catch exactly as main.js does.
     // `payload` replaces the constructed object in main.js — caller supplies
@@ -2390,14 +2415,10 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
                     // Source cannot be verified deterministically — either fetch failed
                     // (network/proxy/empty body), URL is on the skip list (Google Books),
                     // or the body-classifier flagged the extracted content as structurally
-                    // unusable. No LLM call is made.
+                    // unusable. No LLM call is made. Message wording is in
+                    // sourceUnavailableStatusText() (core/worker.js) for unit testability.
                     this.showSourceTextInput();
-                    const reason = sourceInfo.reason;
-                    if (reason === 'fetch_failed') {
-                        this.updateStatus('Could not fetch source. Please paste the source text below.');
-                    } else {
-                        this.updateStatus(`Source unavailable (${reason}). Paste the source text below if you have it.`);
-                    }
+                    this.updateStatus(sourceUnavailableStatusText(sourceInfo.reason));
                     return;
                 }
 
@@ -3567,11 +3588,8 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
                     } else if (typeof sourceContent === 'object' && sourceContent.sourceUnavailable) {
                         // Source cannot be verified deterministically — fetch failure,
                         // skip-listed URL (Google Books), or body-classifier rejection.
-                        // No LLM call is made.
-                        const reason = sourceContent.reason;
-                        const comments = reason === 'fetch_failed'
-                            ? 'Could not fetch source content'
-                            : `Pipeline-attributed (${reason})`;
+                        // No LLM call is made. Comment wording is in
+                        // sourceUnavailableComment() (core/worker.js) for unit testability.
                         result = {
                             citationNumber: citation.citationNumber,
                             claimText: citation.claimText,
@@ -3579,7 +3597,7 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
                             refElement: citation.refElement,
                             verdict: 'SOURCE UNAVAILABLE',
                             confidence: 0,
-                            comments,
+                            comments: sourceUnavailableComment(sourceContent.reason),
                             truncated: false
                         };
                     } else {

--- a/main.js
+++ b/main.js
@@ -633,10 +633,121 @@ async function callProviderAPI(name, config) {
     }
 }
 
+// --- core/body-classifier.js ---
+// Classify whether an extracted source body is usable for downstream LLM
+// verification. Returns { usable: true, reason: 'ok' } for content that should
+// proceed, or { usable: false, reason: <pattern-name> } for structurally-bad
+// bodies (Wayback chrome, CSS leak, JSON-LD blob, anti-bot challenge, etc.).
+//
+// When the classifier returns usable:false, the caller (userscript / benchmark)
+// should short-circuit to a "Source unavailable" verdict without invoking an
+// LLM. This pulls the SU-vs-Not-Supported decision out of the LLM's
+// responsibility in cases where the answer is mechanically determinable — the
+// LLM only needs to handle support-or-not-support on usable content.
+//
+// Patterns are derived from real failure cases observed in a 185-row × 9-provider
+// citation-verification benchmark (combined-integration treatment), where both
+// Claude Sonnet 4.5 and Claude Opus 4.7 agreed on a wrong "Source unavailable"
+// verdict against a ground-truth "Not supported" label. Each pattern has at
+// least one matching regression-test fixture in tests/body_classifier.test.js.
+
+const SIGNATURE_LEN = 500;
+const SHORT_BODY_FLOOR = 300;
+// Upper length bound for "chrome-dominated" detectors. Above this, even if a
+// chrome marker is present at the top, we assume substantive content follows
+// (e.g., row_9: 912 chars of "The Wayback Machine - …" prefix + USCIS article).
+// Tuned conservatively to favor false negatives (let body through, LLM handles)
+// over false positives (real content discarded as unusable).
+const CHROME_LENGTH_CAP = 600;
+
+const PATTERNS = [
+  {
+    reason: 'json_ld_leak',
+    // Body is a JSON-LD blob (schema.org structured data picked up by Defuddle
+    // instead of the article body).
+    test: (text) =>
+      /^\s*\{[^{}]{0,200}"@(context|type|graph)"\s*:/.test(text),
+  },
+  {
+    reason: 'css_leak',
+    // Body is CSS rules (Defuddle picked up a <style> element).
+    // Confirmed with CSS-glyph density in the signature window.
+    test: (text) => {
+      const head = text.slice(0, SIGNATURE_LEN);
+      if (!/^[\s.#@\w-]+\{[^{}]{10,}/.test(head)) return false;
+      const cssGlyphs = (head.match(/[{};:]/g) || []).length;
+      return cssGlyphs / head.length > 0.05;
+    },
+  },
+  {
+    reason: 'anti_bot_challenge',
+    // Cloudflare / Anubis / generic JS-challenge interstitials.
+    test: (text) =>
+      /(Making sure you('|&#39;)re not a bot|Anubis uses a Proof-of-Work|Just a moment\.\.\.|Verifying you are human|Please enable JavaScript and cookies|Checking your browser before accessing)/i
+        .test(text.slice(0, 1500)),
+  },
+  {
+    reason: 'wayback_redirect_notice',
+    // Wayback "page redirected at crawl time" interstitial.
+    test: (text) =>
+      /Got an HTTP \d{3} response at crawl time/.test(text.slice(0, 1500)),
+  },
+  {
+    reason: 'wayback_chrome',
+    // Wayback Machine wrapper captured without the inner archived content.
+    // Fire only when the body is too short to contain substantive content
+    // after the chrome — a Wayback prefix on a long body indicates the real
+    // article follows (see row_9: 912 chars, USCIS glossary entry).
+    // The id_-flag URL rewrite in PAP reduces incidence but doesn't eliminate
+    // it (PDF-too-large, JS-only archives still produce chrome).
+    test: (text) => {
+      if (text.length >= CHROME_LENGTH_CAP) return false;
+      const head = text.slice(0, SIGNATURE_LEN);
+      return (
+        /^The Wayback Machine - https?:\/\//.test(head) ||
+        /\d+ captures\s+\d{1,2} \w+ \d{4}/.test(head) ||
+        /\bCOLLECTED BY\s+Collection:/.test(head)
+      );
+    },
+  },
+  {
+    reason: 'amazon_stub',
+    // Amazon listing page rendered without product details (JS-loaded).
+    test: (text) =>
+      /Conditions of Use(?: & Sale)?\s*\n?\s*Privacy Notice\s*\n?\s*©\s*\d{4}-\d{4},?\s*Amazon\.com/i
+        .test(text),
+  },
+  {
+    reason: 'short_body',
+    // Catch-all for bodies too short to be substantive. Conservative floor —
+    // false positives (real short content flagged as unusable) directly hurt
+    // accuracy; false negatives are recoverable (LLM still handles).
+    test: (text) => text.length < SHORT_BODY_FLOOR,
+  },
+];
+
+function classifyBody(text) {
+  if (text == null) return { usable: false, reason: 'short_body' };
+  const trimmed = text.trim();
+  for (const { reason, test } of PATTERNS) {
+    if (test(trimmed)) return { usable: false, reason };
+  }
+  return { usable: true, reason: 'ok' };
+}
+
 // --- core/worker.js ---
 // Calls to the Cloudflare Worker proxy: source fetching and verification logging.
 
 
+// fetchSourceContent return shapes:
+//   string                                  — usable body, formatted as
+//                                             "Source URL: <u>\n\nSource Content:\n<body>"
+//   null                                    — fetch failed (network/proxy/Google Books skip)
+//   { sourceUnavailable, reason }           — body is structurally bad (Wayback chrome,
+//                                             CSS leak, JSON-LD blob, anti-bot challenge,
+//                                             etc.). Callers should record a deterministic
+//                                             "Source unavailable" verdict without invoking
+//                                             the LLM. See core/body-classifier.js.
 async function fetchSourceContent(url, pageNum, { workerBase = 'https://publicai-proxy.alaexis.workers.dev' } = {}) {
     if (isGoogleBooksUrl(url)) {
         console.log('[CitationVerifier] Skipping Google Books URL:', url);
@@ -657,6 +768,10 @@ async function fetchSourceContent(url, pageNum, { workerBase = 'https://publicai
         }
 
         if (data.content && data.content.length > 100) {
+            const classification = classifyBody(data.content);
+            if (!classification.usable) {
+                return { sourceUnavailable: true, reason: classification.reason };
+            }
             // Proxy caps fetched content around 12k chars. If we're at or
             // above that, the source was almost certainly truncated and
             // only partially sent to the model.
@@ -2223,6 +2338,15 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
                     return;
                 }
 
+                if (typeof sourceInfo === 'object' && sourceInfo.sourceUnavailable) {
+                    // Body classifier flagged the extracted content as structurally
+                    // unusable (Wayback chrome, JS-only skeleton, anti-bot challenge,
+                    // etc.). The verdict is determined here without invoking the LLM.
+                    this.showSourceTextInput();
+                    this.updateStatus(`Source unavailable (${sourceInfo.reason}). Paste the source text below if you have it.`);
+                    return;
+                }
+
                 this.activeSource = sourceInfo;
                 const sourceElement = document.getElementById('verifier-source-text');
 
@@ -3382,6 +3506,19 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
                             verdict: 'SOURCE UNAVAILABLE',
                             confidence: 0,
                             comments: 'Could not fetch source content',
+                            truncated: false
+                        };
+                    } else if (typeof sourceContent === 'object' && sourceContent.sourceUnavailable) {
+                        // Body classifier flagged the extracted content as structurally
+                        // unusable. Record SU verdict without invoking the LLM.
+                        result = {
+                            citationNumber: citation.citationNumber,
+                            claimText: citation.claimText,
+                            url: citation.url,
+                            refElement: citation.refElement,
+                            verdict: 'SOURCE UNAVAILABLE',
+                            confidence: 0,
+                            comments: `Pipeline-attributed (${sourceContent.reason})`,
                             truncated: false
                         };
                     } else {

--- a/main.js
+++ b/main.js
@@ -779,16 +779,23 @@ function classifyBody(text) {
 // fetchSourceContent return shapes:
 //   string                                  — usable body, formatted as
 //                                             "Source URL: <u>\n\nSource Content:\n<body>"
-//   null                                    — fetch failed (network/proxy/Google Books skip)
-//   { sourceUnavailable, reason }           — body is structurally bad (Wayback chrome,
-//                                             CSS leak, JSON-LD blob, anti-bot challenge,
-//                                             etc.). Callers should record a deterministic
-//                                             "Source unavailable" verdict without invoking
-//                                             the LLM. See core/body-classifier.js.
+//   { sourceUnavailable, reason }           — source cannot be verified deterministically.
+//                                             Callers should record a "Source unavailable"
+//                                             verdict without invoking the LLM. Reasons:
+//                                               'google_books_skip' — Google Books URL,
+//                                                                    intentionally not fetched
+//                                               'fetch_failed'      — proxy error, empty response,
+//                                                                    or network exception
+//                                               '<classifier code>' — body fetched but flagged
+//                                                                    structurally bad by
+//                                                                    core/body-classifier.js
+//                                                                    (wayback_chrome, short_body,
+//                                                                    json_ld_leak, css_leak,
+//                                                                    amazon_stub, anti_bot_challenge)
 async function fetchSourceContent(url, pageNum, { workerBase = 'https://publicai-proxy.alaexis.workers.dev' } = {}) {
     if (isGoogleBooksUrl(url)) {
         console.log('[CitationVerifier] Skipping Google Books URL:', url);
-        return null;
+        return { sourceUnavailable: true, reason: 'google_books_skip' };
     }
 
     try {
@@ -801,7 +808,7 @@ async function fetchSourceContent(url, pageNum, { workerBase = 'https://publicai
 
         if (data.error) {
             console.warn('[CitationVerifier] Proxy error:', data.error);
-            return null;
+            return { sourceUnavailable: true, reason: 'fetch_failed' };
         }
 
         if (data.content && data.content.length > 100) {
@@ -834,7 +841,9 @@ async function fetchSourceContent(url, pageNum, { workerBase = 'https://publicai
     } catch (error) {
         console.error('Proxy fetch failed:', error);
     }
-    return null; // Falls back to manual input
+    // Reached when content is missing/too-short or an exception was caught.
+    // Both are forms of "couldn't get usable content" → fetch_failed SU.
+    return { sourceUnavailable: true, reason: 'fetch_failed' };
 }
 
 function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis.workers.dev' } = {}) {
@@ -2370,17 +2379,25 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
                 }
 
                 if (!sourceInfo) {
+                    // Defensive: callers may cache null on exception (see batch report
+                    // path). worker.js itself no longer returns null.
                     this.showSourceTextInput();
                     this.updateStatus('Could not fetch source. Please paste the source text below.');
                     return;
                 }
 
                 if (typeof sourceInfo === 'object' && sourceInfo.sourceUnavailable) {
-                    // Body classifier flagged the extracted content as structurally
-                    // unusable (Wayback chrome, JS-only skeleton, anti-bot challenge,
-                    // etc.). The verdict is determined here without invoking the LLM.
+                    // Source cannot be verified deterministically — either fetch failed
+                    // (network/proxy/empty body), URL is on the skip list (Google Books),
+                    // or the body-classifier flagged the extracted content as structurally
+                    // unusable. No LLM call is made.
                     this.showSourceTextInput();
-                    this.updateStatus(`Source unavailable (${sourceInfo.reason}). Paste the source text below if you have it.`);
+                    const reason = sourceInfo.reason;
+                    if (reason === 'fetch_failed') {
+                        this.updateStatus('Could not fetch source. Please paste the source text below.');
+                    } else {
+                        this.updateStatus(`Source unavailable (${reason}). Paste the source text below if you have it.`);
+                    }
                     return;
                 }
 
@@ -3535,6 +3552,8 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
                     const sourceContent = this.sourceCache.get(cacheKey);
 
                     if (!sourceContent) {
+                        // Defensive: an exception in fetchSourceContent was caught above
+                        // and cached as null. worker.js itself no longer returns null.
                         result = {
                             citationNumber: citation.citationNumber,
                             claimText: citation.claimText,
@@ -3546,8 +3565,13 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
                             truncated: false
                         };
                     } else if (typeof sourceContent === 'object' && sourceContent.sourceUnavailable) {
-                        // Body classifier flagged the extracted content as structurally
-                        // unusable. Record SU verdict without invoking the LLM.
+                        // Source cannot be verified deterministically — fetch failure,
+                        // skip-listed URL (Google Books), or body-classifier rejection.
+                        // No LLM call is made.
+                        const reason = sourceContent.reason;
+                        const comments = reason === 'fetch_failed'
+                            ? 'Could not fetch source content'
+                            : `Pipeline-attributed (${reason})`;
                         result = {
                             citationNumber: citation.citationNumber,
                             claimText: citation.claimText,
@@ -3555,7 +3579,7 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
                             refElement: citation.refElement,
                             verdict: 'SOURCE UNAVAILABLE',
                             confidence: 0,
-                            comments: `Pipeline-attributed (${sourceContent.reason})`,
+                            comments,
                             truncated: false
                         };
                     } else {

--- a/scripts/sync-main.js
+++ b/scripts/sync-main.js
@@ -19,6 +19,7 @@ const CORE_ORDER = [
   'urls.js',
   'claim.js',
   'providers.js',
+  'body-classifier.js',
   'worker.js',
 ];
 

--- a/tests/benchmark_runner.test.js
+++ b/tests/benchmark_runner.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-import { runPool, withRetry, makeSaver, hostForProvider } from '../benchmark/run_benchmark.js';
+import { runPool, withRetry, makeSaver, hostForProvider, synthesizePipelineSU, compareVerdicts } from '../benchmark/run_benchmark.js';
 
 // ---- runPool ----------------------------------------------------------------
 
@@ -259,4 +259,53 @@ test('hostForProvider: real PROVIDERS — PublicAI models share one host', () =>
 test('hostForProvider: Anthropic and Gemini are independent hosts', () => {
     assert.equal(hostForProvider('claude-sonnet-4-5'), 'api.anthropic.com');
     assert.equal(hostForProvider('gemini-2.5-flash'), 'generativelanguage.googleapis.com');
+});
+
+// ---- synthesizePipelineSU --------------------------------------------------
+
+test('synthesizePipelineSU emits Source unavailable verdict with pipeline_attributed flag', () => {
+    const entry = {
+        id: 'row_70',
+        ground_truth: 'Not supported',
+        extraction_status: 'body_unusable',
+        body_unusable_reason: 'json_ld_leak',
+    };
+    const result = synthesizePipelineSU(entry, 'claude-sonnet-4-5', 'claude-sonnet-4-5-20250929');
+    assert.equal(result.entry_id, 'row_70');
+    assert.equal(result.provider, 'claude-sonnet-4-5');
+    assert.equal(result.model, 'claude-sonnet-4-5-20250929');
+    assert.equal(result.predicted_verdict, 'Source unavailable');
+    assert.equal(result.confidence, 'High');
+    assert.equal(result.comments, 'Pipeline-attributed (json_ld_leak)');
+    assert.equal(result.latency_ms, 0);
+    assert.equal(result.error, null);
+    assert.equal(result.pipeline_attributed, true);
+    assert.ok(result.timestamp);
+});
+
+test('synthesizePipelineSU correct field reflects GT match', () => {
+    // When GT is "Source unavailable", the synthesized verdict matches → exact
+    const matchingEntry = {
+        id: 'row_x',
+        ground_truth: 'Source unavailable',
+        body_unusable_reason: 'wayback_chrome',
+    };
+    const matching = synthesizePipelineSU(matchingEntry, 'p', 'm');
+    assert.equal(matching.correct, 'exact');
+
+    // When GT is "Supported", the synthesized SU verdict is wrong (per-row this
+    // is a pipeline-attributed failure; the analyzer separates from model failures).
+    const mismatchEntry = {
+        id: 'row_y',
+        ground_truth: 'Supported',
+        body_unusable_reason: 'wayback_chrome',
+    };
+    const mismatch = synthesizePipelineSU(mismatchEntry, 'p', 'm');
+    assert.equal(mismatch.correct, 'wrong');
+});
+
+test('synthesizePipelineSU handles missing body_unusable_reason gracefully', () => {
+    const entry = { id: 'row_x', ground_truth: 'Not supported' };
+    const result = synthesizePipelineSU(entry, 'p', 'm');
+    assert.equal(result.comments, 'Pipeline-attributed (unknown)');
 });

--- a/tests/benchmark_runner.test.js
+++ b/tests/benchmark_runner.test.js
@@ -336,3 +336,19 @@ test('synthesizePipelineSU handles missing body_unusable_reason gracefully', () 
     const result = synthesizePipelineSU(entry, 'p', 'm');
     assert.equal(result.comments, 'Pipeline-attributed (unknown)');
 });
+
+test('synthesizePipelineSU uses fetch_failed reason for source_fetch_failed rows', () => {
+    // source_fetch_failed rows have no body_unusable_reason (the proxy never
+    // returned content for the classifier to inspect). The synthesizer should
+    // tag them as fetch_failed rather than 'unknown'.
+    const entry = {
+        id: 'row_77',
+        ground_truth: 'Source unavailable',
+        extraction_status: 'source_fetch_failed',
+    };
+    const result = synthesizePipelineSU(entry, 'p', 'm');
+    assert.equal(result.predicted_verdict, 'Source unavailable');
+    assert.equal(result.comments, 'Pipeline-attributed (fetch_failed)');
+    assert.equal(result.pipeline_attributed, true);
+    assert.equal(result.correct, 'exact');
+});

--- a/tests/benchmark_runner.test.js
+++ b/tests/benchmark_runner.test.js
@@ -3,7 +3,16 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-import { runPool, withRetry, makeSaver, hostForProvider, shapeResult, synthesizePipelineSU, compareVerdicts } from '../benchmark/run_benchmark.js';
+import {
+    runPool,
+    withRetry,
+    makeSaver,
+    hostForProvider,
+    shapeResult,
+    synthesizePipelineSU,
+    compareVerdicts,
+    filterBenchmarkableEntries,
+} from '../benchmark/run_benchmark.js';
 
 // ---- runPool ----------------------------------------------------------------
 
@@ -348,7 +357,67 @@ test('synthesizePipelineSU uses fetch_failed reason for source_fetch_failed rows
     };
     const result = synthesizePipelineSU(entry, 'p', 'm');
     assert.equal(result.predicted_verdict, 'Source unavailable');
-    assert.equal(result.comments, 'Pipeline-attributed (fetch_failed)');
+    // fetch_failed routes through sourceUnavailableComment which preserves the
+    // pre-unification "Could not fetch source content" wording, matching
+    // main.js's batch-report path. Other reasons get "Pipeline-attributed (X)".
+    assert.equal(result.comments, 'Could not fetch source content');
     assert.equal(result.pipeline_attributed, true);
     assert.equal(result.correct, 'exact');
+});
+
+// ---- filterBenchmarkableEntries --------------------------------------------
+
+test('filterBenchmarkableEntries: admits complete + non-NMR rows', () => {
+    const dataset = [
+        { id: 'a', extraction_status: 'complete', needs_manual_review: false },
+        { id: 'b', extraction_status: 'complete', needs_manual_review: true },
+    ];
+    const admitted = filterBenchmarkableEntries(dataset);
+    assert.deepEqual(admitted.map(e => e.id), ['a']);
+});
+
+test('filterBenchmarkableEntries: admits body_unusable when not NMR', () => {
+    const dataset = [
+        { id: 'a', extraction_status: 'body_unusable', needs_manual_review: false, body_unusable_reason: 'wayback_chrome' },
+        { id: 'b', extraction_status: 'body_unusable', needs_manual_review: true,  body_unusable_reason: 'short_body' },
+    ];
+    const admitted = filterBenchmarkableEntries(dataset);
+    assert.deepEqual(admitted.map(e => e.id), ['a']);
+});
+
+test('filterBenchmarkableEntries: admits source_fetch_failed when not NMR', () => {
+    // Regression guard for the unification: rows whose proxy fetch failed
+    // (no source_text, no body_unusable_reason) were previously excluded as
+    // unbenchmarkable. They now flow through synthesizePipelineSU as
+    // deterministic SU. NMR rows are still rejected — those need human GT
+    // reconciliation before they enter metrics.
+    const dataset = [
+        { id: 'a', extraction_status: 'source_fetch_failed', needs_manual_review: false },
+        { id: 'b', extraction_status: 'source_fetch_failed', needs_manual_review: true },
+    ];
+    const admitted = filterBenchmarkableEntries(dataset);
+    assert.deepEqual(admitted.map(e => e.id), ['a']);
+});
+
+test('filterBenchmarkableEntries: rejects unknown extraction_status', () => {
+    // Defensive: a typo or a new status that hasn't been wired through the
+    // synthesize path yet should not silently enter the benchmark.
+    const dataset = [
+        { id: 'a', extraction_status: 'pending_review', needs_manual_review: false },
+        { id: 'b', extraction_status: 'something_new',  needs_manual_review: false },
+    ];
+    assert.equal(filterBenchmarkableEntries(dataset).length, 0);
+});
+
+test('filterBenchmarkableEntries: preserves order and does not mutate input', () => {
+    const dataset = [
+        { id: 'a', extraction_status: 'complete', needs_manual_review: false },
+        { id: 'b', extraction_status: 'body_unusable', needs_manual_review: true },
+        { id: 'c', extraction_status: 'source_fetch_failed', needs_manual_review: false },
+        { id: 'd', extraction_status: 'complete', needs_manual_review: false },
+    ];
+    const snapshot = JSON.stringify(dataset);
+    const admitted = filterBenchmarkableEntries(dataset);
+    assert.deepEqual(admitted.map(e => e.id), ['a', 'c', 'd']);
+    assert.equal(JSON.stringify(dataset), snapshot, 'input dataset must not be mutated');
 });

--- a/tests/body_classifier.test.js
+++ b/tests/body_classifier.test.js
@@ -1,0 +1,120 @@
+// Regression tests for core/body-classifier.js.
+//
+// Each fixture is a real Defuddle output from the combined-integration
+// benchmark where both Sonnet 4.5 and Opus 4.7 returned "Source unavailable"
+// against a GT of "Not supported" — i.e., cases the classifier should catch
+// so the pipeline returns SU mechanically and the LLM never has to guess.
+// The "usable" fixtures are sampled from rows where both models produced the
+// GT-matching verdict — bodies the pipeline demonstrably handled end-to-end.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { classifyBody } from '../core/body-classifier.js';
+
+// ===== Unusable bodies — classifier must catch =====
+
+test('row_94: Wayback wrapper for Croydon Minster (short, chrome-dominated)', () => {
+  const text = 'The Wayback Machine - https://web.archive.org/web/20120324190450/http://www.croydonminster.org/about-us A Living Past and a Growing Future If you want to help us support Croydon Minster, you can donate online through JustGiving.';
+  assert.deepEqual(classifyBody(text), { usable: false, reason: 'wayback_chrome' });
+});
+
+test("row_17: Wayback captures-only page (PDF didn't extract)", () => {
+  const text = '45 captures 05 Feb 2021 - 28 Jan 2026 Aug SEP Oct 10 2021 2022 2023 success fail About this capture COLLECTED BY Collection: Wikipedia Eventstream TIMESTAMPS The Wayback Machine - https://web.archive.org/web/20220910221959/https://www2.census.gov/library/publications/decennial/1900/century-of-growth';
+  assert.deepEqual(classifyBody(text), { usable: false, reason: 'wayback_chrome' });
+});
+
+test('row_64: Wayback collection-metadata-only page', () => {
+  const text = 'Aug SEP Oct 24 2022 2023 2024 COLLECTED BY Collection: Common Crawl Web crawl data from Common Crawl. The Wayback Machine - http://web.archive.org/web/20230924034658/https://almeezan.qa/LawArticles.aspx';
+  assert.deepEqual(classifyBody(text), { usable: false, reason: 'wayback_chrome' });
+});
+
+test('row_22: Internet Archive HTTP-301 redirect notice', () => {
+  const text = 'About Blog Events Projects Help Donate Donate icon An illustration of a heart shape Contact Jobs Volunteer Loading... http://seattletimes.nwsource.com/html/nationworld/2003265600_impghistory20.html | 20:20:25 October 15, 2012 Got an HTTP 301 response at crawl time Redirecting to... http://seattletimes.com/html/nationworld/2003265600_impghistory20.html';
+  assert.deepEqual(classifyBody(text), { usable: false, reason: 'wayback_redirect_notice' });
+});
+
+test('row_70: JSON-LD schema.org blob (el Heraldo)', () => {
+  const text = '{ "@context": "https://schema.org", "@type": "NewsArticle", "mainEntityOfPage": "https://www.elheraldo.hn/honduras/corte-apelaciones-admite-recurso-apelacion-alcalde-nasry-tito-asfura-corrupcion-GXEH1467634", "name": "Sala Penal ordena anular acciones penales contra Nasry \'Tito\' Asfura"';
+  assert.deepEqual(classifyBody(text), { usable: false, reason: 'json_ld_leak' });
+});
+
+test('row_146: CSS stylesheet content (almerja.com)', () => {
+  const text = '#header{ position: sticky; top: 0; z-index: 10; background-color: rgba(0961511); border-bottom: 3px solid #008ec5; padding: 0px 20px; display: flex; align-items: center; justify-content:space-around; color: #fff; user-select: none; } #header #h_r{ display: flex; align-items: center; padding: 5px; } #header #h_r p:nth-child(1){ width: 35px; height: 35px; background-color: #fff; border-radius: 50%; margin-left: 10px; display: flex; align-items: center; text-align: center; } #header #h_r p a{ display: flex; align-items: center; }';
+  assert.deepEqual(classifyBody(text), { usable: false, reason: 'css_leak' });
+});
+
+test('row_134: Amazon page rendered as footer-only stub', () => {
+  const text = 'Click the button below to continue shopping Conditions of Use & Sale Privacy Notice © 1996-2025, Amazon.com, Inc. or its affiliates';
+  assert.deepEqual(classifyBody(text), { usable: false, reason: 'amazon_stub' });
+});
+
+test('row_92: Author contact page (too short)', () => {
+  const text = 'CB-Forrest-Author-Logo Reach out to C.B. Forrest on Twitter – @cbforrest. Get in Touch Connect Please follow or message C.B. Forrest on Twitter. Twitter Hours Direct message replies on Twitter: Mon-Fri 09:00-19:00 Scroll to Top';
+  assert.deepEqual(classifyBody(text), { usable: false, reason: 'short_body' });
+});
+
+test('row_144: Anubis proof-of-work anti-bot challenge (eBird)', () => {
+  const text = 'Making sure you&#39;re not a bot! Loading... Why am I seeing this? You are seeing this because the administrator of this website has set up Anubis to protect the server against the scourge of AI companies aggressively scraping websites.';
+  assert.deepEqual(classifyBody(text), { usable: false, reason: 'anti_bot_challenge' });
+});
+
+// ===== Usable bodies — must NOT be flagged =====
+// Sampled from rows where both Sonnet 4.5 and Opus 4.7 produced the
+// GT-matching verdict in the combined-integration benchmark — i.e.,
+// bodies the pipeline demonstrably handled end-to-end. Includes Wayback-
+// prefix + real-article (row_9, common shape), short news prose, long
+// article bodies, RTL/Arabic text, and a Forbes-style intro.
+
+test('row_9: Wayback URL prefix + real USCIS glossary article (must pass — chrome is short)', () => {
+  const text = 'The Wayback Machine - https://web.archive.org/web/20160121232201/http://www.uscis.gov/tools/glossary/country-limit The maximum number of family-sponsored and employment-based preference visas that can be issued to citizens of any country in a fiscal year. The limits are calculated each fiscal year depending on the total number of family-sponsored and employment-based visas available. No more than 7 percent of the visas may be issued to natives of any one independent country in a fiscal year; no more than 2 percent may issued to any one dependency of any independent country. The per-country limit does not indicate, however, that a country is entitled to the maximum number of visas each year, just that it cannot receive more than that number. Because of the combined workings of the preference system and per-country limits, most countries do not reach this level of visa issuance. Last Reviewed/Updated:';
+  assert.deepEqual(classifyBody(text), { usable: true, reason: 'ok' });
+});
+
+test('row_14: News opinion piece (medium-length)', () => {
+  const text = 'As his price for not deporting roughly 800000 "Dreamers" who came to this country as children, Donald Trump demands an escalated war against immigrants, topped by his nightmarish 2000-mile wall along the Mexican border. Democrats have said no. Whether or not some sort of deal is eventually struck, the larger story of the past several decades is that the long-running drive to keep America Caucasian — the dream of a "Christian nation" of European descent — is failing definitively.';
+  assert.deepEqual(classifyBody(text), { usable: true, reason: 'ok' });
+});
+
+test('row_104: Local-news article (substantive prose, 1.4k chars)', () => {
+  const text = 'CIRCLEVILLE – Rax Roast beef restaurants were much like Arbys back in the 80s and 90s but where one became a huge giant the other shrunk to only a handful of stores, one that still exists is right here in Circleville Ohio. In the Hayday Rax had as many as 504 locations across the US in 38 states and now there are only seven still operating. The history of the chain dates back to 1967.';
+  assert.deepEqual(classifyBody(text), { usable: true, reason: 'ok' });
+});
+
+test('row_91: Arabic article (must not trip on non-Latin scripts)', () => {
+  const text = 'عملية الاغتيال جرت برصاصة واحدة أطلقت عليه من مسافة قريبة من إحدى نوافذ منزله سوريا قتل قائد فصيل محلي في محافظة السويداء السورية، صباح الأربعاء، وذكرت التحقيقات الأولية بإقدام مجهولين على قتله داخل منزله وباستخدام سلاح كاتم صوت. والقيادي القتيل هو قائد فصيل "لواء الجبل"، مرهج الجرماني.وقالت شبكة "السويداء 24"، إن عملية الاغتيال جرت برصاصة واحدة أطلقت عليه من مسافة قريبة من إحدى نوافذ منزله خلال نومه.والجرماني كان قائد فصيل محلي في السويداء السورية وينشط منذ عام 2014 باسم "لواء الجبل".';
+  assert.deepEqual(classifyBody(text), { usable: true, reason: 'ok' });
+});
+
+test('row_189: Real Goodreads book description (short but substantive)', () => {
+  const text = "Jump to ratings and reviews Rate this book Marjane Satrapi Rate this book From the author of Persepolis, comes this illustrated fairy tale. Rose is one of three daughters of a rich merchant who always brings gifts for his girls from the market. One day Rose asks for the seed of a blue bean, but he fails to find one for her. She lets out a sigh in resignation, and her sigh attracts the Sigh, a mysterious being that brings the seed she desired to the merchant. But every debt has to be paid, and every gift has a price, and the Sigh returns a year later to take the merchant's daughter to a secret and distant palace.56 pages, Hardcover First published January 1, 2004";
+  assert.deepEqual(classifyBody(text), { usable: true, reason: 'ok' });
+});
+
+test('row_125: Real Museo Novecento exhibition page', () => {
+  const text = 'From 17 June to 2 November 2022 the Museo Novecento hosts Corrado Cagli. Copernican Artist, an exhibition curated by Eva Francioli, Francesca Neri and Stefania Rispoli. Exhibition Hours Museo Novecento With this new exhibition project, the Museo Novecento continues its activity of enhancing the artists present within the Florentine civic collections. A scientific project started in 2018 with the exhibition dedicated to Emilio Vedova and continued with monographs dedicated, among others, to Mirko Basaldella, Mario Mafai, Arturo Martini, of which a large number of works are present in the permanent collection.';
+  assert.deepEqual(classifyBody(text), { usable: true, reason: 'ok' });
+});
+
+test('row_8: Real DHS statistical-table prose (long)', () => {
+  const text = 'The is a compendium of tables that provide data on foreign nationals who are granted lawful permanent residence (i.e., immigrants who receive a "green card"), admitted as temporary nonimmigrants, granted asylum or refugee status, or are naturalized. The Yearbook also presents data on immigration enforcement actions, including apprehensions and arrests, removals, and returns. Family-Sponsored Preferences Type and class of admission Total Adjustments of Status New Arrivals Total, all immigrants 1183505 565427 618078 Family-sponsored preferences 238087 15116 222971';
+  assert.deepEqual(classifyBody(text), { usable: true, reason: 'ok' });
+});
+
+test('row_98: Real Forbes article about Zogby and housing trends', () => {
+  const text = "This article is more than 8 years old. Cabin in woods Cara Fuller, Unsplash Back in 2008 John Zogby, author, founder of the Zogby International Poll and a fellow Forbes.com contributor, predicted a seismic shift in American's aspirations, values and ideals in his book The Way We'll Be: The Zogby Report on the Transformation of the American Dream.";
+  assert.deepEqual(classifyBody(text), { usable: true, reason: 'ok' });
+});
+
+// ===== Edge cases =====
+
+test('edge: empty string', () => {
+  assert.deepEqual(classifyBody(''), { usable: false, reason: 'short_body' });
+});
+
+test('edge: null', () => {
+  assert.deepEqual(classifyBody(null), { usable: false, reason: 'short_body' });
+});
+
+test('edge: leading whitespace + short content', () => {
+  assert.deepEqual(classifyBody('   \n\n  Brief contact page.   '), { usable: false, reason: 'short_body' });
+});

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -285,7 +285,8 @@ test('runVerify: success path prints verdict and returns 0', async () => {
     },
     {
       match: (url) => String(url).includes('publicai-proxy.alaexis.workers.dev') && String(url).includes('?fetch='),
-      respond: async () => ({ ok: true, json: async () => ({ content: 'The sky is indeed blue due to Rayleigh scattering.' + 'x'.repeat(200) }) }),
+      // Body padded above SHORT_BODY_FLOOR (300 chars in core/body-classifier.js).
+      respond: async () => ({ ok: true, json: async () => ({ content: 'The sky is indeed blue due to Rayleigh scattering. ' + 'Sunlight entering the atmosphere is scattered by gas molecules, with shorter wavelengths (blue) scattering more strongly than longer ones (red), producing the characteristic blue color we see overhead during daytime. '.repeat(2) }) }),
     },
     {
       match: (url, opts) => String(url) === 'https://publicai-proxy.alaexis.workers.dev' && opts?.method === 'POST',
@@ -627,7 +628,9 @@ test('runVerify: DOM traversal chain works against a realistic Wikipedia fixture
     },
     {
       match: (url) => String(url).includes('?fetch=https%3A%2F%2Fexample.com%2Fsecond'),
-      respond: async () => ({ ok: true, json: async () => ({ content: 'At higher pressures the boiling point of water increases above 100 C.' + 'y'.repeat(200) }) }),
+      // Body padded above SHORT_BODY_FLOOR (300 chars in core/body-classifier.js)
+      // so the body-usability classifier passes it through to the LLM mock.
+      respond: async () => ({ ok: true, json: async () => ({ content: 'At higher pressures the boiling point of water increases above 100 C. ' + 'Water exhibits its standard boiling point at 100 C only at one standard atmosphere of pressure; at altitude or under reduced pressure the boiling point drops, while pressure cookers and industrial autoclaves raise it well above that. '.repeat(2) }) }),
     },
     {
       match: (url, opts) => String(url) === 'https://publicai-proxy.alaexis.workers.dev' && opts?.method === 'POST',

--- a/tests/worker.test.js
+++ b/tests/worker.test.js
@@ -1,6 +1,11 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { fetchSourceContent, logVerification } from '../core/worker.js';
+import {
+  fetchSourceContent,
+  logVerification,
+  sourceUnavailableStatusText,
+  sourceUnavailableComment,
+} from '../core/worker.js';
 
 function mockFetch(impl) {
   const original = globalThis.fetch;
@@ -106,6 +111,79 @@ test('fetchSourceContent passes usable body through unchanged (Wayback prefix + 
   } finally {
     mock.restore();
   }
+});
+
+// ---- sourceUnavailableStatusText (user-facing status in single-Verify) -----
+
+test('sourceUnavailableStatusText: fetch_failed preserves pre-unification wording', () => {
+  // Regression guard: before the SU-shape unification, the userscript showed
+  // "Could not fetch source. Please paste the source text below." on null
+  // returns. Preserved verbatim for the fetch_failed reason so users don't
+  // see new jargon on the most common failure mode.
+  assert.equal(
+    sourceUnavailableStatusText('fetch_failed'),
+    'Could not fetch source. Please paste the source text below.'
+  );
+});
+
+test('sourceUnavailableStatusText: classifier reasons surface in parens', () => {
+  assert.equal(
+    sourceUnavailableStatusText('wayback_chrome'),
+    'Source unavailable (wayback_chrome). Paste the source text below if you have it.'
+  );
+  assert.equal(
+    sourceUnavailableStatusText('short_body'),
+    'Source unavailable (short_body). Paste the source text below if you have it.'
+  );
+});
+
+test('sourceUnavailableStatusText: google_books_skip surfaces with reason', () => {
+  // No special-case wording yet; if/when we add user-friendly copy for Google
+  // Books citations specifically, update this test alongside the helper.
+  assert.equal(
+    sourceUnavailableStatusText('google_books_skip'),
+    'Source unavailable (google_books_skip). Paste the source text below if you have it.'
+  );
+});
+
+test('sourceUnavailableStatusText: unknown reason still produces a coherent message', () => {
+  assert.equal(
+    sourceUnavailableStatusText('something_new'),
+    'Source unavailable (something_new). Paste the source text below if you have it.'
+  );
+});
+
+// ---- sourceUnavailableComment (report comment field) ------------------------
+
+test('sourceUnavailableComment: fetch_failed preserves pre-unification wording', () => {
+  // Batch-report results.json previously recorded "Could not fetch source
+  // content" for null returns. Preserved verbatim for fetch_failed so the
+  // benchmark-runner's synthesizePipelineSU output for source_fetch_failed
+  // rows matches the userscript's batch-report comment string.
+  assert.equal(
+    sourceUnavailableComment('fetch_failed'),
+    'Could not fetch source content'
+  );
+});
+
+test('sourceUnavailableComment: classifier reasons use Pipeline-attributed prefix', () => {
+  // Pattern that analyze_results.js readers and human reviewers can grep on
+  // to attribute outcomes to the deterministic pipeline rather than the LLM.
+  assert.equal(
+    sourceUnavailableComment('json_ld_leak'),
+    'Pipeline-attributed (json_ld_leak)'
+  );
+  assert.equal(
+    sourceUnavailableComment('amazon_stub'),
+    'Pipeline-attributed (amazon_stub)'
+  );
+});
+
+test('sourceUnavailableComment: unknown reason produces a coherent comment', () => {
+  assert.equal(
+    sourceUnavailableComment('unknown'),
+    'Pipeline-attributed (unknown)'
+  );
 });
 
 test('logVerification posts payload and swallows failures', async () => {

--- a/tests/worker.test.js
+++ b/tests/worker.test.js
@@ -12,12 +12,48 @@ function mockFetch(impl) {
   return { calls, restore: () => { globalThis.fetch = original; } };
 }
 
-test('fetchSourceContent returns null for Google Books URLs without hitting the network', async () => {
+test('fetchSourceContent returns SU(google_books_skip) for Google Books URLs without hitting the network', async () => {
   const mock = mockFetch(async () => { throw new Error('should not be called'); });
   try {
     const result = await fetchSourceContent('https://books.google.com/books?id=abc', null);
-    assert.equal(result, null);
+    assert.deepEqual(result, { sourceUnavailable: true, reason: 'google_books_skip' });
     assert.equal(mock.calls.length, 0);
+  } finally {
+    mock.restore();
+  }
+});
+
+test('fetchSourceContent returns SU(fetch_failed) on proxy error', async () => {
+  const mock = mockFetch(async () => ({
+    ok: true,
+    json: async () => ({ error: 'upstream timeout' }),
+  }));
+  try {
+    const result = await fetchSourceContent('https://example.com/doc', null);
+    assert.deepEqual(result, { sourceUnavailable: true, reason: 'fetch_failed' });
+  } finally {
+    mock.restore();
+  }
+});
+
+test('fetchSourceContent returns SU(fetch_failed) on empty proxy response', async () => {
+  const mock = mockFetch(async () => ({
+    ok: true,
+    json: async () => ({ content: '', truncated: false }),
+  }));
+  try {
+    const result = await fetchSourceContent('https://example.com/doc', null);
+    assert.deepEqual(result, { sourceUnavailable: true, reason: 'fetch_failed' });
+  } finally {
+    mock.restore();
+  }
+});
+
+test('fetchSourceContent returns SU(fetch_failed) on network exception', async () => {
+  const mock = mockFetch(async () => { throw new Error('network down'); });
+  try {
+    const result = await fetchSourceContent('https://example.com/doc', null);
+    assert.deepEqual(result, { sourceUnavailable: true, reason: 'fetch_failed' });
   } finally {
     mock.restore();
   }

--- a/tests/worker.test.js
+++ b/tests/worker.test.js
@@ -38,6 +38,40 @@ test('fetchSourceContent returns formatted source text on success', async () => 
   }
 });
 
+test('fetchSourceContent returns sourceUnavailable object when body is structurally bad', async () => {
+  // Wayback Machine chrome wrapper, short body — should hit the wayback_chrome
+  // pattern in core/body-classifier.js. Real failure case from row_94.
+  const chromeBody = 'The Wayback Machine - https://web.archive.org/web/20120324190450/http://www.croydonminster.org/about-us A Living Past and a Growing Future If you want to help us support Croydon Minster, you can donate online through JustGiving.';
+  const mock = mockFetch(async () => ({
+    ok: true,
+    json: async () => ({ content: chromeBody, truncated: false }),
+  }));
+  try {
+    const result = await fetchSourceContent('https://web.archive.org/web/20120324190450/http://www.croydonminster.org/about-us', null);
+    assert.deepEqual(result, { sourceUnavailable: true, reason: 'wayback_chrome' });
+  } finally {
+    mock.restore();
+  }
+});
+
+test('fetchSourceContent passes usable body through unchanged (Wayback prefix + real article)', async () => {
+  // Wayback URL prefix on a long body — body-classifier should let this through.
+  // Real success case from row_9 (USCIS country-limit glossary).
+  const usableBody = 'The Wayback Machine - https://web.archive.org/web/20160121232201/http://www.uscis.gov/tools/glossary/country-limit The maximum number of family-sponsored and employment-based preference visas that can be issued to citizens of any country in a fiscal year. The limits are calculated each fiscal year depending on the total number of family-sponsored and employment-based visas available. No more than 7 percent of the visas may be issued to natives of any one independent country in a fiscal year; no more than 2 percent may issued to any one dependency of any independent country. The per-country limit does not indicate, however, that a country is entitled to the maximum number of visas each year, just that it cannot receive more than that number.';
+  const mock = mockFetch(async () => ({
+    ok: true,
+    json: async () => ({ content: usableBody, truncated: false }),
+  }));
+  try {
+    const result = await fetchSourceContent('https://example.com/doc', null);
+    assert.equal(typeof result, 'string');
+    assert.ok(result.includes('Source Content:'));
+    assert.ok(result.includes('family-sponsored'));
+  } finally {
+    mock.restore();
+  }
+});
+
 test('logVerification posts payload and swallows failures', async () => {
   const mock = mockFetch(async () => ({ ok: true, json: async () => ({}) }));
   try {


### PR DESCRIPTION
# Summary

Adds `core/body-classifier.js` — a deterministic classifier that inspects extracted source text and flags structurally-bad bodies (Wayback Machine chrome wrappers, CSS leak from `<style>` extraction, JSON-LD blob misextraction, Amazon listing stubs without product details, anti-bot challenges, abnormally short bodies). When a body is flagged unusable, callers short-circuit to a `Source unavailable` verdict without invoking the LLM.

Pulls the SU-vs-not-supported decision out of the LLM's responsibility for cases where the answer is mechanically determinable, and makes the SU pipeline-attributed rather than model-attributed in the benchmark analysis. The LLM only handles support-or-not-support on bodies the pipeline has already screened as usable.

## Five commits

1. **`core: add body-usability classifier with regression fixtures`** — new `core/body-classifier.js` with pattern-matched detectors; each pattern has at least one fixture in `tests/body_classifier.test.js`.
2. **`core+ui: classify body usability after fetch, route unusable to SU`** — `core/worker.js` `fetchSourceContent()` calls `classifyBody()` and returns a `{ sourceUnavailable: true, reason }` shape when the body fails. Userscript caller (`main.js`) routes that shape to a deterministic SU verdict without an LLM call. `scripts/sync-main.js` adds `body-classifier.js` to `CORE_ORDER` so it's inlined into `main.js`. CLI (`cli/verify.js`) handles the new return shape too.
3. **`benchmark/extract_dataset: classify body usability, set body_unusable status`** — at extract time, `extract_dataset.js` runs `classifyBody()` on each fetched body. Rows that fail are written with `extraction_status: 'body_unusable'` and `body_unusable_reason: <pattern>`.
4. **`benchmark/run_benchmark: synthesize SU verdict for body_unusable rows`** — the runner's entry filter now admits both `complete` and `body_unusable` rows. For `body_unusable`, it synthesizes a `Source unavailable` result per provider without invoking the LLM, tagged `pipeline_attributed: true`.
5. **`benchmark/analyze_results: split model-attributed vs pipeline-attributed metrics`** — adds `overview.pipelineCoverage` (top-level dataset-coverage stat) and per-provider `metricsOnUsable` (accuracy computed only over rows the LLM actually saw). Existing `metrics` field stays unchanged so historical comparisons keep working.

## Patterns covered (with empirical provenance)

Patterns are derived from real failure cases observed in a 185-row × 9-provider benchmark where both Claude Sonnet 4.5 and Opus 4.7 agreed on a wrong `Source unavailable` verdict against a `Not supported` ground truth — i.e., cases where the LLM was deterministically misreading "no usable body" as "claim wrong." Each pattern has a regression fixture in `tests/body_classifier.test.js`:

- `wayback_chrome` — Wayback Machine wrapper text dominates a short body (real failure: row_94)
- `css_leak` — Defuddle extracted a `<style>` block; body is CSS rules
- `json_ld_leak` — Defuddle extracted a `schema.org` JSON-LD blob instead of the article body
- `amazon_stub` — Amazon listing rendered without product details
- `anti_bot_challenge` — Cloudflare/Akamai challenge page
- `short_body` — body is below `SHORT_BODY_FLOOR` (300 chars)

`CHROME_LENGTH_CAP = 600` bounds chrome detectors: above 600 chars even with chrome at the top we let the body through (real success case: row_9, Wayback prefix + 912 chars of USCIS glossary). Tuning is biased toward false negatives over false positives.

## Order-independent vs PR #203

This PR is intentionally **standalone**, not stacked on #203. The branch is rebased on current `origin/main` (which already includes #214's parser consolidation) and contains *only* the classifier work. Either order works:

- **If this lands before #203:** clean merge. #203's rebase will need to bump its two Citoid test fixtures (`'body content '.repeat(20)` and `'untouched body '.repeat(20)` — both at or below `SHORT_BODY_FLOOR`) above 300 chars, otherwise the classifier flags them as `short_body` and the Citoid tests fail.
- **If #203 lands first:** this PR's rebase brings in #203's worker.js Citoid additions; classifier's worker.js additions compose cleanly with them. The fixture-pad change would land here during the rebase instead.

## Expected metric impact: this is a tradeoff, not a free improvement

The benchmark in `benchmark/dataset.json` is a **tool-vs-human-reviewer** test. Each row's `ground_truth` is what an editor following the citation on the *live* page would conclude — not what our scraper captured, and not what the tool produced on any prior run. The strict-rubric principle in `CLAUDE.md` makes this explicit: GT reflects what an editor finds on the live page, not what's in our stored snapshot.

Against that yardstick, the body-classifier makes a deterministic tradeoff that's worth naming up front:

> The classifier returns `Source unavailable` whenever the *snapshot* is structurally bad (Wayback chrome wrapper, JSON-LD blob, short stub, anti-bot challenge page, etc.) — **even when a human reviewer in a browser could still reach the live page and verify the claim.**

So on rows where the scraper hits a wall but a human wouldn't, the tool's verdict goes from "whatever the LLM produced" to a deterministic SU. If the GT for that row is S/PS/NS (which is correct per the strict-rubric principle), the tool is now legitimately scoring worse than a human. That's not a metric quirk; the metric is right — the tool is honestly producing a less-useful outcome on those rows than a human would.

### Concrete impact on the current dataset

Running the classifier against `origin/main`'s `benchmark/dataset.json` flags 3 rows: `row_17` (wayback_chrome, GT=Supported), `row_92` (short_body, GT=Not supported), `row_144` (short_body, GT=Partially supported). All 3 have GT ≠ SU. So the headline metric will dip by ~3 × 9 providers ≈ 27 cells.

The dataset currently contains zero rows with GT=`Source unavailable` — the original curation pass found no live page that was genuinely unverifiable — so there are no rows where the classifier's deterministic SU would *correctly* match the human verdict and recover any cells. The net is pure cost on this benchmark.

### The argument for shipping anyway

When the snapshot is structurally bad, the LLM is pattern-matching on Wayback chrome or a JSON-LD blob, not on the article body. Whatever verdict it produces has weak signal, and on those rows the tool is often quietly wrong with confidence rather than honestly uncertain. Substituting a deterministic SU is more honest about the *system's* uncertainty — and in production (userscript runtime) it gives the user something actionable (paste-text fallback, retry, manual review) instead of a confidently-wrong S/PS/NS.

### The argument against

If a human reviewer can reach the live page, the right long-term fix is to improve the scraper / proxy so the body the LLM sees matches what the human sees — not to give up on the row deterministically. The body-classifier short-circuits work that could be done at the extraction layer.

Both arguments are real. This PR ships the classifier and the new return shape; the decision about whether the tradeoff is worth landing is a judgment call.

### Note on the other axis: regression-vs-prior-tool

The historical-runs replay infrastructure (added in #195, `benchmark/historical-runs/`) supports a different test: pin a prior tool output as the baseline and compare today's output row-by-row. On *that* axis, the body-classifier's SU emissions look like flips from one verdict to another, neither inherently "wrong" — just changed. That's a useful complement to the headline metric but it's not what `dataset.json`'s `ground_truth` field measures.

### Per-provider attribution split

`analyze_results.js` reports two metric surfaces per provider in this PR:

- `metrics`: legacy field. Mixes model-attributed and pipeline-attributed outcomes. Stays unchanged so historical comparisons keep working. This is the right axis for tool-vs-human-reviewer comparisons because it includes the body-classifier's deterministic SUs in the count, so the regression shows up where it actually happens.
- `metricsOnUsable`: same shape, computed only over rows the LLM actually saw (excludes `pipeline_attributed: true` rows). This is the right axis for evaluating LLM behavior changes (e.g., comparing two prompt variants) without the deterministic-SU rows pulling the number around.

### Follow-up: SU-labeled fixtures for rows where humans agree it's SU

Field reality includes paywalled articles, retracted content, dead domains, and full-browser anti-bot walls — cases where a human reviewer in a browser also can't verify. Adding ~10–20 such fixtures (real Wikipedia citations that no editor can verify even on the live page) would let the body-classifier's deterministic SU sometimes match the human-reviewer SU and score correctly on the human-comparison axis. That's a separate dataset PR; this PR does not depend on it.

## What's *not* in this PR

- Removing `Source unavailable` from the LLM verdict set in `core/prompts.js`. Separate change, requires this PR to land first so the pipeline reliably catches the deterministic-SU cases before the LLM's escape valve is removed.
- SU-labeled benchmark fixtures (see "Follow-up" above).
- Scraper / proxy improvements for rows where the snapshot is bad but the live page is reachable. Some classifier-flagged rows are arguably better fixed at the extraction layer; that's a separate workstream.

## Test plan

- [x] `npm test` — 270/270 pass. New coverage includes `tests/body_classifier.test.js` regression fixtures, `synthesizePipelineSU` cases (including the `source_fetch_failed → fetch_failed` reason fallback), `compareVerdicts` cases, `filterBenchmarkableEntries` cases, and the two new `core/worker.js` helpers (`sourceUnavailableStatusText` / `sourceUnavailableComment`) that hold the user-facing SU wording in one testable place.
- [x] `npm run build -- --check` — `main.js` in sync with `core/`
- [ ] Maintainer manual: load the userscript on a Wikipedia article with at least one Wayback-chrome-wrapper citation; click it; confirm the status reads `Source unavailable (wayback_chrome). Paste the source text below if you have it.` and the network tab shows no LLM provider request.
- [ ] Maintainer manual: trigger a proxy fetch failure (e.g., point the userscript at a 404 URL); confirm the status reads `Could not fetch source. Please paste the source text below.` — same wording as before the SU-unification commits, preserved as a regression guard. No LLM provider request.
- [ ] Maintainer manual: run "Verify all citations" on an article with mixed citation outcomes (one usable, one Wayback-chrome, one fetch-fail); confirm the generated wikitext report shows three rows with three different comment strings (LLM verdict text, `Pipeline-attributed (wayback_chrome)`, `Could not fetch source content`).
- [ ] Maintainer manual: run `npm run extract` from `benchmark/` against the current dataset and confirm the classifier flags a small number of rows as `body_unusable` (expect ~3 on current `origin/main` dataset: `row_17` wayback_chrome, `row_92` short_body, `row_144` short_body — counts will drift as the dataset evolves).
- [ ] Playwright coverage for the three UX paths above is queued in a separate workstream (`tests/e2e/`) and will land on the same branch or shortly after merge.
