### PR TITLE
Remove HuggingFace provider, make PublicAI the default

### DIFF
--- a/cli/verify.js
+++ b/cli/verify.js
@@ -13,7 +13,7 @@ import { callProviderAPI } from '../core/providers.js';
 import { parseVerificationResult } from '../core/parsing.js';
 import { parseCompareArgs, COMPARE_HELP_TEXT, runCompare } from './compare.js';
 
-const KNOWN_PROVIDERS = ['publicai', 'huggingface', 'claude', 'gemini', 'openai'];
+const KNOWN_PROVIDERS = ['publicai', 'claude', 'gemini', 'openai'];
 
 export function parseCliArgs(argv) {
     const raw = argv.slice(2);
@@ -44,7 +44,7 @@ function parseVerifyArgs(args) {
     const { values, positionals } = parseArgs({
         args,
         options: {
-            provider: { type: 'string', default: 'huggingface' },
+            provider: { type: 'string', default: 'publicai' },
             'no-log': { type: 'boolean', default: false },
             help:     { type: 'boolean', short: 'h', default: false },
         },
@@ -152,7 +152,6 @@ export function classifyProviderError(err) {
 
 const PROVIDER_MODELS = {
     publicai:    'aisingapore/Qwen-SEA-LION-v4-32B-IT',
-    huggingface: 'openai/gpt-oss-20b',
     claude:      'claude-sonnet-4-6',
     gemini:      'gemini-flash-latest',
     openai:      'gpt-4o',
@@ -160,7 +159,6 @@ const PROVIDER_MODELS = {
 
 const PROVIDER_ENV_VARS = {
     publicai:    null, // routed through the worker proxy; no client-side key
-    huggingface: null, // proxy by default; HF_API_KEY (optional) opts into direct
     claude:      'CLAUDE_API_KEY',
     gemini:      'GEMINI_API_KEY',
     openai:      'OPENAI_API_KEY',
@@ -169,7 +167,6 @@ const PROVIDER_ENV_VARS = {
 // Optional env vars: when present, switch the provider to a direct-call path.
 // Absent is fine — the call falls back to PROVIDER_ENV_VARS' default routing.
 const PROVIDER_OPTIONAL_ENV_VARS = {
-    huggingface: 'HF_API_KEY',
 };
 
 export const VERIFY_HELP_TEXT = `usage: ccs verify <wikipedia-url> <citation-number> [options]
@@ -185,11 +182,7 @@ Arguments:
 
 Options:
   --provider <name>  LLM provider to use. One of:
-                       huggingface (default; routed via the worker proxy,
-                                    no API key needed; set HF_API_KEY to
-                                    call HF directly and unlock any
-                                    HF-hosted model)
-                       publicai    (routed via the worker proxy,
+                       publicai    (default; routed via the worker proxy,
                                     no API key needed)
                        claude      (requires CLAUDE_API_KEY)
                        gemini      (requires GEMINI_API_KEY)

--- a/main.js
+++ b/main.js
@@ -1018,16 +1018,6 @@ function buildDatasetSubmissionUrl(
                     model: 'aisingapore/Qwen-SEA-LION-v4-32B-IT',
                     requiresKey: false
                 },
-                huggingface: {
-                    name: 'HuggingFace',
-                    // Optional key: free via the proxy without one; direct call
-                    // to HF (any model) when stored.
-                    storageKey: 'hf_api_key',
-                    color: '#6B21A8', // HF yellow-orange
-                    model: 'openai/gpt-oss-20b',
-                    requiresKey: false,
-                    optionalKey: true
-                },
                 claude: {
                     name: 'Claude',
                     storageKey: 'claude_api_key',
@@ -1051,14 +1041,13 @@ function buildDatasetSubmissionUrl(
                 }
             };
             
-            // Migrate legacy provider selections ('apertus', 'publicai') to
-            // the current default ('huggingface').
+            // Migrate legacy provider selections to the current default.
             let storedProvider = localStorage.getItem('source_verifier_provider');
-            if (storedProvider === 'apertus' || storedProvider === 'publicai') {
-                storedProvider = 'huggingface';
-                localStorage.setItem('source_verifier_provider', 'huggingface');
+            if (storedProvider === 'apertus' || storedProvider === 'huggingface') {
+                storedProvider = 'publicai';
+                localStorage.setItem('source_verifier_provider', 'publicai');
             }
-            this.currentProvider = storedProvider || 'huggingface';
+            this.currentProvider = storedProvider || 'publicai';
             this.sidebarWidth = localStorage.getItem('verifier_sidebar_width') || '400px';
             this.isVisible = localStorage.getItem('verifier_sidebar_visible') === 'true';
             this.buttons = {};
@@ -3594,8 +3583,6 @@ function buildDatasetSubmissionUrl(
             let modelDesc;
             if (this.currentProvider === 'publicai') {
                 modelDesc = 'a PublicAI-hosted open-source LLM';
-            } else if (this.currentProvider === 'huggingface') {
-                modelDesc = `a HuggingFace-hosted open-source LLM (${provider.model})`;
             } else {
                 modelDesc = provider.model;
             }

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -28,7 +28,7 @@ test('parseCliArgs: verify subcommand with url and citation number', () => {
   assert.equal(result.subcommand, 'verify');
   assert.equal(result.url, 'https://en.wikipedia.org/wiki/Foo');
   assert.equal(result.citationNumber, 3);
-  assert.equal(result.provider, 'huggingface');
+  assert.equal(result.provider, 'publicai');
   assert.equal(result.noLog, false);
 });
 
@@ -369,78 +369,6 @@ test('runVerify: missing citation number returns 5', async () => {
   }
 });
 
-test('runVerify: provider=huggingface without HF_API_KEY routes via worker /hf', async () => {
-  const mock = mkFetchMock([
-    {
-      match: (url) => String(url).startsWith('https://en.wikipedia.org/api/rest_v1/'),
-      respond: async () => ({ ok: true, status: 200, text: async () => WIKI_HTML_WITH_ONE_CITATION }),
-    },
-    {
-      match: (url) => String(url).includes('?fetch='),
-      respond: async () => ({ ok: true, json: async () => ({ content: 'x'.repeat(300) }) }),
-    },
-    {
-      match: (url, opts) => String(url) === 'https://publicai-proxy.alaexis.workers.dev/hf' && opts?.method === 'POST',
-      respond: async (_url, opts) => {
-        assert.equal(opts.headers['Authorization'], undefined,
-          'proxy path must not forward an Authorization header');
-        return {
-          ok: true, status: 200, json: async () => ({
-            choices: [{ message: { content: '{"verdict":"SUPPORTED","confidence":80,"comments":"ok"}' } }],
-            usage: { prompt_tokens: 10, completion_tokens: 5 },
-          }),
-        };
-      },
-    },
-  ]);
-  const stdout = mkStream();
-  const stderr = mkStream();
-  try {
-    const code = await runVerify(
-      { url: 'https://en.wikipedia.org/wiki/Sky', citationNumber: 1, provider: 'huggingface', noLog: true },
-      { stdout, stderr, env: {} },
-    );
-    assert.equal(code, 0, `stderr: ${stderr.value()}`);
-  } finally {
-    mock.restore();
-  }
-});
-
-test('runVerify: provider=huggingface with HF_API_KEY hits HF router with Bearer header', async () => {
-  const mock = mkFetchMock([
-    {
-      match: (url) => String(url).startsWith('https://en.wikipedia.org/api/rest_v1/'),
-      respond: async () => ({ ok: true, status: 200, text: async () => WIKI_HTML_WITH_ONE_CITATION }),
-    },
-    {
-      match: (url) => String(url).includes('?fetch='),
-      respond: async () => ({ ok: true, json: async () => ({ content: 'x'.repeat(300) }) }),
-    },
-    {
-      match: (url, opts) => String(url) === 'https://router.huggingface.co/v1/chat/completions' && opts?.method === 'POST',
-      respond: async (_url, opts) => {
-        assert.equal(opts.headers['Authorization'], 'Bearer hf_test_key');
-        return {
-          ok: true, status: 200, json: async () => ({
-            choices: [{ message: { content: '{"verdict":"SUPPORTED","confidence":80,"comments":"ok"}' } }],
-            usage: { prompt_tokens: 10, completion_tokens: 5 },
-          }),
-        };
-      },
-    },
-  ]);
-  const stdout = mkStream();
-  const stderr = mkStream();
-  try {
-    const code = await runVerify(
-      { url: 'https://en.wikipedia.org/wiki/Sky', citationNumber: 1, provider: 'huggingface', noLog: true },
-      { stdout, stderr, env: { HF_API_KEY: 'hf_test_key' } },
-    );
-    assert.equal(code, 0, `stderr: ${stderr.value()}`);
-  } finally {
-    mock.restore();
-  }
-});
 
 test('runVerify: provider 500 returns 10', async () => {
   const mock = mkFetchMock([


### PR DESCRIPTION
## Summary

This PR removes the HuggingFace provider integration and establishes PublicAI as the new default provider across the codebase. This simplifies the provider landscape and consolidates on a single free, proxy-routed LLM option.

## Key Changes

- **Removed HuggingFace provider configuration** from `main.js`:
  - Deleted the `huggingface` provider object (name, storageKey, model, requiresKey, optionalKey)
  - Removed HuggingFace-specific model description logic
  
- **Updated provider defaults**:
  - Changed CLI default from `'huggingface'` to `'publicai'` in `cli/verify.js`
  - Changed UI default from `'huggingface'` to `'publicai'` in `main.js`
  - Updated localStorage migration logic to convert legacy `'huggingface'` selections to `'publicai'`

- **Cleaned up provider metadata**:
  - Removed `huggingface` from `KNOWN_PROVIDERS` list in `cli/verify.js`
  - Removed HuggingFace entries from `PROVIDER_MODELS` and `PROVIDER_ENV_VARS` dicts
  - Removed `HF_API_KEY` from `PROVIDER_OPTIONAL_ENV_VARS`
  - Updated help text to reflect PublicAI as the default with no API key requirement

- **Removed test coverage** for HuggingFace-specific behavior:
  - Deleted test for HuggingFace without `HF_API_KEY` (proxy routing via `/hf` endpoint)
  - Deleted test for HuggingFace with `HF_API_KEY` (direct HF router call with Bearer auth)

- **Updated test expectations**:
  - Changed expected default provider from `'huggingface'` to `'publicai'` in CLI args test

## Implementation Details

The migration preserves backward compatibility by automatically converting any stored `'huggingface'` provider preference to `'publicai'` on next load, ensuring users with the old default are seamlessly transitioned to the new one.

https://claude.ai/code/session_01An4yfYAnousNC79jd4nr92