### PR TITLE
core: forward response_format param; enable JSON mode for Granite 4.1 8B

### DIFF
--- a/benchmark/run_benchmark.js
+++ b/benchmark/run_benchmark.js
@@ -124,7 +124,11 @@ const PROVIDERS = {
         endpoint: 'https://openrouter.ai/api/v1/chat/completions',
         requiresKey: true,
         keyEnv: 'OPENROUTER_API_KEY',
-        type: 'openrouter'
+        type: 'openrouter',
+        // Forces JSON-only output. Granite-8B's parse-error rate jumps from
+        // ~0.5% to 13% under terser prompts without this hint; with it
+        // supplied, parse failures return to 0.
+        responseFormat: { type: 'json_object' },
     },
     'openrouter-gemma-4-26b-a4b': {
         name: 'Gemma 4 26B-A4B (OpenRouter)',
@@ -367,6 +371,7 @@ async function callOpenRouter(config, systemPrompt, userPrompt) {
         maxTokens: BENCHMARK_MAX_TOKENS,
         temperature: BENCHMARK_TEMPERATURE,
         extraBody: config.extraBody,
+        responseFormat: config.responseFormat,
     }));
 }
 

--- a/core/providers.js
+++ b/core/providers.js
@@ -6,7 +6,15 @@
 // OpenRouter (which adds attribution headers and surfaces per-call cost),
 // and the benchmark runner (which calls direct PublicAI/OpenAI endpoints
 // with bearer auth from environment variables).
