### PR TITLE
Handle oversized source text with 413 errors and client-side trimming

### DIFF
--- a/core/providers.js
+++ b/core/providers.js
@@ -46,6 +46,13 @@ export async function callOpenAICompatibleChat({ url, apiKey, model, systemPromp
         } catch {
             errorMessage = errorText;
         }
+        // 413 is a byte cap on the request body (the CORS proxy rejects the
+        // request before the model sees it), not a model context limit — so the
+        // fix is a shorter source or a provider that calls its API directly
+        // rather than through the size-limited proxy.
+        if (response.status === 413) {
+            throw new Error(`${label}: the source is too large to send. Trim the source text, or switch to a provider that calls its API directly (Claude, Gemini, or OpenAI).`);
+        }
         throw new Error(`${label} API request failed (${response.status}): ${errorMessage}`);
     }
 

--- a/main.js
+++ b/main.js
@@ -1101,6 +1101,15 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
 //      `entry.<numeric-id>` from the pre-filled link.
 //   4. Run `npm run build` so the constants are re-inlined into main.js.
 
+// Cap for manually-pasted source text. Unlike fetched sources — which the
+// Cloudflare Worker proxy truncates server-side before they reach us — a manual
+// paste goes straight into the request body, so an oversized paste hits the
+// proxy's request-body limit (HTTP 413 "Request body too large"). We trim here
+// to stay comfortably under that limit (currently ~100 KB): budget = 100 KB
+// minus the ~6.5 KB system prompt, the claim/user-prompt boilerplate, and
+// JSON-escaping + UTF-8 overhead on the source itself. 80 000 chars leaves room.
+const MAX_MANUAL_SOURCE_CHARS = 80000;
+
 // Sentinel substring that marks scaffolded values as not-yet-configured.
 // isDatasetSubmissionConfigured() looks for this exact token; don't reuse it
 // anywhere else in this file.
