### PR TITLE
Rename verifier filter chip hidden state class

### DIFF
--- a/main.js
+++ b/main.js
@@ -1655,7 +1655,7 @@ function buildDatasetSubmissionUrl(
                     background: #eef2ff;
                     border-color: #99a;
                 }
-                .verifier-filter-chip.hidden {
+                .verifier-filter-chip.verifier-chip-off {
                     opacity: 0.5;
                     text-decoration: line-through;
                     background: #f0f0f0;
@@ -2046,7 +2046,7 @@ function buildDatasetSubmissionUrl(
                     background: #3a3a5e !important;
                     border-color: #5a5a7e !important;
                 }
-                html.skin-theme-clientpref-night .verifier-filter-chip.hidden {
+                html.skin-theme-clientpref-night .verifier-filter-chip.verifier-chip-off {
                     background: #1f1f2e !important;
                     color: #8a8a9e !important;
                 }
@@ -2272,7 +2272,7 @@ function buildDatasetSubmissionUrl(
                         background: #3a3a5e !important;
                         border-color: #5a5a7e !important;
                     }
-                    html.skin-theme-clientpref-os .verifier-filter-chip.hidden {
+                    html.skin-theme-clientpref-os .verifier-filter-chip.verifier-chip-off {
                         background: #1f1f2e !important;
                         color: #8a8a9e !important;
                     }
@@ -3468,7 +3468,7 @@ function buildDatasetSubmissionUrl(
             const chip = (key, count, label, color) => {
                 const hidden = !!this.reportFilters[key];
                 return `<button type="button"
-                    class="verifier-filter-chip${hidden ? ' hidden' : ''}"
+                    class="verifier-filter-chip${hidden ? ' verifier-chip-off' : ''}"
                     data-filter="${key}"
                     title="${hidden ? 'Show' : 'Hide'} ${this.escapeHtml(label)} citations"
                     aria-pressed="${hidden ? 'false' : 'true'}">


### PR DESCRIPTION
## Summary
Rename the CSS class used to represent the "off" state of verifier filter chips from `.hidden` to `.verifier-chip-off` for improved semantic clarity and to avoid conflicts with generic utility class names.

## Changes
- Updated CSS class name from `.verifier-filter-chip.hidden` to `.verifier-filter-chip.verifier-chip-off` across all theme variants:
  - Base light theme styles
  - Dark theme (`skin-theme-clientpref-night`)
  - OS preference theme (`skin-theme-clientpref-os`)
- Updated the chip button element generation to apply the new class name when the filter is active (hidden)

## Implementation Details
The change affects both the CSS rule definitions and the dynamic class assignment in the `chip()` function. The semantic meaning remains unchanged — when `this.reportFilters[key]` is truthy, the chip receives the `verifier-chip-off` class to visually indicate it's in the "off" state (opacity reduced, strikethrough text, grayed background). This more specific class name reduces the risk of unintended style conflicts with other components using generic `.hidden` classes.

https://claude.ai/code/session_01U5WUYcKGdp2LgPzGxfTigf