### PR TITLE
Add reason_type field to verification logging

### DIFF
--- a/core/worker.js
+++ b/core/worker.js
@@ -96,6 +96,9 @@ export async function fetchSourceContent(url, pageNum, { workerBase = 'https://p
 }
 
 export function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis.workers.dev' } = {}) {
+    // Caller supplies the payload object:
+    //   { article_url, article_title, citation_number, source_url, provider,
+    //     verdict, confidence, reason_type }.
     try {
         fetch(`${workerBase}/log`, {
             method: 'POST',

--- a/main.js
+++ b/main.js
@@ -936,9 +936,9 @@ async function fetchSourceContent(url, pageNum, { workerBase = 'https://publicai
 }
 
 function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis.workers.dev' } = {}) {
-    // Wrap the fetch POST in try/catch exactly as main.js does.
-    // `payload` replaces the constructed object in main.js — caller supplies
-    //   { article_url, article_title, citation_number, source_url, provider, verdict, confidence }.
+    // Caller supplies the payload object:
+    //   { article_url, article_title, citation_number, source_url, provider,
+    //     verdict, confidence, reason_type }.
     try {
         fetch(`${workerBase}/log`, {
             method: 'POST',
@@ -2981,7 +2981,7 @@ function buildDatasetSubmissionUrl(
             return generateUserPrompt(claim, sourceInfo);
         }
 
-        logVerification(verdict, confidence) {
+        logVerification(verdict, confidence, reasonType) {
             logVerification({
                 article_url: window.location.href,
                 article_title: typeof mw !== 'undefined' ? mw.config.get('wgTitle') : document.title,
@@ -2990,6 +2990,7 @@ function buildDatasetSubmissionUrl(
                 provider: this.currentProvider,
                 verdict: verdict,
                 confidence: confidence,
+                reason_type: reasonType ?? null,
             });
         }
 
@@ -3025,7 +3026,7 @@ function buildDatasetSubmissionUrl(
                     const jsonMatch = result.match(/```(?:json)?\s*([\s\S]*?)\s*```/) ||
                                      [null, result.match(/\{[\s\S]*\}/)?.[0]];
                     const parsed = JSON.parse(jsonMatch[1]);
-                    this.logVerification(parsed.verdict, parsed.confidence);
+                    this.logVerification(parsed.verdict, parsed.confidence, parsed.reason_type);
                 } catch (e) {}
 
             } catch (error) {
@@ -3862,7 +3863,7 @@ function buildDatasetSubmissionUrl(
                                 const savedSourceUrl = this.activeSourceUrl;
                                 this.activeCitationNumber = citation.citationNumber;
                                 this.activeSourceUrl = citation.url;
-                                this.logVerification(parsed.verdict, parsed.confidence);
+                                this.logVerification(parsed.verdict, parsed.confidence, parsed.reason_type);
                                 this.activeCitationNumber = savedCitationNumber;
                                 this.activeSourceUrl = savedSourceUrl;
                             } catch (e) {}


### PR DESCRIPTION
## Summary
Extends the verification logging system to capture the reason or type associated with each verdict, enabling more detailed tracking of why citations were marked as supported, partially supported, or not supported.

## Changes
- **Updated `logVerification()` signature** in both `main.js` and `core/worker.js` to accept a `reasonType` parameter
- **Enhanced payload structure** to include `reason_type` field (nullable) in the logged verification object
- **Updated documentation** in function comments to reflect the new `reason_type` field in the payload schema
- **Modified verification call sites** to extract and pass `parsed.reason_type` from LLM responses:
  - Main verification flow (line ~3028)
  - Batch citation verification flow (line ~3865)

## Implementation Details
- The `reasonType` parameter is optional and defaults to `null` if not provided (`reason_type: reasonType ?? null`)
- The field is extracted from the LLM response JSON alongside existing `verdict` and `confidence` fields
- Changes maintain backward compatibility — existing callers that don't provide `reason_type` will log `null`
- Both the userscript (`main.js`) and shared worker module (`core/worker.js`) are kept in sync

https://claude.ai/code/session_01JZebHFhCw4JWidLRh4PPDv