### PR TITLE
Use Internet Archive Wayback API for citation source fetching

### DIFF
--- a/core/urls.js
+++ b/core/urls.js
@@ -6,18 +6,26 @@
 
 const ARCHIVE_HOST_PATTERN = /web\.archive\.org|archive\.today|archive\.is|archive\.ph|webcitation\.org/i;
 
-function isArchiveUrl(href) {
+export function isArchiveUrl(href) {
     return ARCHIVE_HOST_PATTERN.test(href);
+}
+
+export function parseArchiveOrgUrl(url) {
+    const match = url.match(/^https?:\/\/web\.archive\.org\/web\/(\d+)(?:id_)?\/(https?:\/\/.+)$/);
+    if (!match) return null;
+    return { timestamp: match[1], originalUrl: match[2] };
 }
 
 export function extractHttpUrl(element) {
     if (!element) return null;
     const links = element.querySelectorAll('a[href^="http"]');
     if (links.length === 0) return null;
-    // Prefer live URLs over archive snapshots. archive.org rate-limits the
-    // proxy's Cloudflare egress IPs aggressively (429 on most requests),
-    // so archive snapshots are only used as a last-resort fallback when no
-    // live link exists in the citation.
+    // Prefer Internet Archive URLs — we fetch via the Wayback raw endpoint
+    // (id_) which returns clean original content without toolbar framing.
+    for (const link of links) {
+        if (/web\.archive\.org/.test(link.href)) return link.href;
+    }
+    // Then any live URL; other archive services (archive.today etc.) last.
     for (const link of links) {
         if (!isArchiveUrl(link.href)) return link.href;
     }

--- a/core/worker.js
+++ b/core/worker.js
@@ -1,20 +1,10 @@
 // Calls to the Cloudflare Worker proxy: source fetching and verification logging.
 
-import { isGoogleBooksUrl } from './urls.js';
+import { isGoogleBooksUrl, parseArchiveOrgUrl } from './urls.js';
 
-// Always returns { content, error, status }. `content` is the formatted source
-// text on success and null on any failure; `error` is a short human-readable
-// reason when content is null; `status` is the upstream HTTP status code if the
-// proxy reports one (`data.status`), otherwise the proxy's own response status,
-// or null if we never got a response at all.
-export async function fetchSourceContent(url, pageNum, { workerBase = 'https://publicai-proxy.alaexis.workers.dev' } = {}) {
-    if (isGoogleBooksUrl(url)) {
-        console.log('[CitationVerifier] Skipping Google Books URL:', url);
-        return { content: null, error: 'Google Books URL skipped (no fetchable content)', status: null };
-    }
-
+async function fetchViaProxy(fetchUrl, pageNum, workerBase, sourceUrl) {
     try {
-        let proxyUrl = `${workerBase}/?fetch=${encodeURIComponent(url)}`;
+        let proxyUrl = `${workerBase}/?fetch=${encodeURIComponent(fetchUrl)}`;
         if (pageNum) {
             proxyUrl += `&page=${pageNum}`;
         }
@@ -35,11 +25,8 @@ export async function fetchSourceContent(url, pageNum, { workerBase = 'https://p
         }
 
         if (data.content && data.content.length > 100) {
-            // Proxy caps fetched content around 12k chars. If we're at or
-            // above that, the source was almost certainly truncated and
-            // only partially sent to the model.
             const isTruncated = data.truncated === true || data.content.length >= 12000;
-            let meta = `Source URL: ${url}`;
+            let meta = `Source URL: ${sourceUrl}`;
             if (data.pdf) {
                 meta += `\nPDF: ${data.totalPages} pages`;
                 if (data.page) {
@@ -52,8 +39,6 @@ export async function fetchSourceContent(url, pageNum, { workerBase = 'https://p
             return { content: `${meta}\n\nSource Content:\n${data.content}`, error: null, status };
         }
 
-        // If PDF was large and we didn't request a specific page, retry
-        // with the citation page if available
         if (data.pdf && !pageNum && data.totalPages > 15) {
             console.log('[CitationVerifier] Large PDF without page param, content may be truncated');
         }
@@ -64,10 +49,53 @@ export async function fetchSourceContent(url, pageNum, { workerBase = 'https://p
     }
 }
 
+async function findWaybackSnapshot(url) {
+    try {
+        const apiUrl = `https://archive.org/wayback/available?url=${encodeURIComponent(url)}`;
+        const response = await fetch(apiUrl);
+        const data = await response.json();
+        const snapshot = data?.archived_snapshots?.closest;
+        if (snapshot?.available && snapshot.timestamp) {
+            return `https://web.archive.org/web/${snapshot.timestamp}id_/${url}`;
+        }
+    } catch (e) {
+        console.warn('[CitationVerifier] Wayback availability check failed:', e?.message);
+    }
+    return null;
+}
+
+// Always returns { content, error, status }. `content` is the formatted source
+// text on success and null on any failure; `error` is a short human-readable
+// reason when content is null; `status` is the upstream HTTP status code if the
+// proxy reports one (`data.status`), otherwise the proxy's own response status,
+// or null if we never got a response at all.
+export async function fetchSourceContent(url, pageNum, { workerBase = 'https://publicai-proxy.alaexis.workers.dev' } = {}) {
+    if (isGoogleBooksUrl(url)) {
+        console.log('[CitationVerifier] Skipping Google Books URL:', url);
+        return { content: null, error: 'Google Books URL skipped (no fetchable content)', status: null };
+    }
+
+    const archiveInfo = parseArchiveOrgUrl(url);
+    if (archiveInfo) {
+        const rawUrl = `https://web.archive.org/web/${archiveInfo.timestamp}id_/${archiveInfo.originalUrl}`;
+        console.log('[CitationVerifier] Fetching via Wayback raw endpoint');
+        return fetchViaProxy(rawUrl, pageNum, workerBase, url);
+    }
+
+    const result = await fetchViaProxy(url, pageNum, workerBase, url);
+
+    if (!result.content) {
+        const waybackUrl = await findWaybackSnapshot(url);
+        if (waybackUrl) {
+            console.log('[CitationVerifier] Live fetch failed, trying Wayback snapshot');
+            return fetchViaProxy(waybackUrl, pageNum, workerBase, url);
+        }
+    }
+
+    return result;
+}
+
 export function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis.workers.dev' } = {}) {
-    // Wrap the fetch POST in try/catch exactly as main.js does.
-    // `payload` replaces the constructed object in main.js — caller supplies
-    //   { article_url, article_title, citation_number, source_url, provider, verdict, confidence }.
     try {
         fetch(`${workerBase}/log`, {
             method: 'POST',

--- a/main.js
+++ b/main.js
@@ -340,14 +340,22 @@ function isArchiveUrl(href) {
     return ARCHIVE_HOST_PATTERN.test(href);
 }
 
+function parseArchiveOrgUrl(url) {
+    const match = url.match(/^https?:\/\/web\.archive\.org\/web\/(\d+)(?:id_)?\/(https?:\/\/.+)$/);
+    if (!match) return null;
+    return { timestamp: match[1], originalUrl: match[2] };
+}
+
 function extractHttpUrl(element) {
     if (!element) return null;
     const links = element.querySelectorAll('a[href^="http"]');
     if (links.length === 0) return null;
-    // Prefer live URLs over archive snapshots. archive.org rate-limits the
-    // proxy's Cloudflare egress IPs aggressively (429 on most requests),
-    // so archive snapshots are only used as a last-resort fallback when no
-    // live link exists in the citation.
+    // Prefer Internet Archive URLs — we fetch via the Wayback raw endpoint
+    // (id_) which returns clean original content without toolbar framing.
+    for (const link of links) {
+        if (/web\.archive\.org/.test(link.href)) return link.href;
+    }
+    // Then any live URL; other archive services (archive.today etc.) last.
     for (const link of links) {
         if (!isArchiveUrl(link.href)) return link.href;
     }
@@ -823,19 +831,9 @@ async function callProviderAPI(name, config) {
 // Calls to the Cloudflare Worker proxy: source fetching and verification logging.
 
 
-// Always returns { content, error, status }. `content` is the formatted source
-// text on success and null on any failure; `error` is a short human-readable
-// reason when content is null; `status` is the upstream HTTP status code if the
-// proxy reports one (`data.status`), otherwise the proxy's own response status,
-// or null if we never got a response at all.
-async function fetchSourceContent(url, pageNum, { workerBase = 'https://publicai-proxy.alaexis.workers.dev' } = {}) {
-    if (isGoogleBooksUrl(url)) {
-        console.log('[CitationVerifier] Skipping Google Books URL:', url);
-        return { content: null, error: 'Google Books URL skipped (no fetchable content)', status: null };
-    }
-
+async function fetchViaProxy(fetchUrl, pageNum, workerBase, sourceUrl) {
     try {
-        let proxyUrl = `${workerBase}/?fetch=${encodeURIComponent(url)}`;
+        let proxyUrl = `${workerBase}/?fetch=${encodeURIComponent(fetchUrl)}`;
         if (pageNum) {
             proxyUrl += `&page=${pageNum}`;
         }
@@ -856,11 +854,8 @@ async function fetchSourceContent(url, pageNum, { workerBase = 'https://publicai
         }
 
         if (data.content && data.content.length > 100) {
-            // Proxy caps fetched content around 12k chars. If we're at or
-            // above that, the source was almost certainly truncated and
-            // only partially sent to the model.
             const isTruncated = data.truncated === true || data.content.length >= 12000;
-            let meta = `Source URL: ${url}`;
+            let meta = `Source URL: ${sourceUrl}`;
             if (data.pdf) {
                 meta += `\nPDF: ${data.totalPages} pages`;
                 if (data.page) {
@@ -873,8 +868,6 @@ async function fetchSourceContent(url, pageNum, { workerBase = 'https://publicai
             return { content: `${meta}\n\nSource Content:\n${data.content}`, error: null, status };
         }
 
-        // If PDF was large and we didn't request a specific page, retry
-        // with the citation page if available
         if (data.pdf && !pageNum && data.totalPages > 15) {
             console.log('[CitationVerifier] Large PDF without page param, content may be truncated');
         }
@@ -883,6 +876,52 @@ async function fetchSourceContent(url, pageNum, { workerBase = 'https://publicai
         console.error('Proxy fetch failed:', error);
         return { content: null, error: error?.message || String(error), status: null };
     }
+}
+
+async function findWaybackSnapshot(url) {
+    try {
+        const apiUrl = `https://archive.org/wayback/available?url=${encodeURIComponent(url)}`;
+        const response = await fetch(apiUrl);
+        const data = await response.json();
+        const snapshot = data?.archived_snapshots?.closest;
+        if (snapshot?.available && snapshot.timestamp) {
+            return `https://web.archive.org/web/${snapshot.timestamp}id_/${url}`;
+        }
+    } catch (e) {
+        console.warn('[CitationVerifier] Wayback availability check failed:', e?.message);
+    }
+    return null;
+}
+
+// Always returns { content, error, status }. `content` is the formatted source
+// text on success and null on any failure; `error` is a short human-readable
+// reason when content is null; `status` is the upstream HTTP status code if the
+// proxy reports one (`data.status`), otherwise the proxy's own response status,
+// or null if we never got a response at all.
+async function fetchSourceContent(url, pageNum, { workerBase = 'https://publicai-proxy.alaexis.workers.dev' } = {}) {
+    if (isGoogleBooksUrl(url)) {
+        console.log('[CitationVerifier] Skipping Google Books URL:', url);
+        return { content: null, error: 'Google Books URL skipped (no fetchable content)', status: null };
+    }
+
+    const archiveInfo = parseArchiveOrgUrl(url);
+    if (archiveInfo) {
+        const rawUrl = `https://web.archive.org/web/${archiveInfo.timestamp}id_/${archiveInfo.originalUrl}`;
+        console.log('[CitationVerifier] Fetching via Wayback raw endpoint');
+        return fetchViaProxy(rawUrl, pageNum, workerBase, url);
+    }
+
+    const result = await fetchViaProxy(url, pageNum, workerBase, url);
+
+    if (!result.content) {
+        const waybackUrl = await findWaybackSnapshot(url);
+        if (waybackUrl) {
+            console.log('[CitationVerifier] Live fetch failed, trying Wayback snapshot');
+            return fetchViaProxy(waybackUrl, pageNum, workerBase, url);
+        }
+    }
+
+    return result;
 }
 
 function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis.workers.dev' } = {}) {

--- a/tests/urls.test.js
+++ b/tests/urls.test.js
@@ -5,6 +5,8 @@ import {
   extractHttpUrl,
   extractReferenceUrl,
   isGoogleBooksUrl,
+  isArchiveUrl,
+  parseArchiveOrgUrl,
 } from '../core/urls.js';
 
 test('extractHttpUrl pulls href from a direct <a>', () => {
@@ -16,14 +18,15 @@ test('extractHttpUrl pulls href from a direct <a>', () => {
   assert.equal(url, 'https://example.com/page');
 });
 
-test('extractHttpUrl prefers live URLs over archive snapshots', () => {
+test('extractHttpUrl prefers Internet Archive URLs over live URLs', () => {
+  const archiveUrl = 'https://web.archive.org/web/20250515222512/https://example.com/page';
   const jsdom = new JSDOM(`<!DOCTYPE html><body><span id="container">
-    <a href="https://web.archive.org/web/20250515222512/https://example.com/page">archived</a>
     <a href="https://example.com/page">live</a>
+    <a href="${archiveUrl}">archived</a>
   </span></body>`);
   const element = jsdom.window.document.getElementById('container');
   const url = extractHttpUrl(element);
-  assert.equal(url, 'https://example.com/page');
+  assert.equal(url, archiveUrl);
 });
 
 test('extractHttpUrl falls back to archive URL when no live URL exists', () => {
@@ -90,4 +93,43 @@ test('extractReferenceUrl handles Wikipedia REST API relative hrefs like ./Page#
   const refElement = doc.getElementById('ref-1');
   const url = extractReferenceUrl(refElement, doc);
   assert.equal(url, 'https://example.com/sky-source');
+});
+
+test('parseArchiveOrgUrl extracts timestamp and original URL', () => {
+  const result = parseArchiveOrgUrl('https://web.archive.org/web/20250515222512/https://example.com/page');
+  assert.deepEqual(result, { timestamp: '20250515222512', originalUrl: 'https://example.com/page' });
+});
+
+test('parseArchiveOrgUrl handles id_ URLs', () => {
+  const result = parseArchiveOrgUrl('https://web.archive.org/web/20250515222512id_/https://example.com/page');
+  assert.deepEqual(result, { timestamp: '20250515222512', originalUrl: 'https://example.com/page' });
+});
+
+test('parseArchiveOrgUrl returns null for non-archive URLs', () => {
+  assert.equal(parseArchiveOrgUrl('https://example.com/page'), null);
+  assert.equal(parseArchiveOrgUrl('https://archive.today/abc'), null);
+});
+
+test('isArchiveUrl detects all archive hosts', () => {
+  assert.equal(isArchiveUrl('https://web.archive.org/web/2025/https://x.com'), true);
+  assert.equal(isArchiveUrl('https://archive.today/abc'), true);
+  assert.equal(isArchiveUrl('https://archive.is/abc'), true);
+  assert.equal(isArchiveUrl('https://example.com'), false);
+});
+
+test('extractHttpUrl falls back to live URL when no archive.org link exists', () => {
+  const jsdom = new JSDOM(`<!DOCTYPE html><body><span id="container">
+    <a href="https://example.com/page">live</a>
+  </span></body>`);
+  const element = jsdom.window.document.getElementById('container');
+  assert.equal(extractHttpUrl(element), 'https://example.com/page');
+});
+
+test('extractHttpUrl uses other archive services only as last resort', () => {
+  const jsdom = new JSDOM(`<!DOCTYPE html><body><span id="container">
+    <a href="https://archive.today/abc">archive.today</a>
+    <a href="https://example.com/page">live</a>
+  </span></body>`);
+  const element = jsdom.window.document.getElementById('container');
+  assert.equal(extractHttpUrl(element), 'https://example.com/page');
 });

--- a/tests/worker.test.js
+++ b/tests/worker.test.js
@@ -119,6 +119,115 @@ test('fetchSourceContent reports network failures with a null status', async () 
   }
 });
 
+test('fetchSourceContent converts archive.org URLs to raw id_ endpoint', async () => {
+  const mock = mockFetch(async (url) => {
+    assert.ok(url.includes(encodeURIComponent('https://web.archive.org/web/20250515id_/https://example.com/page')),
+      'should fetch via id_ raw endpoint');
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ content: 'a'.repeat(500), truncated: false }),
+    };
+  });
+  try {
+    const result = await fetchSourceContent(
+      'https://web.archive.org/web/20250515/https://example.com/page', null);
+    assert.ok(result.content);
+    assert.ok(result.content.includes('Source URL: https://web.archive.org/web/20250515/https://example.com/page'),
+      'metadata should show the original archive URL');
+  } finally {
+    mock.restore();
+  }
+});
+
+test('fetchSourceContent tries Wayback fallback when live fetch fails', async () => {
+  let callCount = 0;
+  const mock = mockFetch(async (url) => {
+    callCount++;
+    if (callCount === 1) {
+      // Live fetch fails
+      return {
+        ok: true, status: 200,
+        json: async () => ({ error: 'upstream returned 404', status: 404 }),
+      };
+    }
+    if (callCount === 2) {
+      // Wayback availability API
+      assert.ok(url.includes('archive.org/wayback/available'));
+      return {
+        ok: true, status: 200,
+        json: async () => ({
+          archived_snapshots: {
+            closest: { available: true, timestamp: '20240101120000', url: 'http://web.archive.org/web/20240101120000/https://example.com/doc' }
+          }
+        }),
+      };
+    }
+    // Wayback fetch via proxy
+    return {
+      ok: true, status: 200,
+      json: async () => ({ content: 'b'.repeat(500), truncated: false }),
+    };
+  });
+  try {
+    const result = await fetchSourceContent('https://example.com/doc', null);
+    assert.ok(result.content);
+    assert.ok(result.content.includes('Source URL: https://example.com/doc'));
+    assert.equal(callCount, 3);
+  } finally {
+    mock.restore();
+  }
+});
+
+test('fetchSourceContent skips Wayback fallback when no snapshot exists', async () => {
+  let callCount = 0;
+  const mock = mockFetch(async () => {
+    callCount++;
+    if (callCount === 1) {
+      return {
+        ok: true, status: 200,
+        json: async () => ({ error: 'upstream returned 404', status: 404 }),
+      };
+    }
+    // Wayback says no snapshot
+    return {
+      ok: true, status: 200,
+      json: async () => ({ archived_snapshots: {} }),
+    };
+  });
+  try {
+    const result = await fetchSourceContent('https://example.com/doc', null);
+    assert.equal(result.content, null);
+    assert.equal(result.error, 'upstream returned 404');
+    assert.equal(callCount, 2);
+  } finally {
+    mock.restore();
+  }
+});
+
+test('fetchSourceContent handles Wayback API failure gracefully', async () => {
+  let callCount = 0;
+  const mock = mockFetch(async () => {
+    callCount++;
+    if (callCount === 1) {
+      return {
+        ok: true, status: 200,
+        json: async () => ({ error: 'upstream returned 503', status: 503 }),
+      };
+    }
+    // Wayback API itself fails
+    throw new Error('network error');
+  });
+  try {
+    const result = await fetchSourceContent('https://example.com/doc', null);
+    assert.equal(result.content, null);
+    assert.equal(result.error, 'upstream returned 503');
+    assert.equal(callCount, 2);
+  } finally {
+    mock.restore();
+  }
+});
+
 test('logVerification posts payload and swallows failures', async () => {
   const mock = mockFetch(async () => ({ ok: true, json: async () => ({}) }));
   try {


### PR DESCRIPTION
When a citation contains a web.archive.org link, fetch via the Wayback raw endpoint (id_) which returns clean original content without toolbar framing. When a live URL fetch fails, fall back to the Wayback Availability API to check for an archived snapshot before giving up.

URL extraction now prefers Internet Archive links over live URLs when both are present in a citation, since archived content better represents what the source said when the citation was added.

https://claude.ai/code/session_01FiMTRzLKmxCEoFuaMmGCD4