### PR TITLE
Collapse tool output in talk-page feedback sections

### DIFF
--- a/.github/scripts/scrape_and_create.py
+++ b/.github/scripts/scrape_and_create.py
@@ -125,6 +125,13 @@ The tool helps Wikipedia editors verify whether cited sources actually support t
 
 Below is content from one section of the Wikipedia Talk page for this userscript. It may contain feature requests, bug reports, questions, or general discussion from Wikipedia editors who use the tool.
 
+Sections opened from the tool's Comment button have a fixed shape: the tool's own
+output sits inside a {{hidden begin|title=Check details}} ... {{hidden end}} box,
+and the editor's own words follow an "Editor's explanation:" label (sometimes
+preceded by "Editor says it should be:"). Treat the collapsed box as context
+only — the actionable request is in what the editor wrote. A section whose
+explanation is still empty carries no request at all.
+
 Your job:
 1. Extract all ACTIONABLE items (feature requests and bug reports only)
 2. Ignore: thank-yous, general questions with no clear ask, already-resolved discussions, noise, meta-discussion about Wikipedia

--- a/.github/scripts/scrape_and_create.py
+++ b/.github/scripts/scrape_and_create.py
@@ -25,6 +25,10 @@ WIKI_TIMESTAMP_RE = re.compile(
     r'\b(\d{1,2}:\d{2}),\s+(\d{1,2}\s+\w+\s+\d{4})\s+\(UTC\)'
 )
 
+# The marker buildTalkSectionBody() leaves at the end of every section the
+# tool's Comment button opens.
+CHECK_MARKER_RE = re.compile(r'<!--\s*source-verifier check:\s*\w+\s*-->')
+
 def parse_wiki_timestamp(time_part: str, date_part: str) -> datetime | None:
     try:
         combined = f"{time_part}, {date_part}"
@@ -100,7 +104,17 @@ def section_is_new(section: dict, since: datetime) -> bool:
         ts = parse_wiki_timestamp(time_part, date_part)
         if ts and ts > since:
             return True
-    return False
+
+    # A section carrying the tool's marker but no timestamp at all is one
+    # nobody signed. The script no longer preloads a signature (four tildes in
+    # preloaded text get expanded by whoever saves the page next, not by the
+    # editor), so dating a section is now entirely up to whether the editor's
+    # own editor signed for them. Rather than drop these silently, let them
+    # through; an unsigned section usually means the editor published without
+    # writing anything, and the extraction prompt returns nothing for those.
+    if matches:
+        return False
+    return bool(CHECK_MARKER_RE.search(section["content"]))
 
 def fetch_new_sections(since_str: str) -> list[dict]:
     since = datetime.fromisoformat(since_str.replace("Z", "+00:00"))

--- a/core/feedback.js
+++ b/core/feedback.js
@@ -150,9 +150,20 @@ export const EDITOR_EXPLANATION_LABEL = "Editor's explanation";
 // having to parse headings. HTML comments are also how the "write here"
 // guidance is delivered — visible in the edit box, invisible once published.
 //
