### PR TITLE
Refactor report card actions layout and update submit button styling

### DIFF
--- a/main.js
+++ b/main.js
@@ -1415,7 +1415,7 @@ function buildDatasetSubmissionUrl(
                     font-weight: normal;
                 }
                 .report-card-action .report-card-feedback-action .oo-ui-iconElement-icon {
-                    opacity: 0.4;
+                    opacity: 0.4 !important;
                 }
                 .report-card-header-actions {
                     display: flex;

--- a/main.js
+++ b/main.js
@@ -1415,7 +1415,7 @@ function buildDatasetSubmissionUrl(
                     font-weight: normal;
                 }
                 .report-card-action .report-card-feedback-action .oo-ui-iconElement-icon {
-                    opacity: 0.65;
+                    opacity: 0.4;
                 }
                 .report-card-header-actions {
                     display: flex;
@@ -3184,7 +3184,7 @@ function buildDatasetSubmissionUrl(
             }
 
             if (result.verdict && result.verdict !== 'ERROR' && this.isDatasetSubmissionConfigured()) {
-                const submitBtn = this.buildSubmitToDatasetButton(result, { label: 'Submit report' });
+                const submitBtn = this.buildSubmitToDatasetButton(result);
                 submitBtn.$element.addClass('report-card-feedback-action');
                 actionDiv.appendChild(submitBtn.$element[0]);
             }
@@ -3250,7 +3250,7 @@ function buildDatasetSubmissionUrl(
             if (result.verdict && result.verdict !== 'ERROR' && this.isDatasetSubmissionConfigured()) {
                 const actionDiv = document.createElement('div');
                 actionDiv.className = 'report-card-action';
-                const submitBtn = this.buildSubmitToDatasetButton(result, { label: 'Submit report' });
+                const submitBtn = this.buildSubmitToDatasetButton(result);
                 submitBtn.$element.addClass('report-card-feedback-action');
                 actionDiv.appendChild(submitBtn.$element[0]);
                 row.appendChild(actionDiv);
@@ -3735,7 +3735,7 @@ function buildDatasetSubmissionUrl(
             });
         }
 
-        buildSubmitToDatasetButton(result, { label = 'Submit to dataset' } = {}) {
+        buildSubmitToDatasetButton(result, { label = 'Give feedback' } = {}) {
             return new OO.ui.ButtonWidget({
                 label,
                 icon: 'feedback',

--- a/main.js
+++ b/main.js
@@ -874,7 +874,7 @@ function buildDatasetSubmissionUrl(
         }
         
         async loadOOUI() {
-            await mw.loader.using(['oojs-ui-core', 'oojs-ui-widgets', 'oojs-ui-windows']);
+            await mw.loader.using(['oojs-ui-core', 'oojs-ui-widgets', 'oojs-ui-windows', 'oojs-ui.styles.icons-interactions']);
         }
         
         getCurrentApiKey() {
@@ -1409,6 +1409,13 @@ function buildDatasetSubmissionUrl(
                 .report-card-action .oo-ui-buttonElement-button {
                     font-size: 11px;
                     padding: 2px 4px;
+                }
+                .report-card-action .report-card-feedback-action .oo-ui-buttonElement-button .oo-ui-labelElement-label {
+                    color: #54595d;
+                    font-weight: normal;
+                }
+                .report-card-action .report-card-feedback-action .oo-ui-iconElement-icon {
+                    opacity: 0.65;
                 }
                 .report-card-header-actions {
                     display: flex;
@@ -3178,6 +3185,7 @@ function buildDatasetSubmissionUrl(
 
             if (result.verdict && result.verdict !== 'ERROR' && this.isDatasetSubmissionConfigured()) {
                 const submitBtn = this.buildSubmitToDatasetButton(result, { label: 'Submit report' });
+                submitBtn.$element.addClass('report-card-feedback-action');
                 actionDiv.appendChild(submitBtn.$element[0]);
             }
 
@@ -3243,6 +3251,7 @@ function buildDatasetSubmissionUrl(
                 const actionDiv = document.createElement('div');
                 actionDiv.className = 'report-card-action';
                 const submitBtn = this.buildSubmitToDatasetButton(result, { label: 'Submit report' });
+                submitBtn.$element.addClass('report-card-feedback-action');
                 actionDiv.appendChild(submitBtn.$element[0]);
                 row.appendChild(actionDiv);
             }
@@ -3781,7 +3790,7 @@ function buildDatasetSubmissionUrl(
     }
     
     if (typeof mw !== 'undefined' && [0, 118].includes(mw.config.get('wgNamespaceNumber'))) {
-        mw.loader.using(['mediawiki.util', 'mediawiki.api', 'oojs-ui-core', 'oojs-ui-widgets', 'oojs-ui-windows']).then(function() {
+        mw.loader.using(['mediawiki.util', 'mediawiki.api', 'oojs-ui-core', 'oojs-ui-widgets', 'oojs-ui-windows', 'oojs-ui.styles.icons-interactions']).then(function() {
             $(function() {
                 new WikipediaSourceVerifier();
             });

--- a/main.js
+++ b/main.js
@@ -3161,14 +3161,10 @@ function buildDatasetSubmissionUrl(
 
             this.attachRefScrollHandler(card, result.refElement);
 
-            if (result.verdict && result.verdict !== 'ERROR' && this.isDatasetSubmissionConfigured()) {
-                const submitBtn = this.buildSubmitToDatasetButton(result, { label: 'Submit report' });
-                card.querySelector('.report-card-header-actions').appendChild(submitBtn.$element[0]);
-            }
+            const actionDiv = document.createElement('div');
+            actionDiv.className = 'report-card-action';
 
             if (result.refElement && (result.verdict === 'NOT SUPPORTED' || result.verdict === 'PARTIALLY SUPPORTED' || result.verdict === 'SOURCE UNAVAILABLE')) {
-                const actionDiv = document.createElement('div');
-                actionDiv.className = 'report-card-action';
                 const editBtn = new OO.ui.ButtonWidget({
                     label: 'Edit Section',
                     flags: ['progressive'],
@@ -3178,6 +3174,14 @@ function buildDatasetSubmissionUrl(
                     framed: false
                 });
                 actionDiv.appendChild(editBtn.$element[0]);
+            }
+
+            if (result.verdict && result.verdict !== 'ERROR' && this.isDatasetSubmissionConfigured()) {
+                const submitBtn = this.buildSubmitToDatasetButton(result, { label: 'Submit report' });
+                actionDiv.appendChild(submitBtn.$element[0]);
+            }
+
+            if (actionDiv.children.length) {
                 card.appendChild(actionDiv);
             }
             return card;
@@ -3236,8 +3240,11 @@ function buildDatasetSubmissionUrl(
             this.attachRefScrollHandler(row, result.refElement);
 
             if (result.verdict && result.verdict !== 'ERROR' && this.isDatasetSubmissionConfigured()) {
+                const actionDiv = document.createElement('div');
+                actionDiv.className = 'report-card-action';
                 const submitBtn = this.buildSubmitToDatasetButton(result, { label: 'Submit report' });
-                row.querySelector('.report-card-header-actions').appendChild(submitBtn.$element[0]);
+                actionDiv.appendChild(submitBtn.$element[0]);
+                row.appendChild(actionDiv);
             }
 
             return row;
@@ -3722,8 +3729,7 @@ function buildDatasetSubmissionUrl(
         buildSubmitToDatasetButton(result, { label = 'Submit to dataset' } = {}) {
             return new OO.ui.ButtonWidget({
                 label,
-                flags: ['progressive'],
-                icon: 'upload',
+                icon: 'feedback',
                 framed: false,
                 href: this.buildDatasetSubmissionUrl(result),
                 target: '_blank',


### PR DESCRIPTION
## Summary
Restructures the report card action button layout to consolidate "Edit Section" and "Submit report" buttons into a unified action container, and updates the submit button styling to use a feedback icon instead of upload.

## Key Changes

- **Action container consolidation:** Moved action button creation into a shared `actionDiv` container that appears at the end of both card and row report elements, replacing the previous approach of appending directly to header actions
- **Conditional rendering:** Action buttons (Edit Section, Submit report) are now only added to the container if they exist, and the container is only appended if it has children
- **Submit button styling:** Changed the submit button icon from `'upload'` to `'feedback'` and removed the `'progressive'` flag for a more neutral appearance
- **CSS refinements:** Added new styles for `.report-card-feedback-action` button labels (normal weight, muted color) and icon opacity (0.65) to visually distinguish feedback actions
- **OOUI module loading:** Added `'oojs-ui.styles.icons-interactions'` to the module dependencies to support the feedback icon

## Implementation Details

- The action container is created unconditionally but only populated and appended when action buttons are present
- Submit button now receives the `'report-card-feedback-action'` class for targeted styling
- Both card and row report generation now follow the same action layout pattern
- The feedback icon requires the additional OOUI styles module, loaded in both the `loadOOUI()` method and the main initialization

https://claude.ai/code/session_01JzqDgrQg6FDpXPQTg8AfPy