### PR TITLE
Localize the report completion/cancellation status line

### DIFF
--- a/main.js
+++ b/main.js
@@ -1242,6 +1242,10 @@ function buildDatasetSubmissionUrl(
         'Rate limited, retrying in {secs}s...':
             'Limite de débit atteinte, nouvelle tentative dans {secs}s…',
         'Checking combined sources {token}': 'Vérification des sources combinées {token}',
+        'Completed: {count} citations checked': 'Terminé : {count} citations vérifiées',
+        'Completed: {count} citation checked': 'Terminé : {count} citation vérifiée',
+        'Cancelled after {done} of {total} citations': 'Annulé après {done} sur {total} citations',
+        'Cancelled after {done} of {total} citation': 'Annulé après {done} sur {total} citation',
         ' · ~{duration} remaining': ' · ~{duration} restant',
 
         // Report summary
@@ -4570,8 +4574,8 @@ function buildDatasetSubmissionUrl(
             // Finalize
             this.reportRunning = false;
             const finalPhase = this.reportCancelled
-                ? `Cancelled after ${this.reportResults.length} of ${citations.length} citations`
-                : `Completed: ${this.reportResults.length} citations checked`;
+                ? this.t(citations.length === 1 ? 'Cancelled after {done} of {total} citation' : 'Cancelled after {done} of {total} citations', { done: this.reportResults.length, total: citations.length })
+                : this.t(this.reportResults.length === 1 ? 'Completed: {count} citation checked' : 'Completed: {count} citations checked', { count: this.reportResults.length });
             this.updateReportProgress(completed, progressTotal, finalPhase, startTime);
             this.renderReportSummary();
             this.renderReportActions();


### PR DESCRIPTION
The final progress phase ("Completed: N citations checked" / "Cancelled after N of M citations") was still built from a bare template, so it stayed English on French wikis. Route it through t() with singular/plural keys.