### PR TITLE
Skip internal Wikimedia wikilinks in citation source extraction

### DIFF
--- a/core/urls.js
+++ b/core/urls.js
@@ -10,6 +10,21 @@ export function isArchiveUrl(href) {
     return ARCHIVE_HOST_PATTERN.test(href);
 }
 
+// Wikimedia-family internal wikilinks (a[href^="http"] resolves to an absolute
+// URL, so blue wikilinks like the "ISBN (identifier)" article, and the
+// Special:BookSources bookseller-list page that ISBN magic links point to, can
+// slip through the http filter). These are never genuine citation sources —
+// verifying a claim against a wikilink is meaningless — so exclude them.
+const WIKIMEDIA_INTERNAL_PATTERN = /^https?:\/\/[a-z0-9-]+\.(?:wikipedia|wikimedia|wiktionary|wikidata|wikisource|wikiquote|wikibooks|wikinews|wikiversity|wikivoyage)\.org\/wiki\//i;
+
+export function isInternalWikiLink(href) {
+    if (!href) return false;
+    // Special:BookSources is the page ISBN magic links target; match it
+    // directly so localized/mirrored hosts are covered too.
+    if (/Special:BookSources/i.test(href)) return true;
+    return WIKIMEDIA_INTERNAL_PATTERN.test(href);
+}
+
 export function parseArchiveOrgUrl(url) {
     const match = url.match(/^https?:\/\/web\.archive\.org\/web\/(\d+)(?:id_)?\/(https?:\/\/.+)$/);
     if (!match) return null;
@@ -18,7 +33,11 @@ export function parseArchiveOrgUrl(url) {
 
 export function extractHttpUrl(element) {
     if (!element) return null;
-    const links = element.querySelectorAll('a[href^="http"]');
+    // Skip internal wikilinks (ISBN article, Special:BookSources, etc.) — a
+    // book-only citation whose sole links are these would otherwise be
+    // "verified" against a Wikipedia navigation page rather than a real source.
+    const links = Array.from(element.querySelectorAll('a[href^="http"]'))
+        .filter(link => !isInternalWikiLink(link.href));
     if (links.length === 0) return null;
     // Prefer Internet Archive URLs — we fetch via the Wayback raw endpoint
     // (id_) which returns clean original content without toolbar framing.

--- a/main.js
+++ b/main.js
@@ -465,6 +465,21 @@ function isArchiveUrl(href) {
     return ARCHIVE_HOST_PATTERN.test(href);
 }
 
+// Wikimedia-family internal wikilinks (a[href^="http"] resolves to an absolute
+// URL, so blue wikilinks like the "ISBN (identifier)" article, and the
+// Special:BookSources bookseller-list page that ISBN magic links point to, can
+// slip through the http filter). These are never genuine citation sources —
+// verifying a claim against a wikilink is meaningless — so exclude them.
+const WIKIMEDIA_INTERNAL_PATTERN = /^https?:\/\/[a-z0-9-]+\.(?:wikipedia|wikimedia|wiktionary|wikidata|wikisource|wikiquote|wikibooks|wikinews|wikiversity|wikivoyage)\.org\/wiki\//i;
+
+function isInternalWikiLink(href) {
+    if (!href) return false;
+    // Special:BookSources is the page ISBN magic links target; match it
+    // directly so localized/mirrored hosts are covered too.
+    if (/Special:BookSources/i.test(href)) return true;
+    return WIKIMEDIA_INTERNAL_PATTERN.test(href);
+}
+
 function parseArchiveOrgUrl(url) {
     const match = url.match(/^https?:\/\/web\.archive\.org\/web\/(\d+)(?:id_)?\/(https?:\/\/.+)$/);
     if (!match) return null;
@@ -473,7 +488,11 @@ function parseArchiveOrgUrl(url) {
 
 function extractHttpUrl(element) {
     if (!element) return null;
-    const links = element.querySelectorAll('a[href^="http"]');
+    // Skip internal wikilinks (ISBN article, Special:BookSources, etc.) — a
+    // book-only citation whose sole links are these would otherwise be
+    // "verified" against a Wikipedia navigation page rather than a real source.
+    const links = Array.from(element.querySelectorAll('a[href^="http"]'))
+        .filter(link => !isInternalWikiLink(link.href));
     if (links.length === 0) return null;
     // Prefer Internet Archive URLs — we fetch via the Wayback raw endpoint
     // (id_) which returns clean original content without toolbar framing.
@@ -1050,6 +1069,9 @@ async function fetchSourceContent(url, pageNum, { workerBase = 'https://publicai
 }
 
 function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis.workers.dev' } = {}) {
+    // Caller supplies the payload object:
+    //   { article_url, article_title, citation_number, source_url, provider,
+    //     verdict, confidence, reason_type }.
     try {
         fetch(`${workerBase}/log`, {
             method: 'POST',

--- a/tests/urls.test.js
+++ b/tests/urls.test.js
@@ -6,6 +6,7 @@ import {
   extractReferenceUrl,
   isGoogleBooksUrl,
   isArchiveUrl,
+  isInternalWikiLink,
   parseArchiveOrgUrl,
 } from '../core/urls.js';
 
@@ -123,6 +124,54 @@ test('extractHttpUrl falls back to live URL when no archive.org link exists', ()
   </span></body>`);
   const element = jsdom.window.document.getElementById('container');
   assert.equal(extractHttpUrl(element), 'https://example.com/page');
+});
+
+test('isInternalWikiLink flags ISBN article and Special:BookSources wikilinks', () => {
+  assert.equal(isInternalWikiLink('https://en.wikipedia.org/wiki/ISBN_(identifier)'), true);
+  assert.equal(isInternalWikiLink('https://en.wikipedia.org/wiki/Special:BookSources/9788401230134'), true);
+  // Sister projects and localized hosts are internal too.
+  assert.equal(isInternalWikiLink('https://de.wikipedia.org/wiki/Spezial:ISBN-Suche/9788401230134'), true);
+  assert.equal(isInternalWikiLink('https://en.wiktionary.org/wiki/source'), true);
+  // Genuine external sources are not internal wikilinks.
+  assert.equal(isInternalWikiLink('https://example.com/page'), false);
+  assert.equal(isInternalWikiLink('https://books.google.com/books?id=abc'), false);
+  assert.equal(isInternalWikiLink(null), false);
+});
+
+test('extractHttpUrl skips ISBN article and Special:BookSources wikilinks', () => {
+  // A book-only citation: its only http links are the internal "ISBN" article
+  // and the Special:BookSources magic-link target. Neither is a real source.
+  const jsdom = new JSDOM(`<!DOCTYPE html><body><span id="container">
+    <a href="https://en.wikipedia.org/wiki/ISBN_(identifier)">ISBN</a>
+    <a href="https://en.wikipedia.org/wiki/Special:BookSources/9788401230134">9788401230134</a>
+  </span></body>`);
+  const element = jsdom.window.document.getElementById('container');
+  assert.equal(extractHttpUrl(element), null);
+});
+
+test('extractHttpUrl returns the real source alongside ISBN wikilinks', () => {
+  const jsdom = new JSDOM(`<!DOCTYPE html><body><span id="container">
+    <a class="external" href="https://example.com/book-review">review</a>
+    <a href="https://en.wikipedia.org/wiki/ISBN_(identifier)">ISBN</a>
+    <a href="https://en.wikipedia.org/wiki/Special:BookSources/9788401230134">9788401230134</a>
+  </span></body>`);
+  const element = jsdom.window.document.getElementById('container');
+  assert.equal(extractHttpUrl(element), 'https://example.com/book-review');
+});
+
+test('extractReferenceUrl returns null for an ISBN-only book citation', () => {
+  const jsdom = new JSDOM(`<!DOCTYPE html><body>
+    <a id="ref-1" href="#cite_note-1">1</a>
+    <span id="cite_note-1" class="reference">
+      <cite class="citation book">Walsh, Michael (1990). El mundo secreto del Opus Dei.
+        <a href="https://en.wikipedia.org/wiki/ISBN_(identifier)">ISBN</a>
+        <a href="https://en.wikipedia.org/wiki/Special:BookSources/9788401230134">9788401230134</a>
+      </cite>
+    </span>
+  </body>`);
+  const doc = jsdom.window.document;
+  const refElement = doc.getElementById('ref-1');
+  assert.equal(extractReferenceUrl(refElement, doc), null);
 });
 
 test('extractHttpUrl uses other archive services only as last resort', () => {


### PR DESCRIPTION
## Summary

Add detection and filtering of internal Wikimedia wikilinks (ISBN article, Special:BookSources, etc.) from citation source extraction. This prevents book-only citations whose sole HTTP links are Wikipedia navigation pages from being incorrectly "verified" against those internal pages rather than real sources.

## Changes

- **New function `isInternalWikiLink()`** in `core/urls.js` (exported) and synced to `main.js`:
  - Detects Wikimedia-family internal wikilinks via regex pattern matching all major projects (Wikipedia, Wiktionary, Wikidata, etc.)
  - Special-cases `Special:BookSources` (the target of ISBN magic links) to handle localized/mirrored hosts
  - Returns `false` for `null`/`undefined` input

- **Updated `extractHttpUrl()`** in both `core/urls.js` and `main.js`:
  - Filters out internal wikilinks before processing HTTP links
  - Converts `querySelectorAll()` result to array and applies `.filter()` to exclude links matching `isInternalWikiLink()`
  - Prevents book citations with only ISBN article + Special:BookSources links from returning a false "source"

- **Added comprehensive test coverage** in `tests/urls.test.js`:
  - `isInternalWikiLink()` correctly identifies ISBN articles, Special:BookSources, and sister projects
  - `extractHttpUrl()` returns `null` for ISBN-only citations
  - `extractHttpUrl()` correctly returns real sources when mixed with ISBN wikilinks
  - `extractReferenceUrl()` returns `null` for ISBN-only book citations

- **Documentation comment** added to `logVerification()` in `main.js` describing the payload structure

## Implementation Details

The regex pattern `WIKIMEDIA_INTERNAL_PATTERN` matches any Wikimedia-family domain (`[a-z0-9-]+.{wikipedia,wiktionary,...}.org/wiki/`) to catch all localized versions and sister projects. The `Special:BookSources` check is case-insensitive and domain-agnostic, ensuring ISBN magic links are filtered regardless of language or mirror.

https://claude.ai/code/session_01K9fqXPy9U1BXQkqBhSC5FB