### PR TITLE
Add reason_type field to NOT SUPPORTED verdicts (contradiction vs omi…

### DIFF
--- a/core/parsing.js
+++ b/core/parsing.js
@@ -25,7 +25,8 @@ export function parseVerificationResult(response) {
         return {
             verdict: result.verdict || 'UNKNOWN',
             confidence: result.confidence ?? null,
-            comments: result.comments || ''
+            comments: result.comments || '',
+            reason_type: result.reason_type || null
         };
     } catch (e) {
         // fall through to the markdown-emphasis recovery

--- a/core/prompts.js
+++ b/core/prompts.js
@@ -35,8 +35,11 @@ Respond in JSON format:
 {
   "confidence": <number 0-100>,
   "verdict": "<verdict>",
+  "reason_type": "<only for NOT SUPPORTED: 'contradiction' or 'omission'>",
   "comments": "<relevant quote and brief explanation>"
 }
+
+For NOT SUPPORTED verdicts, include a "reason_type" field: use "contradiction" when the source explicitly states something incompatible with the claim, or "omission" when the source simply does not mention or address the claim. If both apply (source contradicts one part and omits another), use "contradiction". Do not include reason_type for other verdicts.
 
 Confidence guide:
 - 80-100: SUPPORTED
@@ -55,7 +58,7 @@ Source text: "History of Modern Economics - Economic Research Council - Google B
 Claim: "The bridge was completed in 1998."
 Source text: "Skip to main content Web Archive toolbar... Capture date: 2015-03-12 ... City Tribune - Local News ... The Morrison Bridge project broke ground in 1994 after years of planning. Construction faced multiple delays due to funding shortages. The bridge was finally opened to traffic in August 2002, four years behind schedule. Mayor Davis called it 'a triumph of persistence.'"
 
-{"confidence": 15, "verdict": "NOT SUPPORTED", "comments": "\"finally opened to traffic in August 2002, four years behind schedule\" - Source says the bridge opened in 2002, not 1998. The article is accessible despite being an Internet Archive capture."}
+{"confidence": 15, "verdict": "NOT SUPPORTED", "reason_type": "contradiction", "comments": "\"finally opened to traffic in August 2002, four years behind schedule\" - Source says the bridge opened in 2002, not 1998. The article is accessible despite being an Internet Archive capture."}
 </example>
 
 <example>
@@ -69,7 +72,7 @@ Source text: "Acme Corp was established in 1985. Its founder, John Smith, served
 Claim: "The treaty was signed by 45 countries."
 Source text: "The treaty, finalized in March, was signed by over 30 nations, though the exact number remains disputed."
 
-{"confidence": 20, "verdict": "NOT SUPPORTED", "comments": "\"signed by over 30 nations\" - Source says \"over 30,\" not 45."}
+{"confidence": 20, "verdict": "NOT SUPPORTED", "reason_type": "contradiction", "comments": "\"signed by over 30 nations\" - Source says \"over 30,\" not 45."}
 </example>
 
 <example>
@@ -90,7 +93,14 @@ Source text: "Census data shows significant population growth in the region duri
 Claim: "The president resigned on March 3."
 Source text: "The president remained in office throughout March."
 
-{"confidence": 5, "verdict": "NOT SUPPORTED", "comments": "\"remained in office throughout March\" - Source directly contradicts the claim."}
+{"confidence": 5, "verdict": "NOT SUPPORTED", "reason_type": "contradiction", "comments": "\"remained in office throughout March\" - Source directly contradicts the claim."}
+</example>
+
+<example>
+Claim: "She received the Nobel Prize in Chemistry in 2015."
+Source text: "Professor Martin completed her PhD at Oxford in 1998 and joined the faculty at Cambridge in 2003. Her research focuses on organic synthesis and catalysis. She has published over 200 papers and received several university teaching awards."
+
+{"confidence": 10, "verdict": "NOT SUPPORTED", "reason_type": "omission", "comments": "The source discusses her academic career and publications but makes no mention of a Nobel Prize."}
 </example>`;
 }
 

--- a/main.js
+++ b/main.js
@@ -44,8 +44,11 @@ Respond in JSON format:
 {
   "confidence": <number 0-100>,
   "verdict": "<verdict>",
+  "reason_type": "<only for NOT SUPPORTED: 'contradiction' or 'omission'>",
   "comments": "<relevant quote and brief explanation>"
 }
+
+For NOT SUPPORTED verdicts, include a "reason_type" field: use "contradiction" when the source explicitly states something incompatible with the claim, or "omission" when the source simply does not mention or address the claim. If both apply (source contradicts one part and omits another), use "contradiction". Do not include reason_type for other verdicts.
 
 Confidence guide:
 - 80-100: SUPPORTED
@@ -64,7 +67,7 @@ Source text: "History of Modern Economics - Economic Research Council - Google B
 Claim: "The bridge was completed in 1998."
 Source text: "Skip to main content Web Archive toolbar... Capture date: 2015-03-12 ... City Tribune - Local News ... The Morrison Bridge project broke ground in 1994 after years of planning. Construction faced multiple delays due to funding shortages. The bridge was finally opened to traffic in August 2002, four years behind schedule. Mayor Davis called it 'a triumph of persistence.'"
 
-{"confidence": 15, "verdict": "NOT SUPPORTED", "comments": "\"finally opened to traffic in August 2002, four years behind schedule\" - Source says the bridge opened in 2002, not 1998. The article is accessible despite being an Internet Archive capture."}
+{"confidence": 15, "verdict": "NOT SUPPORTED", "reason_type": "contradiction", "comments": "\"finally opened to traffic in August 2002, four years behind schedule\" - Source says the bridge opened in 2002, not 1998. The article is accessible despite being an Internet Archive capture."}
 </example>
 
 <example>
@@ -78,7 +81,7 @@ Source text: "Acme Corp was established in 1985. Its founder, John Smith, served
 Claim: "The treaty was signed by 45 countries."
 Source text: "The treaty, finalized in March, was signed by over 30 nations, though the exact number remains disputed."
 
-{"confidence": 20, "verdict": "NOT SUPPORTED", "comments": "\"signed by over 30 nations\" - Source says \"over 30,\" not 45."}
+{"confidence": 20, "verdict": "NOT SUPPORTED", "reason_type": "contradiction", "comments": "\"signed by over 30 nations\" - Source says \"over 30,\" not 45."}
 </example>
 
 <example>
@@ -99,7 +102,14 @@ Source text: "Census data shows significant population growth in the region duri
 Claim: "The president resigned on March 3."
 Source text: "The president remained in office throughout March."
 
-{"confidence": 5, "verdict": "NOT SUPPORTED", "comments": "\"remained in office throughout March\" - Source directly contradicts the claim."}
+{"confidence": 5, "verdict": "NOT SUPPORTED", "reason_type": "contradiction", "comments": "\"remained in office throughout March\" - Source directly contradicts the claim."}
+</example>
+
+<example>
+Claim: "She received the Nobel Prize in Chemistry in 2015."
+Source text: "Professor Martin completed her PhD at Oxford in 1998 and joined the faculty at Cambridge in 2003. Her research focuses on organic synthesis and catalysis. She has published over 200 papers and received several university teaching awards."
+
+{"confidence": 10, "verdict": "NOT SUPPORTED", "reason_type": "omission", "comments": "The source discusses her academic career and publications but makes no mention of a Nobel Prize."}
 </example>`;
 }
 
@@ -228,7 +238,8 @@ function parseVerificationResult(response) {
         return {
             verdict: result.verdict || 'UNKNOWN',
             confidence: result.confidence ?? null,
-            comments: result.comments || ''
+            comments: result.comments || '',
+            reason_type: result.reason_type || null
         };
     } catch (e) {
         // fall through to the markdown-emphasis recovery
@@ -1576,6 +1587,17 @@ function buildDatasetSubmissionUrl(
                 .report-card-verdict.not-supported { background: #f8d7da; color: #721c24; }
                 .report-card-verdict.unavailable { background: #e2e3e5; color: #383d41; }
                 .report-card-verdict.error { background: #e2e3e5; color: #383d41; }
+                .reason-type-tag {
+                    display: inline-block;
+                    font-size: 11px;
+                    padding: 1px 6px;
+                    border-radius: 3px;
+                    margin-left: 6px;
+                    font-weight: normal;
+                    vertical-align: middle;
+                }
+                .reason-type-contradiction { background: #f8d7da; color: #721c24; }
+                .reason-type-omission { background: #fff3cd; color: #856404; }
                 .report-card-claim {
                     color: #555;
                     font-size: 11px;
@@ -1894,6 +1916,14 @@ function buildDatasetSubmissionUrl(
                     background: #2a2a2e !important;
                     color: #a0a0a8 !important;
                 }
+                html.skin-theme-clientpref-night .reason-type-contradiction {
+                    background: #3a1a1a !important;
+                    color: #e06060 !important;
+                }
+                html.skin-theme-clientpref-night .reason-type-omission {
+                    background: #3a3a1a !important;
+                    color: #e0c060 !important;
+                }
                 html.skin-theme-clientpref-night #verifier-source-textarea-container textarea {
                     background: #2a2a3e !important;
                     color: #e0e0e0 !important;
@@ -2111,6 +2141,14 @@ function buildDatasetSubmissionUrl(
                     html.skin-theme-clientpref-os .report-card-verdict.error {
                         background: #2a2a2e !important;
                         color: #a0a0a8 !important;
+                    }
+                    html.skin-theme-clientpref-os .reason-type-contradiction {
+                        background: #3a1a1a !important;
+                        color: #e06060 !important;
+                    }
+                    html.skin-theme-clientpref-os .reason-type-omission {
+                        background: #3a3a1a !important;
+                        color: #e0c060 !important;
                     }
                     html.skin-theme-clientpref-os #verifier-source-textarea-container textarea {
                         background: #2a2a3e !important;
@@ -3008,6 +3046,16 @@ function buildDatasetSubmissionUrl(
 	        verdictEl.classList.add('source-unavailable');
 	    }
 
+	    const existingTag = document.getElementById('verifier-reason-type');
+	    if (existingTag) existingTag.remove();
+	    if (result.verdict === 'NOT SUPPORTED' && result.reason_type) {
+	        const tag = document.createElement('span');
+	        tag.id = 'verifier-reason-type';
+	        tag.className = `reason-type-tag reason-type-${result.reason_type}`;
+	        tag.textContent = result.reason_type === 'contradiction' ? 'Contradiction' : 'Omission';
+	        verdictEl.after(tag);
+	    }
+
 	    commentsEl.textContent = result.comments;
 	    console.log('[Verifier] Verdict for action button:', JSON.stringify(result.verdict));
 	    this.showActionButton(result.verdict, result.comments);
@@ -3340,11 +3388,14 @@ function buildDatasetSubmissionUrl(
             const truncationHtml = (result.truncated && result.verdict !== 'SUPPORTED')
                 ? '<div class="report-card-truncated">⚠ Source is long, only partially checked.</div>'
                 : '';
+            const reasonTypeHtml = (result.verdict === 'NOT SUPPORTED' && result.reason_type)
+                ? `<span class="reason-type-tag reason-type-${result.reason_type}">${result.reason_type === 'contradiction' ? 'Contradiction' : 'Omission'}</span>`
+                : '';
             card.innerHTML = `
                 <div class="report-card-header">
                     <span class="report-card-citation">[${result.citationNumber}]</span>
                     <span class="report-card-header-actions">
-                        <span class="report-card-verdict ${verdictClass}">${verdictLabel}</span>
+                        <span class="report-card-verdict ${verdictClass}">${verdictLabel}</span>${reasonTypeHtml}
                     </span>
                 </div>
                 <div class="report-card-claim">${this.escapeHtml(claimExcerpt)}</div>
@@ -3421,11 +3472,14 @@ function buildDatasetSubmissionUrl(
             const truncationHtml = (result.truncated && result.verdict !== 'SUPPORTED')
                 ? '<div class="report-card-truncated">⚠ Source is long, only partially checked.</div>'
                 : '';
+            const reasonTypeHtml = (result.verdict === 'NOT SUPPORTED' && result.reason_type)
+                ? `<span class="reason-type-tag reason-type-${result.reason_type}">${result.reason_type === 'contradiction' ? 'Contradiction' : 'Omission'}</span>`
+                : '';
             row.innerHTML = `
                 <div class="verifier-report-group-row-header">
                     <span class="report-card-citation">[${result.citationNumber}]</span>
                     <span class="report-card-header-actions">
-                        <span class="report-card-verdict ${verdictClass}">${verdictLabel}</span>
+                        <span class="report-card-verdict ${verdictClass}">${verdictLabel}</span>${reasonTypeHtml}
                     </span>
                 </div>
                 ${result.comments ? `<div class="report-card-comment">${this.escapeHtml(result.comments)}</div>` : ''}
@@ -3759,6 +3813,7 @@ function buildDatasetSubmissionUrl(
                                 verdict: parsed.verdict,
                                 confidence: parsed.confidence,
                                 comments: parsed.comments,
+                                reason_type: parsed.reason_type,
                                 truncated: sourceTruncated
                             };
 

--- a/tests/parsing.test.js
+++ b/tests/parsing.test.js
@@ -78,3 +78,25 @@ test('returns PARSE_ERROR sentinel on completely malformed input', () => {
   assert.equal(out.confidence, null);
   assert.match(out.comments, /Failed to parse/);
 });
+
+test('extracts reason_type from NOT SUPPORTED JSON response', () => {
+  const raw = JSON.stringify({
+    verdict: 'NOT SUPPORTED',
+    confidence: 15,
+    reason_type: 'contradiction',
+    comments: 'Source says 2002, not 1998.'
+  });
+  const out = parseVerificationResult(raw);
+  assert.equal(out.verdict, 'NOT SUPPORTED');
+  assert.equal(out.reason_type, 'contradiction');
+});
+
+test('reason_type defaults to null when not present', () => {
+  const raw = JSON.stringify({
+    verdict: 'SUPPORTED',
+    confidence: 90,
+    comments: 'Matches.'
+  });
+  const out = parseVerificationResult(raw);
+  assert.equal(out.reason_type, null);
+});


### PR DESCRIPTION
When the LLM returns NOT SUPPORTED, it now also returns a reason_type indicating whether the source contradicts the claim or simply omits it. This helps editors decide whether to fix the citation or find a better source. The 4-verdict taxonomy is unchanged; reason_type is informational.

https://claude.ai/code/session_013FugQGovVDQXK6bd9MiEwM