### PR TITLE
Add dark mode (OS preference) styles for verifier report UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,17 @@ When you regenerate `dataset.json` after a CSV reorder, you must also walk `resu
 
 A stable-id refactor (content hash, or a CSV-supplied id column independent of line number) would eliminate the class of bug entirely.
 
+### Dark mode has TWO independent paths — style every new UI element in both (read before touching CSS)
+
+`createStyles()` in `main.js` supports dark mode through **two separate selector prefixes**, and a new element only looks right in dark mode if it gets overrides under *both*:
+
+1. **`html.skin-theme-clientpref-night`** — the user explicitly picked Wikipedia's night theme. These rules live inline (search `skin-theme-clientpref-night`).
+2. **`@media (prefers-color-scheme: dark) { html.skin-theme-clientpref-os ... }`** — the user picked "follow OS" and the OS is dark. These rules live inside the `@media` block near the end of `createStyles()`.
+
+The two blocks are hand-mirrored — there is no shared variable, so an override added to one is **not** inherited by the other. The recurring bug (e.g. grouped-citation blocks looking wrong in dark mode) is a new component that got light-mode CSS plus `-night` overrides but was never added to the `-os` `@media` block, so it stays light-on-light for every "follow OS" reader.
+
+**Whenever you add or restyle a component with a non-transparent `background`, `border-color`, `color`, or `:hover` background, add matching overrides in BOTH dark blocks.** Don't forget `:hover` backgrounds — a light hover color (e.g. `#f0f4ff`) flashes jarringly over a dark card. Provider-tinted values should use `${this.getCurrentColor()}` rather than a hardcoded hex so they track the selected provider color (see the re-create-on-provider-change note near the bottom of `createStyles()`).
+
 ## Common Tasks
 
 **Modifying the user script:** Edit `main.js` directly. Test by loading on Wikipedia via the browser console or user script page.

--- a/main.js
+++ b/main.js
@@ -1902,6 +1902,9 @@ function buildDatasetSubmissionUrl(
                     border-color: #3a3a4e !important;
                     color: #e0e0e0 !important;
                 }
+                html.skin-theme-clientpref-night .verifier-report-group-row:hover {
+                    background: #232336 !important;
+                }
                 html.skin-theme-clientpref-night .verifier-report-group-claim,
                 html.skin-theme-clientpref-night .verifier-report-group-collective-label {
                     color: #d0d0d8 !important;
@@ -2389,6 +2392,26 @@ function buildDatasetSubmissionUrl(
                     html.skin-theme-clientpref-os #source-verifier-sidebar .oo-ui-optionWidget-selected {
                         background: ${this.getCurrentColor()} !important;
                         color: white !important;
+                    }
+                    html.skin-theme-clientpref-os .verifier-report-group {
+                        background: #232336 !important;
+                        border-color: #3a3a4e !important;
+                    }
+                    html.skin-theme-clientpref-os .verifier-report-group-row,
+                    html.skin-theme-clientpref-os .verifier-report-group-collective {
+                        background: #1a1a2e !important;
+                        border-color: #3a3a4e !important;
+                        color: #e0e0e0 !important;
+                    }
+                    html.skin-theme-clientpref-os .verifier-report-group-row:hover {
+                        background: #232336 !important;
+                    }
+                    html.skin-theme-clientpref-os .verifier-report-group-claim,
+                    html.skin-theme-clientpref-os .verifier-report-group-collective-label {
+                        color: #d0d0d8 !important;
+                    }
+                    html.skin-theme-clientpref-os #verifier-claim-group-indicator {
+                        color: #b0b0c0 !important;
                     }
                 }
             `;


### PR DESCRIPTION
## Summary
Extends dark mode support for the verifier report UI components to cover the `@media (prefers-color-scheme: dark)` path used by readers with "follow OS" theme preference. Previously, these components only had overrides for the explicit night theme (`skin-theme-clientpref-night`), causing them to render with light backgrounds on dark OS themes.

## Changes
- **main.js:** Added dark mode CSS overrides for `.verifier-report-group`, `.verifier-report-group-row`, `.verifier-report-group-collective`, and related elements under the `@media (prefers-color-scheme: dark)` block with `html.skin-theme-clientpref-os` selector. Includes hover state styling to prevent jarring light flashes.
- **CLAUDE.md:** Documented the dual dark mode path architecture and added guidance for contributors to ensure new UI components receive overrides in both dark mode blocks (`-night` and `-os`).

## Implementation Details
The verifier report components now have matching color schemes in both dark mode paths:
- Background: `#232336` (group) / `#1a1a2e` (rows/collectives)
- Border: `#3a3a4e`
- Text: `#e0e0e0` (primary) / `#d0d0d8` (claims/labels) / `#b0b0c0` (indicators)
- Hover background: `#232336`

This mirrors the existing `skin-theme-clientpref-night` overrides added earlier in the file, ensuring visual consistency across both dark mode preference paths.

https://claude.ai/code/session_01MS1mduAM2gtfBRJHaC86fV