### PR TITLE
Enable verifier tab in user namespace (namespace 2)

### DIFF
--- a/main.js
+++ b/main.js
@@ -2443,7 +2443,7 @@ function buildDatasetSubmissionUrl(
         }
         
         createVerifierTab() {
-            if (typeof mw !== 'undefined' && [0, 118].includes(mw.config.get('wgNamespaceNumber'))) {
+            if (typeof mw !== 'undefined' && [0, 2, 118].includes(mw.config.get('wgNamespaceNumber'))) {
                 const skin = mw.config.get('skin');
                 let portletId;
                 
@@ -4059,7 +4059,7 @@ function buildDatasetSubmissionUrl(
         }
     }
     
-    if (typeof mw !== 'undefined' && [0, 118].includes(mw.config.get('wgNamespaceNumber'))) {
+    if (typeof mw !== 'undefined' && [0, 2, 118].includes(mw.config.get('wgNamespaceNumber'))) {
         mw.loader.using(['mediawiki.util', 'mediawiki.api', 'oojs-ui-core', 'oojs-ui-widgets', 'oojs-ui-windows', 'oojs-ui.styles.icons-interactions']).then(function() {
             $(function() {
                 new WikipediaSourceVerifier();


### PR DESCRIPTION
## Summary
Extends the verifier tab initialization to include the user namespace (namespace 2) in addition to the main article (0) and user talk (118) namespaces.

## Changes
- Updated namespace check in `createVerifierTab()` method to include namespace 2
- Updated namespace check in the initialization guard at module load time to include namespace 2
- Both checks now validate against `[0, 2, 118]` instead of `[0, 118]`

## Details
The verifier tool can now be used on user pages (namespace 2), allowing editors to verify citations on their own user pages in addition to article and user talk pages. This is consistent with the existing support for user talk pages (namespace 118) and maintains the same initialization pattern across both entry points.

https://claude.ai/code/session_01CC9xoNz2Fd1omTGqwC8fCR