### PR TITLE
Prefer live URLs over archive snapshots in extractHttpUrl

### DIFF
--- a/core/urls.js
+++ b/core/urls.js
@@ -4,15 +4,23 @@
 // when called without one — that's the userscript path, where the browser
 // supplies the global.
 
+const ARCHIVE_HOST_PATTERN = /web\.archive\.org|archive\.today|archive\.is|archive\.ph|webcitation\.org/i;
+
+function isArchiveUrl(href) {
+    return ARCHIVE_HOST_PATTERN.test(href);
+}
+
 export function extractHttpUrl(element) {
     if (!element) return null;
-    // First look for archive links (prioritize these)
-    const archiveLink = element.querySelector('a[href*="web.archive.org"], a[href*="archive.today"], a[href*="archive.is"], a[href*="archive.ph"], a[href*="webcitation.org"]');
-    if (archiveLink) return archiveLink.href;
-
-    // Fall back to any http link
     const links = element.querySelectorAll('a[href^="http"]');
     if (links.length === 0) return null;
+    // Prefer live URLs over archive snapshots. archive.org rate-limits the
+    // proxy's Cloudflare egress IPs aggressively (429 on most requests),
+    // so archive snapshots are only used as a last-resort fallback when no
+    // live link exists in the citation.
+    for (const link of links) {
+        if (!isArchiveUrl(link.href)) return link.href;
+    }
     return links[0].href;
 }
 

--- a/main.js
+++ b/main.js
@@ -334,15 +334,23 @@ async function withRetry(fn, {
 // when called without one — that's the userscript path, where the browser
 // supplies the global.
 
+const ARCHIVE_HOST_PATTERN = /web\.archive\.org|archive\.today|archive\.is|archive\.ph|webcitation\.org/i;
+
+function isArchiveUrl(href) {
+    return ARCHIVE_HOST_PATTERN.test(href);
+}
+
 function extractHttpUrl(element) {
     if (!element) return null;
-    // First look for archive links (prioritize these)
-    const archiveLink = element.querySelector('a[href*="web.archive.org"], a[href*="archive.today"], a[href*="archive.is"], a[href*="archive.ph"], a[href*="webcitation.org"]');
-    if (archiveLink) return archiveLink.href;
-
-    // Fall back to any http link
     const links = element.querySelectorAll('a[href^="http"]');
     if (links.length === 0) return null;
+    // Prefer live URLs over archive snapshots. archive.org rate-limits the
+    // proxy's Cloudflare egress IPs aggressively (429 on most requests),
+    // so archive snapshots are only used as a last-resort fallback when no
+    // live link exists in the citation.
+    for (const link of links) {
+        if (!isArchiveUrl(link.href)) return link.href;
+    }
     return links[0].href;
 }
 

--- a/tests/urls.test.js
+++ b/tests/urls.test.js
@@ -16,6 +16,26 @@ test('extractHttpUrl pulls href from a direct <a>', () => {
   assert.equal(url, 'https://example.com/page');
 });
 
+test('extractHttpUrl prefers live URLs over archive snapshots', () => {
+  const jsdom = new JSDOM(`<!DOCTYPE html><body><span id="container">
+    <a href="https://web.archive.org/web/20250515222512/https://example.com/page">archived</a>
+    <a href="https://example.com/page">live</a>
+  </span></body>`);
+  const element = jsdom.window.document.getElementById('container');
+  const url = extractHttpUrl(element);
+  assert.equal(url, 'https://example.com/page');
+});
+
+test('extractHttpUrl falls back to archive URL when no live URL exists', () => {
+  const archiveUrl = 'https://web.archive.org/web/20250515222512/https://example.com/page';
+  const jsdom = new JSDOM(`<!DOCTYPE html><body><span id="container">
+    <a href="${archiveUrl}">archived</a>
+  </span></body>`);
+  const element = jsdom.window.document.getElementById('container');
+  const url = extractHttpUrl(element);
+  assert.equal(url, archiveUrl);
+});
+
 test('isGoogleBooksUrl recognizes books.google.com URLs', () => {
   assert.equal(isGoogleBooksUrl('https://books.google.com/books?id=abc'), true);
   assert.equal(isGoogleBooksUrl('https://example.com/'), false);


### PR DESCRIPTION
## Summary

Changes the URL extraction logic to prioritize live URLs over archive snapshots (web.archive.org, archive.today, etc.). Archive snapshots are now only used as a fallback when no live URL exists in the citation.

## Changes

- **Added `isArchiveUrl()` helper function** that checks if a URL belongs to known archive hosts (web.archive.org, archive.today, archive.is, archive.ph, webcitation.org)
- **Refactored `extractHttpUrl()` logic** to iterate through all HTTP links and return the first non-archive URL, falling back to archive URLs only if no live links are found
- **Updated comments** to explain the rationale: archive.org aggressively rate-limits the proxy's Cloudflare egress IPs (429 errors on most requests), making archive snapshots unsuitable as the primary choice
- **Added two new test cases**:
  - `extractHttpUrl prefers live URLs over archive snapshots` — verifies that when both live and archived versions exist, the live URL is returned
  - `extractHttpUrl falls back to archive URL when no live URL exists` — verifies that archive URLs are still returned when they're the only option available
- **Applied changes to both `core/urls.js` and `main.js`** (the latter is the inlined userscript version maintained by the sync script)

## Implementation Details

The new logic uses a simple forward iteration through all HTTP links, returning immediately upon finding the first non-archive URL. This is more efficient than the previous approach of using `querySelector()` to specifically search for archive links, and correctly implements the intended priority order.

https://claude.ai/code/session_01PUDY787uLP7J7Fivwz5zRW