-export async function callOpenAICompatibleChat({ url, apiKey, model, systemPrompt, userContent, label, extraHeaders, extraBody, maxTokens = 2048, temperature = 0.1 }) {
+// `responseFormat` is OpenAI-compatible structured-output: pass
+// `{ type: 'json_object' }` to force JSON-only output, or a JSON-schema
+// object on backends that support it. OpenRouter passes the param
+// through to the underlying model; backends that don't recognise it
+// generally ignore it rather than error. Small / weaker instruction-tuned
+// models benefit most — Granite 4.1 8B in particular regressed from
+// ~0.5% to 13% JSON-parse failures under terser prompts until this
+// hint was supplied, after which parse failures returned to 0.
+export async function callOpenAICompatibleChat({ url, apiKey, model, systemPrompt, userContent, label, extraHeaders, extraBody, maxTokens = 2048, temperature = 0.1, responseFormat }) {
     const requestBody = {
         model: model,
         messages: [
@@ -17,6 +25,7 @@ export async function callOpenAICompatibleChat({ url, apiKey, model, systemPromp
         temperature: temperature
     };
     if (extraBody) Object.assign(requestBody, extraBody);
+    if (responseFormat) requestBody.response_format = responseFormat;
 
     const headers = { 'Content-Type': 'application/json' };
     if (apiKey) headers['Authorization'] = `Bearer ${apiKey}`;
@@ -85,11 +94,11 @@ export async function callHuggingFaceAPI({ apiKey, model, systemPrompt, userCont
 // as of 2026; the older `usage: { include: true }` parameter is deprecated).
 // Attribution headers (HTTP-Referer + X-Title) are recommended by OpenRouter
 // for analytics; they don't affect routing.
-export async function callOpenRouterAPI({ apiKey, model, systemPrompt, userContent, maxTokens, temperature, extraBody }) {
+export async function callOpenRouterAPI({ apiKey, model, systemPrompt, userContent, maxTokens, temperature, extraBody, responseFormat }) {
     return callOpenAICompatibleChat({
         url: 'https://openrouter.ai/api/v1/chat/completions',
         apiKey,
-        model, systemPrompt, userContent, maxTokens, temperature, extraBody,
+        model, systemPrompt, userContent, maxTokens, temperature, extraBody, responseFormat,
         label: 'OpenRouter',
         extraHeaders: {
             'HTTP-Referer': 'https://github.com/alex-o-748/citation-checker-script',

--- a/main.js
+++ b/main.js
@@ -561,7 +561,15 @@ function extractClaimText(refElement) {
 // OpenRouter (which adds attribution headers and surfaces per-call cost),
 // and the benchmark runner (which calls direct PublicAI/OpenAI endpoints
 // with bearer auth from environment variables).
-async function callOpenAICompatibleChat({ url, apiKey, model, systemPrompt, userContent, label, extraHeaders, extraBody, maxTokens = 2048, temperature = 0.1 }) {
+// `responseFormat` is OpenAI-compatible structured-output: pass
+// `{ type: 'json_object' }` to force JSON-only output, or a JSON-schema
+// object on backends that support it. OpenRouter passes the param
+// through to the underlying model; backends that don't recognise it
+// generally ignore it rather than error. Small / weaker instruction-tuned
+// models benefit most — Granite 4.1 8B in particular regressed from
+// ~0.5% to 13% JSON-parse failures under terser prompts until this
+// hint was supplied, after which parse failures returned to 0.
+async function callOpenAICompatibleChat({ url, apiKey, model, systemPrompt, userContent, label, extraHeaders, extraBody, maxTokens = 2048, temperature = 0.1, responseFormat }) {
     const requestBody = {
         model: model,
         messages: [
@@ -572,6 +580,7 @@ async function callOpenAICompatibleChat({ url, apiKey, model, systemPrompt, user
         temperature: temperature
     };
     if (extraBody) Object.assign(requestBody, extraBody);
+    if (responseFormat) requestBody.response_format = responseFormat;
 
     const headers = { 'Content-Type': 'application/json' };
     if (apiKey) headers['Authorization'] = `Bearer ${apiKey}`;
@@ -640,11 +649,11 @@ async function callHuggingFaceAPI({ apiKey, model, systemPrompt, userContent, wo
 // as of 2026; the older `usage: { include: true }` parameter is deprecated).
 // Attribution headers (HTTP-Referer + X-Title) are recommended by OpenRouter
 // for analytics; they don't affect routing.
-async function callOpenRouterAPI({ apiKey, model, systemPrompt, userContent, maxTokens, temperature, extraBody }) {
+async function callOpenRouterAPI({ apiKey, model, systemPrompt, userContent, maxTokens, temperature, extraBody, responseFormat }) {
     return callOpenAICompatibleChat({
         url: 'https://openrouter.ai/api/v1/chat/completions',
         apiKey,
-        model, systemPrompt, userContent, maxTokens, temperature, extraBody,
+        model, systemPrompt, userContent, maxTokens, temperature, extraBody, responseFormat,
         label: 'OpenRouter',
         extraHeaders: {
             'HTTP-Referer': 'https://github.com/alex-o-748/citation-checker-script',

--- a/tests/providers.test.js
+++ b/tests/providers.test.js
@@ -275,6 +275,48 @@ test('callOpenRouterAPI hits OpenRouter API with attribution headers and surface
   }
 });
 
+test('callOpenRouterAPI forwards responseFormat as request_body.response_format', async () => {
+  const mock = withMockFetch(async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({
+      choices: [{ message: { content: '{"verdict":"SUPPORTED"}' } }],
+      usage: { prompt_tokens: 10, completion_tokens: 2 },
+    }),
+  }));
+  try {
+    await callOpenRouterAPI({
+      apiKey: 'k',
+      model: 'ibm-granite/granite-4.1-8b',
+      systemPrompt: 's',
+      userContent: 'u',
+      responseFormat: { type: 'json_object' },
+    });
+    const body = JSON.parse(mock.calls[0].opts.body);
+    assert.deepEqual(body.response_format, { type: 'json_object' });
+  } finally {
+    mock.restore();
+  }
+});
+
+test('callOpenRouterAPI omits response_format when not supplied', async () => {
+  const mock = withMockFetch(async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({
+      choices: [{ message: { content: 'x' } }],
+      usage: { prompt_tokens: 10, completion_tokens: 2 },
+    }),
+  }));
+  try {
+    await callOpenRouterAPI({ apiKey: 'k', model: 'm', systemPrompt: 's', userContent: 'u' });
+    const body = JSON.parse(mock.calls[0].opts.body);
+    assert.equal(body.response_format, undefined);
+  } finally {
+    mock.restore();
+  }
+});
+
 test('callOpenRouterAPI returns cost_usd: null when usage.cost missing', async () => {
   const mock = withMockFetch(async () => ({
     ok: true,


### PR DESCRIPTION
## Summary

Plumb an optional `responseFormat` parameter through `callOpenAICompatibleChat`
and `callOpenRouterAPI`, and opt the `openrouter-granite-4.1-8b` provider entry
in with `{ type: 'json_object' }`. Other OpenRouter providers leave their
existing behavior unchanged.

OpenAI-compatible chat backends accept `response_format` to force structured
output. OpenRouter passes the param through to the underlying model; backends
that don't recognise it generally ignore rather than error, so the parameter
is safe to enable per-provider.

## Why

Granite-4.1-8B's JSON parse-failure rate jumped from ~0.5% to **13.0%
(24 of 185 rows)** under terser system-prompt phrasing. Supplying
`{ type: 'json_object' }` in its provider config returns the parse-failure
rate to **0** and recovers +3.9pp of exact accuracy on usable rows
(59.7% → 63.6%).

The plumbing is generally useful for any OpenAI-compatible small / weaker
instruction-tuned model that emits markdown-wrapped or otherwise non-strict
JSON; `response_format` is a cheap, model-independent hint.

## Scope note

This addresses **JSON-formatting failures only** — i.e. the model returns
content but it doesn't parse cleanly. A separate failure mode shows up on
reasoning-style models (gpt-oss-20b, Qwen3) where `message.content` is empty
because the model's reasoning channel consumed the token budget. That's a
different problem class (caller needs to fall back to `message.reasoning`,
raise max_tokens, or exclude the model) and is out of scope here.

## Changes

- \`core/providers.js\` — \`callOpenAICompatibleChat()\` accepts an optional
  \`responseFormat\` and forwards it as \`response_format\` in the request body.
  \`callOpenRouterAPI()\` threads it through. Comment block documents the
  empirical provenance.
- \`benchmark/run_benchmark.js\` — \`openrouter-granite-4.1-8b\` entry gets
  \`responseFormat: { type: 'json_object' }\`; \`callOpenRouter()\` forwards
  \`config.responseFormat\` to the caller.
- \`tests/providers.test.js\` — two new cases: \`response_format\` is forwarded
  when supplied, and omitted when not.
- \`main.js\` — synced from \`core/\`.

## Test plan

- [x] \`npm test\` (250 tests, 0 failures)
- [x] \`npm run build -- --check\` (main.js in sync with core/)