@@ -2862,18 +2871,31 @@ function buildDatasetSubmissionUrl(
         }
 
         loadManualSourceText() {
-            const text = this.sourceTextInput.getValue().trim();
+            let text = this.sourceTextInput.getValue().trim();
             if (!text) {
                 this.updateStatus('Please enter some source text', true);
                 return;
             }
 
+            // Trim overlong pastes so the request body stays under the proxy's
+            // size limit; anything past the cap can only be checked partially.
+            const wasTrimmed = text.length > MAX_MANUAL_SOURCE_CHARS;
+            if (wasTrimmed) {
+                text = text.slice(0, MAX_MANUAL_SOURCE_CHARS);
+            }
+
             this.activeSource = `Manual source text:\n\n${text}`;
-            document.getElementById('verifier-source-text').innerHTML = `<strong>Manual Source Text:</strong><br><em>${text.substring(0, 200)}${text.length > 200 ? '...' : ''}</em>`;
+            const preview = `${text.substring(0, 200)}${text.length > 200 ? '...' : ''}`;
+            const truncationHtml = wasTrimmed
+                ? '<div class="verifier-truncation-warning">⚠ The source is long and can only be checked partially.</div>'
+                : '';
+            document.getElementById('verifier-source-text').innerHTML = `<strong>Manual Source Text:</strong><br><em>${preview}</em>${truncationHtml}`;
             this.sourceInputForOverride = false;
             this.hideSourceTextInput();
             this.updateButtonVisibility();
-            this.updateStatus('Source text loaded. Ready to verify.');
+            this.updateStatus(wasTrimmed
+                ? `Source text loaded (trimmed to ${MAX_MANUAL_SOURCE_CHARS.toLocaleString()} characters). Ready to verify.`
+                : 'Source text loaded. Ready to verify.');
         }
 
         cancelManualSourceText() {

--- a/main.js
+++ b/main.js
@@ -761,6 +761,13 @@ async function callOpenAICompatibleChat({ url, apiKey, model, systemPrompt, user
         } catch {
             errorMessage = errorText;
         }
+        // 413 is a byte cap on the request body (the CORS proxy rejects the
+        // request before the model sees it), not a model context limit — so the
+        // fix is a shorter source or a provider that calls its API directly
+        // rather than through the size-limited proxy.
+        if (response.status === 413) {
+            throw new Error(`${label}: the source is too large to send. Trim the source text, or switch to a provider that calls its API directly (Claude, Gemini, or OpenAI).`);
+        }
         throw new Error(`${label} API request failed (${response.status}): ${errorMessage}`);
     }
 
@@ -1100,15 +1107,6 @@ function logVerification(payload, { workerBase = 'https://publicai-proxy.alaexis
 //      replace each `entry.PLACEHOLDER_*` value with the matching
 //      `entry.<numeric-id>` from the pre-filled link.
 //   4. Run `npm run build` so the constants are re-inlined into main.js.
-
-// Cap for manually-pasted source text. Unlike fetched sources — which the
-// Cloudflare Worker proxy truncates server-side before they reach us — a manual
-// paste goes straight into the request body, so an oversized paste hits the
-// proxy's request-body limit (HTTP 413 "Request body too large"). We trim here
-// to stay comfortably under that limit (currently ~100 KB): budget = 100 KB
-// minus the ~6.5 KB system prompt, the claim/user-prompt boilerplate, and
-// JSON-escaping + UTF-8 overhead on the source itself. 80 000 chars leaves room.
-const MAX_MANUAL_SOURCE_CHARS = 80000;
 
 // Sentinel substring that marks scaffolded values as not-yet-configured.
 // isDatasetSubmissionConfigured() looks for this exact token; don't reuse it

--- a/tests/providers.test.js
+++ b/tests/providers.test.js
@@ -172,6 +172,30 @@ test('callHuggingFaceAPI surfaces upstream error messages', async () => {
   }
 });
 
+test('callOpenAICompatibleChat maps 413 to a legible, actionable message', async () => {
+  // The CORS proxy caps request-body size; an oversized source comes back as
+  // HTTP 413. Surface a message that tells the user how to recover rather than
+  // the raw "Request body too large".
+  const mock = withMockFetch(async () => ({
+    ok: false,
+    status: 413,
+    text: async () => JSON.stringify({ error: { message: 'Request body too large' } }),
+  }));
+  try {
+    await assert.rejects(
+      () => callHuggingFaceAPI({ model: 'm', systemPrompt: 's', userContent: 'u' }),
+      (err) => {
+        assert.match(err.message, /too large to send/);
+        assert.match(err.message, /Trim the source text/);
+        assert.doesNotMatch(err.message, /request failed \(413\)/);
+        return true;
+      }
+    );
+  } finally {
+    mock.restore();
+  }
+});
+
 test('callProviderAPI dispatches huggingface to /hf', async () => {
   const mock = withMockFetch(async () => ({
     ok: true,


### PR DESCRIPTION
## Summary

This PR adds graceful handling for source text that exceeds the CORS proxy's request body size limit. When a 413 error is received, users now get a clear, actionable error message instead of a generic HTTP status code. Additionally, the manual source text input now trims oversized pastes client-side to prevent 413 errors in the first place.

## Key Changes

- **API error handling:** Added specific handling for HTTP 413 responses in `callOpenAICompatibleChat()` (both `core/providers.js` and `main.js`). When a 413 is received, throw a user-friendly error message that explains the issue and suggests solutions (trim the source or switch to a provider that calls its API directly).

- **Client-side trimming:** Modified `loadManualSourceText()` in `main.js` to automatically trim source text to `MAX_MANUAL_SOURCE_CHARS` before submission, preventing 413 errors from oversized pastes.

- **User feedback:** When trimming occurs, display a warning message in the source text preview and update the status message to indicate the source was trimmed and can only be checked partially.

- **Test coverage:** Added test case `callOpenAICompatibleChat maps 413 to a legible, actionable message` to verify the error message is user-friendly and doesn't expose the raw HTTP status.

## Implementation Details

- The 413 check happens before the generic error throw, so users see the specific "too large to send" message rather than "API request failed (413)".
- Trimming is transparent to the user via a warning div with class `verifier-truncation-warning` and updated status text.
- The `wasTrimmed` flag tracks whether trimming occurred, allowing conditional UI updates and status messages.
- Both the userscript (`main.js`) and the core provider module (`core/providers.js`) receive the 413 handling to keep them in sync.

https://claude.ai/code/session_01CAm3NK8TgwdMo8ecaTbSds