### PR TITLE
Recover article text when a Wayback banner survives the fetch

### DIFF
--- a/benchmark/extract_dataset.js
+++ b/benchmark/extract_dataset.js
@@ -34,6 +34,8 @@ import { fileURLToPath } from 'url';
 import { dirname } from 'path';
 import { extractClaimText as extractClaimTextFromRef } from '../core/claim.js';
 import { canonicalizeVerdict, toTitleCase } from '../core/verdicts.js';
+import { parseArchiveOrgUrl } from '../core/urls.js';
+import { recoverWaybackBody } from '../core/worker.js';
 import { writeWithMetadata, todayIso, loadRows } from './io.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -168,16 +170,24 @@ function fetchURL(url) {
  * Fetch source content via proxy, with direct fetch fallback
  */
 async function fetchSourceContent(url) {
+    // Archive.org snapshots are fetched through the raw `id_` endpoint, which
+    // serves the archived response without Wayback's playback chrome. Same
+    // treatment the userscript gives them in core/worker.js.
+    const archiveInfo = parseArchiveOrgUrl(url);
+    const fetchUrl = archiveInfo
+        ? `https://web.archive.org/web/${archiveInfo.timestamp}id_/${archiveInfo.originalUrl}`
+        : url;
+
     // Try proxy first
     try {
         log(`    Trying proxy fetch...`);
-        const proxyUrl = `${PROXY_URL}?fetch=${encodeURIComponent(url)}`;
+        const proxyUrl = `${PROXY_URL}?fetch=${encodeURIComponent(fetchUrl)}`;
         const response = await fetchWithRetry(proxyUrl);
         const data = JSON.parse(response);
 
         if (data.content && data.content.length > 100) {
             log(`    Proxy success: ${data.content.length} chars`);
-            return data.content;
+            return recoverWaybackBody(data.content);
         }
         log(`    Proxy returned insufficient content: ${data.content?.length || 0} chars`);
     } catch (error) {
@@ -187,7 +197,7 @@ async function fetchSourceContent(url) {
     // Try direct fetch as fallback
     try {
         log(`    Trying direct fetch...`);
-        const html = await fetchWithRetry(url);
+        const html = await fetchWithRetry(fetchUrl);
 
         // Basic HTML text extraction
         const textMatch = html.match(/<article[^>]*>([\s\S]*?)<\/article>/i) ||

--- a/core/worker.js
+++ b/core/worker.js
@@ -2,6 +2,31 @@
 
 import { isGoogleBooksUrl, parseArchiveOrgUrl } from './urls.js';
 
+// Chars that must precede the preamble before it is trusted as real page chrome.
+const WAYBACK_MIN_PREFIX = 200;
+// Chars of content that must follow for the recovered slice to be worth taking.
+const WAYBACK_MIN_REMAINDER = 500;
+const WAYBACK_PREAMBLE = /The Wayback Machine - https:\/\/web\.archive\.org\/\S+/;
+
+// Salvage the inner article when a Wayback banner survives into the extracted
+// text. The raw `id_` endpoint avoids the banner for snapshot URLs we can parse,
+// but it still reaches us from snapshots whose URL carries a different playback
+// flag, and from pages the proxy fetched before any archive handling applied.
+//
+// Conservative on both ends: the banner has to be far enough in to be page
+// chrome rather than the article's own words, and enough content has to follow
+// for the remainder to be worth preferring over the whole document. Anything
+// short of both thresholds returns the text untouched.
+export function recoverWaybackBody(text) {
+    const match = WAYBACK_PREAMBLE.exec(text);
+    if (!match) return text;
+    const cut = match.index + match[0].length;
+    if (cut < WAYBACK_MIN_PREFIX) return text;
+    const remainder = text.slice(cut).trim();
+    if (remainder.length < WAYBACK_MIN_REMAINDER) return text;
+    return remainder;
+}
+
 async function fetchViaProxy(fetchUrl, pageNum, workerBase, sourceUrl) {
     try {
         let proxyUrl = `${workerBase}/?fetch=${encodeURIComponent(fetchUrl)}`;
@@ -36,7 +61,8 @@ async function fetchViaProxy(fetchUrl, pageNum, workerBase, sourceUrl) {
             if (isTruncated) {
                 meta += `\nTruncated: true`;
             }
-            return { content: `${meta}\n\nSource Content:\n${data.content}`, error: null, status };
+            const body = recoverWaybackBody(data.content);
+            return { content: `${meta}\n\nSource Content:\n${body}`, error: null, status };
         }
 
         if (data.pdf && !pageNum && data.totalPages > 15) {

--- a/main.js
+++ b/main.js
@@ -956,6 +956,31 @@ async function callProviderAPI(name, config) {
 // Calls to the Cloudflare Worker proxy: source fetching and verification logging.
 
 
+// Chars that must precede the preamble before it is trusted as real page chrome.
+const WAYBACK_MIN_PREFIX = 200;
+// Chars of content that must follow for the recovered slice to be worth taking.
+const WAYBACK_MIN_REMAINDER = 500;
+const WAYBACK_PREAMBLE = /The Wayback Machine - https:\/\/web\.archive\.org\/\S+/;
+
+// Salvage the inner article when a Wayback banner survives into the extracted
+// text. The raw `id_` endpoint avoids the banner for snapshot URLs we can parse,
+// but it still reaches us from snapshots whose URL carries a different playback
+// flag, and from pages the proxy fetched before any archive handling applied.
+//
+// Conservative on both ends: the banner has to be far enough in to be page
+// chrome rather than the article's own words, and enough content has to follow
+// for the remainder to be worth preferring over the whole document. Anything
+// short of both thresholds returns the text untouched.
+function recoverWaybackBody(text) {
+    const match = WAYBACK_PREAMBLE.exec(text);
+    if (!match) return text;
+    const cut = match.index + match[0].length;
+    if (cut < WAYBACK_MIN_PREFIX) return text;
+    const remainder = text.slice(cut).trim();
+    if (remainder.length < WAYBACK_MIN_REMAINDER) return text;
+    return remainder;
+}
+
 async function fetchViaProxy(fetchUrl, pageNum, workerBase, sourceUrl) {
     try {
         let proxyUrl = `${workerBase}/?fetch=${encodeURIComponent(fetchUrl)}`;
@@ -990,7 +1015,8 @@ async function fetchViaProxy(fetchUrl, pageNum, workerBase, sourceUrl) {
             if (isTruncated) {
                 meta += `\nTruncated: true`;
             }
-            return { content: `${meta}\n\nSource Content:\n${data.content}`, error: null, status };
+            const body = recoverWaybackBody(data.content);
+            return { content: `${meta}\n\nSource Content:\n${body}`, error: null, status };
         }
 
         if (data.pdf && !pageNum && data.totalPages > 15) {
@@ -1050,6 +1076,9 @@ async function fetchSourceContent(url, pageNum, { workerBase = 'https://publicai
 }
 
 function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis.workers.dev' } = {}) {
+    // Caller supplies the payload object:
+    //   { article_url, article_title, citation_number, source_url, provider,
+    //     verdict, confidence, reason_type }.
     try {
         fetch(`${workerBase}/log`, {
             method: 'POST',

--- a/tests/worker.test.js
+++ b/tests/worker.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { fetchSourceContent, logVerification } from '../core/worker.js';
+import { fetchSourceContent, logVerification, recoverWaybackBody } from '../core/worker.js';
 
 function mockFetch(impl) {
   const original = globalThis.fetch;
@@ -242,6 +242,42 @@ test('logVerification posts payload and swallows failures', async () => {
     }));
     assert.equal(mock.calls[0].url, 'https://publicai-proxy.alaexis.workers.dev/log');
     assert.equal(mock.calls[0].opts.method, 'POST');
+  } finally {
+    mock.restore();
+  }
+});
+
+const WAYBACK_BANNER = 'The Wayback Machine - https://web.archive.org/web/2020/x';
+
+test('recoverWaybackBody strips a Wayback banner that survived extraction', () => {
+  const input = `${'p'.repeat(300)}${WAYBACK_BANNER} ${'a'.repeat(600)}`;
+  const recovered = recoverWaybackBody(input);
+  assert.ok(!recovered.includes('Wayback Machine'));
+  assert.equal(recovered, 'a'.repeat(600));
+});
+
+test('recoverWaybackBody leaves text without a banner unchanged', () => {
+  const text = 'no banner here, just article prose';
+  assert.equal(recoverWaybackBody(text), text);
+});
+
+test('recoverWaybackBody keeps the original when the banner appears too early', () => {
+  const input = `${'p'.repeat(10)}${WAYBACK_BANNER} ${'a'.repeat(600)}`;
+  assert.equal(recoverWaybackBody(input), input);
+});
+
+test('recoverWaybackBody keeps the original when too little content follows', () => {
+  const input = `${'p'.repeat(300)}${WAYBACK_BANNER} ${'a'.repeat(100)}`;
+  assert.equal(recoverWaybackBody(input), input);
+});
+
+test('fetchSourceContent recovers the article body when the banner survives the fetch', async () => {
+  const content = `${'p'.repeat(300)}${WAYBACK_BANNER} ${'a'.repeat(600)}`;
+  const mock = mockFetch(async () => ({ ok: true, status: 200, json: async () => ({ content }) }));
+  try {
+    const result = await fetchSourceContent('https://example.com/page', null);
+    assert.ok(!result.content.includes('Wayback Machine'));
+    assert.ok(result.content.includes(`Source Content:\n${'a'.repeat(600)}`));
   } finally {
     mock.restore();
   }


### PR DESCRIPTION
Two small fetch-quality fixes for Internet Archive sources, both narrower than they sound.

### 1. Recover the article when a Wayback banner survives the fetch

`fetchSourceContent` already routes parseable snapshot URLs through the raw `id_` endpoint, which returns the archived response without Wayback's playback chrome. Two paths still deliver the banner to the model:

- snapshot URLs whose timestamp carries a playback flag other than `id_` (`im_`, `js_`, `cs_`, …) don't match `parseArchiveOrgUrl`, so they're fetched as-is;
- `id_` playback occasionally still serves the wrapper — most visibly for redirect notices.

When that happens the extracted text opens with `The Wayback Machine - https://web.archive.org/…` followed by toolbar text, and the model is asked to judge a claim against archive chrome.

`recoverWaybackBody()` drops everything up to and including that preamble. It is deliberately hard to trigger:

- the banner must sit **at least 200 chars in**, so an article that merely quotes the phrase is left alone;
- **at least 500 chars** must remain after it, so a short redirect notice is never preferred over the full document.

If either threshold is unmet the text passes through untouched. Worst case is a no-op, which is why it needs no flag.

### 2. Give the benchmark extractor the same `id_` treatment

`benchmark/extract_dataset.js` fetched archive.org URLs in their wrapped form, so any snapshot-backed row captured `source_text` that begins with the banner — the benchmark was measuring against inputs the userscript would never see. It now builds the raw endpoint with core's `parseArchiveOrgUrl`, on both the proxy and direct-fetch paths, and runs the result through `recoverWaybackBody` too.

This does **not** re-extract anything. Existing `source_text` values for snapshot-backed rows still carry whatever they captured; they'll pick up the cleaner text on the next `npm run extract`. That felt like a separate, measurable change rather than something to bundle here.

### Provenance

Ported from a Rust citation-verification codebase I work on that hit the same two problems and landed the same pair of fixes (URL rewrite + preamble recovery). The thresholds are carried over from that implementation, where they've been running against live sources.

### Verification

- `npm test` — 295/295 pass, including 5 new cases: the three threshold behaviors (no banner / banner too early / too little remaining), the successful strip, and the end-to-end fetch path.
- `npm run build -- --check` — `main.js` in sync with `core/`.
- No behavior change for non-archive sources, and none for snapshot URLs that already resolve through `id_` cleanly.