-// The signature stays last (bar that invisible comment) because DiscussionTools
-// attributes a comment by the signature that ends it; content after it lands
-// the reply button in the wrong place.
+// Nothing here emits a signature, and nothing here may. Four tildes are not
+// text: they are an instruction to MediaWiki's pre-save transform, which runs
+// over the *whole page* on every save, so a preloaded signature belongs to
+// whoever saves next rather than to the editor who opened the form. If the
+// tildes survive that first save unexpanded — the new topic tool handles
+// signing itself — they sit in the page as a landmine until some unrelated
+// account saves it and gets its own name and timestamp stamped in. That is
+// exactly what happened to check 4d9d0118, which a passing bot signed.
+// Signing is the editor's, and their editor's, business; we only ask for it.
+//
+// The same trap applies to the guidance below, which is why it spells out
+// "sign" in words. Literal tildes inside an HTML comment are still expanded by
+// the pre-save transform — invisible in the rendered page, and still a
+// landmine in the wikitext.
 export function buildTalkSectionBody(fields = {}) {
     const {
         articleUrl, articleTitle, citationNumber, claimText, sourceUrl,
@@ -200,8 +211,7 @@ export function buildTalkSectionBody(fields = {}) {
     // after the invisible comment — renders as "Editor's explanation: <prose>"
     // rather than leaving a bold heading dangling above the text.
     blocks.push(
-        `'''${EDITOR_EXPLANATION_LABEL}:''' <!-- Write your explanation here, then publish. -->`,
-        '~~~~',
+        `'''${EDITOR_EXPLANATION_LABEL}:''' <!-- Write your explanation here, then sign and publish. -->`,
         `<!-- source-verifier check: ${checkId ?? 'unknown'} -->`,
     );
 

--- a/core/feedback.js
+++ b/core/feedback.js
@@ -121,16 +121,38 @@ export function buildTalkSectionTitle({ articleTitle, citationNumber, checkId } 
     return `Feedback: ${title}${num ? ` [${num}]` : ''} (check ${checkId ?? 'unknown'})`;
 }
 
-// The context half of a talk-page section: everything the tool knows, with a
-// gap for the editor to write in. It is preloaded into Wikipedia's own new
-// section form rather than posted by the script, so this text is a starting
-// point the editor sees and can change, not a finished comment.
+// Title of the collapsed box holding the tool's own output, and the label
+// introducing the editor's prose. Exported because they are the seam between
+// this layout and anything reading it back — the talk-page scraper tells
+// machine context from human text by these two strings.
+export const CHECK_DETAILS_TITLE = 'Check details';
+export const EDITOR_EXPLANATION_LABEL = "Editor's explanation";
+
+// A talk-page section, split by who wrote what: everything the tool produced
+// is collapsed behind {{hidden begin}}, and everything the editor supplies —
+// the corrected verdict and their explanation — stays visible. A reader
+// scanning the talk page sees the human argument; the machine context is one
+// click away when they want to check it.
+//
+// The begin/end template pair is deliberate. {{collapse|...}} would make the
+// bullets a template *parameter*, where a stray | or = in a source URL
+// silently truncates the box; as body text between two templates they are
+// inert. {{cot}}/{{cob}} is also wrong here — it renders "the following
+// discussion is closed", and this was never a discussion.
+//
+// It is preloaded into Wikipedia's own new section form rather than posted by
+// the script, so this text is a starting point the editor sees and can
+// change, not a finished comment.
 //
 // The check id appears twice on purpose: in the heading, where a human reading
 // the talk page can see which check is under discussion, and in a trailing
 // HTML comment, which is what the talk-page scraper can match on without
 // having to parse headings. HTML comments are also how the "write here"
 // guidance is delivered — visible in the edit box, invisible once published.
+//
+// The signature stays last (bar that invisible comment) because DiscussionTools
+// attributes a comment by the signature that ends it; content after it lands
+// the reply button in the wrong place.
 export function buildTalkSectionBody(fields = {}) {
     const {
         articleUrl, articleTitle, citationNumber, claimText, sourceUrl,
@@ -139,36 +161,51 @@ export function buildTalkSectionBody(fields = {}) {
 
     const clean = v => String(v ?? '').replace(/\s+/g, ' ').trim();
     const label = clean(articleTitle) || clean(articleUrl);
-    const lines = [];
+    const toolLines = [];
 
     if (articleUrl && label) {
         const cite = clean(citationNumber);
-        lines.push(`* '''Article:''' [${encodeURI(String(articleUrl))} ${label}]${cite ? `, citation [${cite}]` : ''}`);
+        toolLines.push(`* '''Article:''' [${encodeURI(String(articleUrl))} ${label}]${cite ? `, citation [${cite}]` : ''}`);
     }
     if (sourceUrl) {
         // encodeURI neutralises {{ }} (the one wikitext construct a citation
         // URL could plausibly smuggle in) while leaving the link clickable.
-        lines.push(`* '''Source:''' ${encodeURI(String(sourceUrl))}`);
+        toolLines.push(`* '''Source:''' ${encodeURI(String(sourceUrl))}`);
     }
     if (verdict) {
         const by = [clean(providerName), clean(model)].filter(Boolean).join(', ');
-        lines.push(`* '''Tool's verdict:''' ${clean(verdict)}${by ? ` (${by})` : ''}`);
-    }
-    if (correctedVerdict) {
-        lines.push(`* '''Editor says it should be:''' ${clean(correctedVerdict)}`);
+        toolLines.push(`* '''Tool's verdict:''' ${clean(verdict)}${by ? ` (${by})` : ''}`);
     }
     const claim = nowikiWrap(claimText);
-    if (claim) lines.push(`* '''Claim checked:''' ${claim}`);
+    if (claim) toolLines.push(`* '''Claim checked:''' ${claim}`);
     const reasoning = nowikiWrap(comments);
-    if (reasoning) lines.push(`* '''Tool's reasoning:''' ${reasoning}`);
+    if (reasoning) toolLines.push(`* '''Tool's reasoning:''' ${reasoning}`);
 
-    return [
-        lines.join('\n'),
-        '<!-- Write your comment below, then publish. -->',
-        '',
+    const blocks = [];
+
+    if (toolLines.length) {
+        blocks.push([
+            `{{hidden begin|title=${CHECK_DETAILS_TITLE}}}`,
+            ...toolLines,
+            '{{hidden end}}',
+        ].join('\n'));
+    }
+    // The editor's, not the tool's, so it stays outside the box — on a
+    // thumbs-down this line is the disagreement itself, and burying it would
+    // leave the visible section saying nothing.
+    if (correctedVerdict) {
+        blocks.push(`'''Editor says it should be:''' ${clean(correctedVerdict)}`);
+    }
+    // Label and guidance share a line so that writing at the obvious spot —
+    // after the invisible comment — renders as "Editor's explanation: <prose>"
+    // rather than leaving a bold heading dangling above the text.
+    blocks.push(
+        `'''${EDITOR_EXPLANATION_LABEL}:''' <!-- Write your explanation here, then publish. -->`,
         '~~~~',
         `<!-- source-verifier check: ${checkId ?? 'unknown'} -->`,
-    ].filter(line => line !== undefined).join('\n\n');
+    );
+
+    return blocks.join('\n\n');
 }
 
 // The URL that opens Wikipedia's own "add new section" form with the context

--- a/docs/worker-logging-reference.md
+++ b/docs/worker-logging-reference.md
@@ -229,3 +229,28 @@ The trade for all of this: because the editor publishes it themselves, the
 script never learns whether they went through with it. So `wiki_section` is not
 written at click time — the daily scrape resolves the link instead, matching
 the `<!-- source-verifier check: … -->` marker in each section.
+
+### The section is split by who wrote what
+
+Everything the tool produced — article, source, verdict, claim, rationale —
+goes inside a `{{hidden begin|title=Check details}}` … `{{hidden end}}` box.
+Everything the editor supplies stays visible above the signature: the
+corrected verdict, and their prose under an **`Editor's explanation:`** label.
+A reader scanning the talk page sees the human argument, not five bullets of
+machine output; the context is one click away when they want to check it.
+
+Two things follow from that split and are load-bearing:
+
+- **The begin/end template pair, not `{{collapse|…}}`.** The latter makes the
+  bullets a template *parameter*, where a stray `|` or `=` in a source URL
+  silently truncates the box. As body text between two templates they are
+  inert. `{{cot}}`/`{{cob}}` is wrong for a different reason — it renders "the
+  following discussion is closed", and this was never a discussion.
+- **The signature stays last**, bar the invisible check-id comment.
+  DiscussionTools attributes a comment by the signature that ends it, so
+  content after the signature puts the reply button in the wrong place.
+
+`CHECK_DETAILS_TITLE` and `EDITOR_EXPLANATION_LABEL` are exported from
+`core/feedback.js` because they are the seam between this layout and anything
+reading it back: the scrape tells machine context from human text by those two
+strings.

--- a/docs/worker-logging-reference.md
+++ b/docs/worker-logging-reference.md
@@ -246,11 +246,47 @@ Two things follow from that split and are load-bearing:
   silently truncates the box. As body text between two templates they are
   inert. `{{cot}}`/`{{cob}}` is wrong for a different reason — it renders "the
   following discussion is closed", and this was never a discussion.
-- **The signature stays last**, bar the invisible check-id comment.
-  DiscussionTools attributes a comment by the signature that ends it, so
-  content after the signature puts the reply button in the wrong place.
+- **Nothing preloads a signature.** See below.
 
 `CHECK_DETAILS_TITLE` and `EDITOR_EXPLANATION_LABEL` are exported from
 `core/feedback.js` because they are the seam between this layout and anything
 reading it back: the scrape tells machine context from human text by those two
 strings.
+
+### Never preload four tildes
+
+The preloaded body used to end with `~~~~`, on the assumption that the editor's
+save would expand it into their signature. It does not reliably, and the
+failure is silent and delayed.
+
+Four tildes are not text. They are an instruction to MediaWiki's **pre-save
+transform**, which runs over the *entire page wikitext on every save* — not
+just the part the saver typed. So a preloaded signature belongs to whoever
+saves the page next, whenever that happens. Two things follow:
+
+1. If the first save does not expand them — `action=edit&section=new` on
+   en.wiki is handled by DiscussionTools' new topic tool, which manages
+   signature placement itself rather than passing preloaded tildes through —
+   the tildes land in the saved page intact.
+2. Literal tildes sitting in saved wikitext are a landmine. The next account to
+   save that page, for any unrelated reason, gets *its* name and *its* edit
+   timestamp stamped in.
+
+That is the observed failure on check `4d9d0118`: the section was signed
+`DeadbeefBot II … 21:01, 4 August 2026 (UTC)` — a bot that had merely edited
+the page, at the time it did so.
+
+The guidance comment therefore spells out "sign" in words. Tildes inside an
+HTML comment are expanded too — the pre-save transform does not skip comments —
+so the landmine would simply be invisible instead of absent.
+`tests/feedback.test.js` fails on `~~~` appearing anywhere in the body or in
+the preload parameter.
+
+**Consequence for the scrape.** `section_is_new()` dated sections by finding a
+`(UTC)` timestamp, which the preloaded signature used to guarantee. Dating now
+depends on the editor's editor signing for them (DiscussionTools does;
+the classic form prompts). So a section carrying the check-id marker with *no*
+timestamp at all is now let through rather than dropped: it is almost always
+one published with nothing written in it, for which the extraction prompt
+returns no items. If unsigned sections turn out to be common, the durable fix
+is a ledger of processed check ids rather than a timestamp watermark.

--- a/main.js
+++ b/main.js
@@ -1265,16 +1265,38 @@ function buildTalkSectionTitle({ articleTitle, citationNumber, checkId } = {}) {
     return `Feedback: ${title}${num ? ` [${num}]` : ''} (check ${checkId ?? 'unknown'})`;
 }
 
-// The context half of a talk-page section: everything the tool knows, with a
-// gap for the editor to write in. It is preloaded into Wikipedia's own new
-// section form rather than posted by the script, so this text is a starting
-// point the editor sees and can change, not a finished comment.
+// Title of the collapsed box holding the tool's own output, and the label
+// introducing the editor's prose. Exported because they are the seam between
+// this layout and anything reading it back — the talk-page scraper tells
+// machine context from human text by these two strings.
+const CHECK_DETAILS_TITLE = 'Check details';
+const EDITOR_EXPLANATION_LABEL = "Editor's explanation";
+
+// A talk-page section, split by who wrote what: everything the tool produced
+// is collapsed behind {{hidden begin}}, and everything the editor supplies —
+// the corrected verdict and their explanation — stays visible. A reader
+// scanning the talk page sees the human argument; the machine context is one
+// click away when they want to check it.
+//
+// The begin/end template pair is deliberate. {{collapse|...}} would make the
+// bullets a template *parameter*, where a stray | or = in a source URL
+// silently truncates the box; as body text between two templates they are
+// inert. {{cot}}/{{cob}} is also wrong here — it renders "the following
+// discussion is closed", and this was never a discussion.
+//
+// It is preloaded into Wikipedia's own new section form rather than posted by
+// the script, so this text is a starting point the editor sees and can
+// change, not a finished comment.
 //
 // The check id appears twice on purpose: in the heading, where a human reading
 // the talk page can see which check is under discussion, and in a trailing
 // HTML comment, which is what the talk-page scraper can match on without
 // having to parse headings. HTML comments are also how the "write here"
 // guidance is delivered — visible in the edit box, invisible once published.
+//
+// The signature stays last (bar that invisible comment) because DiscussionTools
+// attributes a comment by the signature that ends it; content after it lands
+// the reply button in the wrong place.
 function buildTalkSectionBody(fields = {}) {
     const {
         articleUrl, articleTitle, citationNumber, claimText, sourceUrl,
@@ -1283,36 +1305,51 @@ function buildTalkSectionBody(fields = {}) {
 
     const clean = v => String(v ?? '').replace(/\s+/g, ' ').trim();
     const label = clean(articleTitle) || clean(articleUrl);
-    const lines = [];
+    const toolLines = [];
 
     if (articleUrl && label) {
         const cite = clean(citationNumber);
-        lines.push(`* '''Article:''' [${encodeURI(String(articleUrl))} ${label}]${cite ? `, citation [${cite}]` : ''}`);
+        toolLines.push(`* '''Article:''' [${encodeURI(String(articleUrl))} ${label}]${cite ? `, citation [${cite}]` : ''}`);
     }
     if (sourceUrl) {
         // encodeURI neutralises {{ }} (the one wikitext construct a citation
         // URL could plausibly smuggle in) while leaving the link clickable.
-        lines.push(`* '''Source:''' ${encodeURI(String(sourceUrl))}`);
+        toolLines.push(`* '''Source:''' ${encodeURI(String(sourceUrl))}`);
     }
     if (verdict) {
         const by = [clean(providerName), clean(model)].filter(Boolean).join(', ');
-        lines.push(`* '''Tool's verdict:''' ${clean(verdict)}${by ? ` (${by})` : ''}`);
-    }
-    if (correctedVerdict) {
-        lines.push(`* '''Editor says it should be:''' ${clean(correctedVerdict)}`);
+        toolLines.push(`* '''Tool's verdict:''' ${clean(verdict)}${by ? ` (${by})` : ''}`);
     }
     const claim = nowikiWrap(claimText);
-    if (claim) lines.push(`* '''Claim checked:''' ${claim}`);
+    if (claim) toolLines.push(`* '''Claim checked:''' ${claim}`);
     const reasoning = nowikiWrap(comments);
-    if (reasoning) lines.push(`* '''Tool's reasoning:''' ${reasoning}`);
+    if (reasoning) toolLines.push(`* '''Tool's reasoning:''' ${reasoning}`);
 
-    return [
-        lines.join('\n'),
-        '<!-- Write your comment below, then publish. -->',
-        '',
+    const blocks = [];
+
+    if (toolLines.length) {
+        blocks.push([
+            `{{hidden begin|title=${CHECK_DETAILS_TITLE}}}`,
+            ...toolLines,
+            '{{hidden end}}',
+        ].join('\n'));
+    }
+    // The editor's, not the tool's, so it stays outside the box — on a
+    // thumbs-down this line is the disagreement itself, and burying it would
+    // leave the visible section saying nothing.
+    if (correctedVerdict) {
+        blocks.push(`'''Editor says it should be:''' ${clean(correctedVerdict)}`);
+    }
+    // Label and guidance share a line so that writing at the obvious spot —
+    // after the invisible comment — renders as "Editor's explanation: <prose>"
+    // rather than leaving a bold heading dangling above the text.
+    blocks.push(
+        `'''${EDITOR_EXPLANATION_LABEL}:''' <!-- Write your explanation here, then publish. -->`,
         '~~~~',
         `<!-- source-verifier check: ${checkId ?? 'unknown'} -->`,
-    ].filter(line => line !== undefined).join('\n\n');
+    );
+
+    return blocks.join('\n\n');
 }
 
 // The URL that opens Wikipedia's own "add new section" form with the context

--- a/main.js
+++ b/main.js
@@ -1294,9 +1294,20 @@ const EDITOR_EXPLANATION_LABEL = "Editor's explanation";
 // having to parse headings. HTML comments are also how the "write here"
 // guidance is delivered — visible in the edit box, invisible once published.
 //
-// The signature stays last (bar that invisible comment) because DiscussionTools
-// attributes a comment by the signature that ends it; content after it lands
-// the reply button in the wrong place.
+// Nothing here emits a signature, and nothing here may. Four tildes are not
+// text: they are an instruction to MediaWiki's pre-save transform, which runs
+// over the *whole page* on every save, so a preloaded signature belongs to
+// whoever saves next rather than to the editor who opened the form. If the
+// tildes survive that first save unexpanded — the new topic tool handles
+// signing itself — they sit in the page as a landmine until some unrelated
+// account saves it and gets its own name and timestamp stamped in. That is
+// exactly what happened to check 4d9d0118, which a passing bot signed.
+// Signing is the editor's, and their editor's, business; we only ask for it.
+//
+// The same trap applies to the guidance below, which is why it spells out
+// "sign" in words. Literal tildes inside an HTML comment are still expanded by
+// the pre-save transform — invisible in the rendered page, and still a
+// landmine in the wikitext.
 function buildTalkSectionBody(fields = {}) {
     const {
         articleUrl, articleTitle, citationNumber, claimText, sourceUrl,
@@ -1344,8 +1355,7 @@ function buildTalkSectionBody(fields = {}) {
     // after the invisible comment — renders as "Editor's explanation: <prose>"
     // rather than leaving a bold heading dangling above the text.
     blocks.push(
-        `'''${EDITOR_EXPLANATION_LABEL}:''' <!-- Write your explanation here, then publish. -->`,
-        '~~~~',
+        `'''${EDITOR_EXPLANATION_LABEL}:''' <!-- Write your explanation here, then sign and publish. -->`,
         `<!-- source-verifier check: ${checkId ?? 'unknown'} -->`,
     );
 

--- a/tests/feedback.test.js
+++ b/tests/feedback.test.js
@@ -12,6 +12,8 @@ import {
   buildCommentUrl,
   FEEDBACK_TALK_PAGE,
   FEEDBACK_PRELOAD_PAGE,
+  CHECK_DETAILS_TITLE,
+  EDITOR_EXPLANATION_LABEL,
 } from '../core/feedback.js';
 import { postFeedback } from '../core/worker.js';
 
@@ -270,10 +272,41 @@ test('buildTalkSectionBody records article, source, verdict, claim and reasoning
 
 test('buildTalkSectionBody leaves room for the editor to write, above the signature', () => {
   const body = buildTalkSectionBody(CONTEXT);
-  const guide = body.indexOf('<!-- Write your comment below, then publish. -->');
+  const guide = body.indexOf('<!-- Write your explanation here, then publish. -->');
   const signature = body.indexOf('~~~~');
   assert.ok(guide !== -1, 'the edit box should say where to write');
   assert.ok(guide < signature, 'the writing space must come before the signature');
+});
+
+test('buildTalkSectionBody collapses the tool output behind a hidden box', () => {
+  const body = buildTalkSectionBody(CONTEXT);
+  const open = body.indexOf(`{{hidden begin|title=${CHECK_DETAILS_TITLE}}}`);
+  const close = body.indexOf('{{hidden end}}');
+  assert.ok(open !== -1, 'the tool output needs an opening collapse tag');
+  assert.ok(close > open, 'the collapse box must be closed after it is opened');
+  assert.equal(body.split('{{hidden end}}').length - 1, 1, 'exactly one closing tag');
+
+  for (const line of ["* '''Article:'''", "* '''Source:'''", "* '''Tool's verdict:'''",
+                      "* '''Claim checked:'''", "* '''Tool's reasoning:'''"]) {
+    const at = body.indexOf(line);
+    assert.ok(at > open && at < close, `${line} belongs inside the collapse box`);
+  }
+});
+
+test('buildTalkSectionBody keeps the editor explanation label outside the collapse box', () => {
+  const body = buildTalkSectionBody(CONTEXT);
+  assert.match(body, new RegExp(`'''${EDITOR_EXPLANATION_LABEL}:'''`));
+  assert.ok(
+    body.indexOf(`'''${EDITOR_EXPLANATION_LABEL}:'''`) > body.indexOf('{{hidden end}}'),
+    'the editor writes below the collapsed machine context, not inside it',
+  );
+});
+
+test('buildTalkSectionBody omits the collapse box when the tool reported nothing', () => {
+  const body = buildTalkSectionBody({ checkId: 'a7f3k2q9' });
+  assert.equal(body.includes('{{hidden begin'), false);
+  assert.equal(body.includes('{{hidden end}}'), false);
+  assert.match(body, new RegExp(`'''${EDITOR_EXPLANATION_LABEL}:'''`));
 });
 
 test('buildTalkSectionBody ends with the machine-readable check id', () => {
@@ -282,7 +315,15 @@ test('buildTalkSectionBody ends with the machine-readable check id', () => {
 
 test('buildTalkSectionBody includes a corrected verdict when one was chosen', () => {
   const body = buildTalkSectionBody({ ...CONTEXT, correctedVerdict: 'SUPPORTED' });
-  assert.match(body, /\* '''Editor says it should be:''' SUPPORTED/);
+  assert.match(body, /'''Editor says it should be:''' SUPPORTED/);
+});
+
+test("buildTalkSectionBody keeps the corrected verdict visible, not collapsed", () => {
+  const body = buildTalkSectionBody({ ...CONTEXT, correctedVerdict: 'SUPPORTED' });
+  assert.ok(
+    body.indexOf("'''Editor says it should be:'''") > body.indexOf('{{hidden end}}'),
+    'the editor\'s correction is the point of the section — it must not be hidden',
+  );
 });
 
 test('buildTalkSectionBody omits the correction line when none was chosen', () => {

--- a/tests/feedback.test.js
+++ b/tests/feedback.test.js
@@ -270,12 +270,25 @@ test('buildTalkSectionBody records article, source, verdict, claim and reasoning
   assert.match(body, /\* '''Tool's reasoning:''' <nowiki>The source never mentions Honolulu\.<\/nowiki>/);
 });
 
-test('buildTalkSectionBody leaves room for the editor to write, above the signature', () => {
+test('buildTalkSectionBody tells the editor where to write and to sign', () => {
   const body = buildTalkSectionBody(CONTEXT);
-  const guide = body.indexOf('<!-- Write your explanation here, then publish. -->');
-  const signature = body.indexOf('~~~~');
-  assert.ok(guide !== -1, 'the edit box should say where to write');
-  assert.ok(guide < signature, 'the writing space must come before the signature');
+  assert.match(body, /<!-- Write your explanation here, then sign and publish\. -->/);
+});
+
+// Four tildes are an instruction to MediaWiki's pre-save transform, which runs
+// over the whole page on every save — a preloaded signature belongs to whoever
+// saves next, not to the editor who opened the form, and if it survives that
+// save unexpanded it gets some later account's name stamped in. The HTML
+// comments are covered too: the transform does not skip them.
+test('buildTalkSectionBody never emits a signature, anywhere', () => {
+  for (const fields of [CONTEXT, { ...CONTEXT, correctedVerdict: 'SUPPORTED' }, { checkId: 'x' }, {}]) {
+    assert.equal(buildTalkSectionBody(fields).includes('~~~'), false);
+  }
+});
+
+test('buildCommentUrl never carries a signature into the preload', () => {
+  const preloaded = new URL(buildCommentUrl(CONTEXT)).searchParams.get('preloadparams[]');
+  assert.equal(preloaded.includes('~~~'), false);
 });
 
 test('buildTalkSectionBody collapses the tool output behind a hidden box', () => {


### PR DESCRIPTION
## Summary

Restructures talk-page feedback sections to improve readability by collapsing the tool's machine-generated output behind a `{{hidden begin}}` box while keeping the editor's human-written explanation visible. This follows Wikipedia conventions for separating context from actionable content.

## Key Changes

- **Exported layout constants** (`CHECK_DETAILS_TITLE`, `EDITOR_EXPLANATION_LABEL`) from `core/feedback.js` to serve as the seam between the layout and anything reading it back (e.g., the talk-page scraper)

- **Restructured section body** to split content by authorship:
  - Tool output (article, source, verdict, claim, reasoning) wrapped in `{{hidden begin|title=Check details}}...{{hidden end}}`
  - Editor's corrected verdict and explanation remain visible outside the box
  - Guidance text updated to say "sign" in words instead of preloading four tildes

- **Removed preloaded signature** (`~~~~`): Four tildes are a MediaWiki pre-save transform instruction that runs over the entire page on every save, causing them to be expanded by whoever saves next rather than the editor who opened the form. If unexpanded by DiscussionTools, they become a landmine for later edits. Added extensive documentation of this failure mode (check `4d9d0118` was signed by a passing bot).

- **Updated scraper logic** (`.github/scripts/scrape_and_create.py`):
  - Added `CHECK_MARKER_RE` to identify tool-generated sections
  - Modified `section_is_new()` to accept unsigned sections carrying the check marker (they typically mean the editor published without writing anything)
  - Updated prompt to explain the new section structure to the scraper

- **Expanded test coverage**:
  - Added tests verifying no tildes appear anywhere in body or preload
  - Added tests for collapse box presence and correct nesting
  - Added tests for editor explanation label placement outside the box
  - Added test for omitting collapse box when tool reported nothing
  - Added test for keeping corrected verdict visible

## Implementation Details

- Used `{{hidden begin|title=...}}...{{hidden end}}` instead of `{{collapse|...}}` because the latter makes bullets a template parameter where stray `|` or `=` in URLs silently truncates the box; as body text between templates they are inert
- Guidance comment spells out "sign" in words because literal tildes inside HTML comments are still expanded by the pre-save transform
- Refactored `lines` array to `toolLines` for clarity about what content belongs in the collapsed section
- Sections with no tool output (empty `toolLines`) omit the collapse box entirely but still include the editor explanation label

https://claude.ai/code/session_01NpkNLeMmuaDCQvfsQ42RS3