### PR TITLE
Redesign feedback controls: icon+label buttons, dual status lines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ docs/                            # Reference docs + design plans (see docs/READM
 | `getReportUnits()` | Merge per-source results + collective group verdicts into one entry per claim (drives summary pills + exports) |
 | `generateWikitextReport()` | Generate wiki markup for failed citations |
 | `logVerification()` | Mint a `check_id`, log the verdict + claim + rationale to the worker, return the id |
-| `buildFeedbackControls()` | 👍/👎/comment row under a result; ratings go to Neon, comments to the talk page (see `docs/worker-logging-reference.md`) |
+| `buildFeedbackControls()` | Yes/No/Comment row under a result; ratings go to Neon, comments to the talk page (see `docs/worker-logging-reference.md`) |
 
 ## Benchmark Suite
 

--- a/main.js
+++ b/main.js
@@ -1463,6 +1463,8 @@ function buildDatasetSubmissionUrl(
 
         // Feedback controls
         'Was this right?': 'Est-ce correct ?',
+        'Yes': 'Oui',
+        'No': 'Non',
         'This verdict looks right': 'Ce verdict semble correct',
         'This verdict looks wrong': 'Ce verdict semble erroné',
         'What should it have been?': 'Quel aurait dû être le verdict ?',
@@ -2645,7 +2647,14 @@ function buildDatasetSubmissionUrl(
                 #verifier-action-container {
                     margin-top: 10px;
                 }
-                #verifier-action-container .oo-ui-buttonElement {
+                /* Direct children only. "Edit Section" is the panel's primary
+                   call to action and is appended straight to this container, so
+                   it spans the full width. The feedback controls live in a
+                   .verifier-feedback wrapper inside the same container, and an
+                   unscoped rule stretched every one of their buttons too —
+                   which is what made Yes/No/Comment and the correction chips
+                   shrink to unrelated widths instead of sitting as a row. */
+                #verifier-action-container > .oo-ui-buttonElement {
                     width: 100%;
                 }
                 #verifier-title-link {
@@ -2655,7 +2664,7 @@ function buildDatasetSubmissionUrl(
                 #verifier-title-link:hover {
                     text-decoration: underline;
                 }
-                #verifier-action-container .oo-ui-buttonElement-button {
+                #verifier-action-container > .oo-ui-buttonElement > .oo-ui-buttonElement-button {
                     width: 100%;
                     justify-content: center;
                 }
@@ -2955,43 +2964,18 @@ function buildDatasetSubmissionUrl(
                 .verifier-feedback .oo-ui-buttonElement {
                     margin: 0;
                 }
-                /* One pill shape for every control in the row. The thumbs used
-                   to be bare 11px emoji beside a full-size Comment button,
-                   which read as decoration rather than as something to click. */
-                .verifier-feedback-row .oo-ui-buttonElement-button {
-                    box-sizing: border-box;
-                    min-height: 26px;
-                    padding: 3px 10px;
-                    border: 1px solid var(--sv-border-chip);
-                    border-radius: 13px;
-                    background: var(--sv-bg-chip-off);
-                    color: var(--sv-ink-chip);
-                    font-size: 11px;
-                    line-height: 18px;
-                }
-                .verifier-feedback-row .oo-ui-buttonElement-button:hover {
-                    border-color: var(--sv-border-chip-hover);
-                    background: var(--sv-bg-chip-hover);
-                }
-                /* OOUI absolutely positions a frameless icon at the button's
-                   padding edge and clears it with a label margin sized to the
-                   icon alone. The pill's own padding moves the icon inward, so
-                   the two end up flush; padding restores the gap without
-                   fighting OOUI's higher-specificity margin rule. */
-                .verifier-feedback-row .oo-ui-iconElement .oo-ui-labelElement-label {
-                    padding-left: 6px;
-                }
-                .verifier-feedback-thumb .oo-ui-buttonElement-button {
-                    font-size: 15px;
-                    padding: 3px 12px;
-                }
-                /* Both thumbs are disabled after the first click, and OOUI's
-                   disabled dimming would flatten the two into looking alike.
-                   The chosen one keeps full contrast and gains an accent ring;
-                   the other fades, so the recorded answer stays readable. */
+                /* Yes / No / Comment are the same widget — a frameless OOUI
+                   button with an icon and a label — and deliberately carry no
+                   styling of our own. Anything we add here is a way for the
+                   three to stop matching, which is how the row ended up with
+                   two emoji next to an icon-and-label button. */
+                /* The ring marks the recorded answer. Both buttons are disabled
+                   after the first click and OOUI dims them identically, so
+                   without it the row forgets which way the editor voted. It is
+                   an inset shadow rather than a border so nothing reflows. */
                 .verifier-feedback .is-chosen .oo-ui-buttonElement-button {
-                    border-color: var(--sv-accent-fg);
                     box-shadow: inset 0 0 0 1px var(--sv-accent-fg);
+                    border-radius: 2px;
                     background: var(--sv-bg-chip-hover);
                     color: var(--sv-ink-chip);
                     opacity: 1;
@@ -5521,7 +5505,7 @@ function buildDatasetSubmissionUrl(
             };
         }
 
-        // The 👍 / 👎 / comment row. Returns null when the check has no id —
+        // The Yes / No / Comment row. Returns null when the check has no id —
         // an unparseable or errored verdict has nothing to attach feedback to,
         // and offering controls that silently go nowhere would be worse than
         // offering none.
@@ -5565,8 +5549,23 @@ function buildDatasetSubmissionUrl(
             const setCorrectionStatus = setStatusOn(correctionStatus);
             let correctedVerdict = null;
 
-            const up = new OO.ui.ButtonWidget({ label: '👍', title: this.t('This verdict looks right'), framed: false });
-            const down = new OO.ui.ButtonWidget({ label: '👎', title: this.t('This verdict looks wrong'), framed: false });
+            // Icon + label frameless buttons, exactly like Comment below. Two
+            // bare emoji beside an icon-and-label button read as decoration
+            // rather than as part of the same set; `check` and `close` come
+            // from oojs-ui.styles.icons-interactions, which is already loaded,
+            // and inherit the dark-mode icon inversion every other icon gets.
+            const up = new OO.ui.ButtonWidget({
+                label: this.t('Yes'),
+                icon: 'check',
+                title: this.t('This verdict looks right'),
+                framed: false,
+            });
+            const down = new OO.ui.ButtonWidget({
+                label: this.t('No'),
+                icon: 'close',
+                title: this.t('This verdict looks wrong'),
+                framed: false,
+            });
             up.$element.addClass('verifier-feedback-thumb');
             down.$element.addClass('verifier-feedback-thumb');
             const rate = (rating, button) => {

--- a/main.js
+++ b/main.js
@@ -3144,7 +3144,12 @@ function buildDatasetSubmissionUrl(
                     font-weight: bold;
                     color: var(--sv-accent-fg);
                 }
-                #source-verifier-sidebar .oo-ui-iconElement-icon + .oo-ui-labelElement-label {
+                /* OOUI renders the icon span on every button, icon or not, so
+                   the sibling selector alone puts this gap on labels with
+                   nothing beside them — it was pushing the text in each
+                   correction chip 4px right of centre. The widget root only
+                   carries .oo-ui-iconElement when an icon was really set. */
+                #source-verifier-sidebar .oo-ui-iconElement .oo-ui-iconElement-icon + .oo-ui-labelElement-label {
                     margin-left: 4px;
                 }
                 #verifier-report-actions {

--- a/main.js
+++ b/main.js
@@ -2930,31 +2930,86 @@ function buildDatasetSubmissionUrl(
                     display: flex;
                     align-items: center;
                     flex-wrap: wrap;
-                    gap: 4px;
+                    gap: 6px;
+                }
+                /* [hidden] has to be restated: the display:flex above outranks
+                   the user-agent's [hidden] rule, so without this the
+                   corrected-verdict chips show under every verdict — including
+                   the thumbs-up they are meant to stay out of. */
+                .verifier-feedback-correction[hidden] {
+                    display: none;
                 }
                 .verifier-feedback-correction {
-                    margin-top: 4px;
+                    margin-top: 6px;
                 }
                 .verifier-feedback-prompt {
                     color: var(--sv-ink-subtle);
                     font-size: 11px;
                 }
+                /* The four verdicts are long enough to wrap in a 400px sidebar.
+                   Giving the question its own line lets them wrap as one block
+                   instead of one chip trailing the label and the rest below. */
+                .verifier-feedback-correction .verifier-feedback-prompt {
+                    flex-basis: 100%;
+                }
                 .verifier-feedback .oo-ui-buttonElement {
                     margin: 0;
                 }
-                .verifier-feedback .oo-ui-buttonElement-button {
+                /* One pill shape for every control in the row. The thumbs used
+                   to be bare 11px emoji beside a full-size Comment button,
+                   which read as decoration rather than as something to click. */
+                .verifier-feedback-row .oo-ui-buttonElement-button {
+                    box-sizing: border-box;
+                    min-height: 26px;
+                    padding: 3px 10px;
+                    border: 1px solid var(--sv-border-chip);
+                    border-radius: 13px;
+                    background: var(--sv-bg-chip-off);
+                    color: var(--sv-ink-chip);
                     font-size: 11px;
-                    padding: 2px 6px;
+                    line-height: 18px;
                 }
-                .verifier-feedback .is-chosen .oo-ui-buttonElement-button {
+                .verifier-feedback-row .oo-ui-buttonElement-button:hover {
+                    border-color: var(--sv-border-chip-hover);
                     background: var(--sv-bg-chip-hover);
-                    border-radius: 2px;
+                }
+                /* OOUI absolutely positions a frameless icon at the button's
+                   padding edge and clears it with a label margin sized to the
+                   icon alone. The pill's own padding moves the icon inward, so
+                   the two end up flush; padding restores the gap without
+                   fighting OOUI's higher-specificity margin rule. */
+                .verifier-feedback-row .oo-ui-iconElement .oo-ui-labelElement-label {
+                    padding-left: 6px;
+                }
+                .verifier-feedback-thumb .oo-ui-buttonElement-button {
+                    font-size: 15px;
+                    padding: 3px 12px;
+                }
+                /* Both thumbs are disabled after the first click, and OOUI's
+                   disabled dimming would flatten the two into looking alike.
+                   The chosen one keeps full contrast and gains an accent ring;
+                   the other fades, so the recorded answer stays readable. */
+                .verifier-feedback .is-chosen .oo-ui-buttonElement-button {
+                    border-color: var(--sv-accent-fg);
+                    box-shadow: inset 0 0 0 1px var(--sv-accent-fg);
+                    background: var(--sv-bg-chip-hover);
+                    color: var(--sv-ink-chip);
+                    opacity: 1;
+                }
+                .verifier-feedback .is-chosen .oo-ui-labelElement-label {
+                    color: var(--sv-ink-chip);
+                    opacity: 1;
+                }
+                .verifier-feedback .is-dimmed {
+                    opacity: 0.35;
                 }
                 .verifier-feedback-chip .oo-ui-buttonElement-button {
                     border: 1px solid var(--sv-border-chip);
                     border-radius: 10px;
                     background: var(--sv-bg-chip-off);
                     color: var(--sv-ink-chip-off);
+                    font-size: 11px;
+                    padding: 2px 8px;
                 }
                 .verifier-feedback-chip .oo-ui-buttonElement-button:hover {
                     border-color: var(--sv-border-chip-hover);
@@ -2967,6 +3022,22 @@ function buildDatasetSubmissionUrl(
                 }
                 .verifier-feedback-status:empty {
                     display: none;
+                }
+                /* The chips' own confirmation is a flex item, so it needs a full
+                   row of its own to land under them rather than beside them. */
+                .verifier-feedback-correction .verifier-feedback-status {
+                    flex-basis: 100%;
+                    margin-top: 2px;
+                }
+                /* The confirmation sits directly under whatever was clicked, so
+                   it has to carry its own weight rather than blend into the
+                   surrounding grey captions. */
+                .verifier-feedback-status.is-done {
+                    color: var(--sv-ok-fg);
+                    font-weight: 600;
+                }
+                .verifier-feedback-status.is-done::before {
+                    content: '✓ ';
                 }
                 .verifier-feedback-status.is-error {
                     color: var(--sv-error-fg);
@@ -5461,13 +5532,24 @@ function buildDatasetSubmissionUrl(
             const wrap = document.createElement('div');
             wrap.className = 'verifier-feedback';
 
-            const status = document.createElement('div');
-            status.className = 'verifier-feedback-status';
-            status.setAttribute('role', 'status');
-            const setStatus = (msg, isError = false) => {
-                status.textContent = msg;
-                status.classList.toggle('is-error', isError);
+            // Two status lines, not one: a confirmation the editor never sees
+            // is the same as no confirmation, so each sits immediately below
+            // the control that produced it — the rating under the thumbs, the
+            // correction under the chips.
+            const makeStatus = () => {
+                const el = document.createElement('div');
+                el.className = 'verifier-feedback-status';
+                el.setAttribute('role', 'status');
+                return el;
             };
+            const setStatusOn = (el) => (msg, isError = false) => {
+                el.textContent = msg;
+                el.classList.toggle('is-error', isError);
+                el.classList.toggle('is-done', !isError && !!msg);
+            };
+
+            const status = makeStatus();
+            const setStatus = setStatusOn(status);
 
             const row = document.createElement('div');
             row.className = 'verifier-feedback-row';
@@ -5479,18 +5561,26 @@ function buildDatasetSubmissionUrl(
             const correction = document.createElement('div');
             correction.className = 'verifier-feedback-correction';
             correction.hidden = true;
+            const correctionStatus = makeStatus();
+            const setCorrectionStatus = setStatusOn(correctionStatus);
             let correctedVerdict = null;
 
             const up = new OO.ui.ButtonWidget({ label: '👍', title: this.t('This verdict looks right'), framed: false });
             const down = new OO.ui.ButtonWidget({ label: '👎', title: this.t('This verdict looks wrong'), framed: false });
+            up.$element.addClass('verifier-feedback-thumb');
+            down.$element.addClass('verifier-feedback-thumb');
             const rate = (rating, button) => {
                 up.setDisabled(true);
                 down.setDisabled(true);
                 button.$element.addClass('is-chosen');
+                (button === up ? down : up).$element.addClass('is-dimmed');
                 setStatus(this.t('Thanks — recorded.'));
                 this.sendFeedback({ checkId: context.checkId, rating })
                     .catch(() => setStatus(this.t('Could not record that, sorry.'), true));
-                if (rating < 0) correction.hidden = false;
+                // The corrected-verdict chips are only worth asking for when the
+                // editor has said the verdict is wrong; after a thumbs-up there
+                // is nothing to correct.
+                correction.hidden = rating >= 0;
             };
             up.on('click', () => rate(1, up));
             down.on('click', () => rate(-1, down));
@@ -5523,22 +5613,26 @@ function buildDatasetSubmissionUrl(
                 chip.$element.addClass('verifier-feedback-chip');
                 chip.on('click', () => {
                     correctedVerdict = verdict;
-                    chips.forEach(c => c.setDisabled(true));
+                    chips.forEach(c => {
+                        c.setDisabled(true);
+                        if (c !== chip) c.$element.addClass('is-dimmed');
+                    });
                     chip.$element.addClass('is-chosen');
-                    setStatus(this.t('Thanks — recorded.'));
+                    setCorrectionStatus(this.t('Thanks — recorded.'));
                     commentBtn.setHref(buildCommentUrl({ ...context, correctedVerdict }));
                     // rating is omitted here: the thumbs-down already counted,
                     // and a second row carrying it would double-count.
                     this.sendFeedback({ checkId: context.checkId, correctedVerdict: verdict })
-                        .catch(() => setStatus(this.t('Could not record that, sorry.'), true));
+                        .catch(() => setCorrectionStatus(this.t('Could not record that, sorry.'), true));
                 });
                 correction.appendChild(chip.$element[0]);
                 return chip;
             });
+            correction.appendChild(correctionStatus);
 
             wrap.appendChild(row);
-            wrap.appendChild(correction);
             wrap.appendChild(status);
+            wrap.appendChild(correction);
             return wrap;
         }
 

--- a/main.js
+++ b/main.js
@@ -2964,6 +2964,20 @@ function buildDatasetSubmissionUrl(
                 .verifier-feedback .oo-ui-buttonElement {
                     margin: 0;
                 }
+                /* OOUI gives a button min-height: 32px but leaves its line box
+                   at the natural height of the text, and an inline-block puts
+                   the leftover space entirely below — so the label sits high in
+                   the box. Icons don't: they are absolutely positioned at
+                   top: 50%, which is why this only reads as broken on the
+                   correction chips, the one button here with no icon beside the
+                   text. inline-flex centres the content vertically without
+                   taking the button out of the inline flow; horizontal
+                   placement is left alone, since the icon is out of flow and
+                   centring the label would slide it under the icon. */
+                .verifier-feedback .oo-ui-buttonElement-button {
+                    display: inline-flex;
+                    align-items: center;
+                }
                 /* Yes / No / Comment are the same widget — a frameless OOUI
                    button with an icon and a label — and deliberately carry no
                    styling of our own. Anything we add here is a way for the

--- a/tests/feedback_controls.test.js
+++ b/tests/feedback_controls.test.js
@@ -185,6 +185,33 @@ test('thumbs-down reveals the corrected-verdict chips; thumbs-up does not', asyn
   assert.equal(upEl.querySelector('.verifier-feedback-correction').hidden, true);
 });
 
+test('the chosen thumb is marked and the other one fades', async () => {
+  const ctx = makeHarness();
+  ctx.harness.buildFeedbackControls(RESULT);
+  const up = ctx.byTitle('This verdict looks right');
+  const down = ctx.byTitle('This verdict looks wrong');
+  // Both thumbs disable on the first click, so OOUI dims them equally. Without
+  // a chosen/dimmed distinction the editor cannot tell which way they voted.
+  await down.click();
+  assert.equal(down.$element[0].classList.contains('is-chosen'), true);
+  assert.equal(up.$element[0].classList.contains('is-dimmed'), true);
+  assert.equal(down.$element[0].classList.contains('is-dimmed'), false);
+});
+
+test('the thumbs are styled as feedback-row buttons, not bare emoji', () => {
+  const ctx = makeHarness();
+  ctx.harness.buildFeedbackControls(RESULT);
+  // The hook the stylesheet sizes them through — without it they render at the
+  // 11px caption size beside a full-height Comment button.
+  for (const title of ['This verdict looks right', 'This verdict looks wrong']) {
+    assert.equal(
+      ctx.byTitle(title).$element[0].classList.contains('verifier-feedback-thumb'),
+      true,
+      `${title} is missing the thumb class`
+    );
+  }
+});
+
 test('every canonical verdict is offered as a correction chip', () => {
   const ctx = makeHarness();
   ctx.harness.buildFeedbackControls(RESULT);
@@ -203,6 +230,42 @@ test('choosing a corrected verdict records it without re-counting the rating', a
   assert.equal(ctx.posted[1].rating, null, 'the correction must not re-send the rating');
   assert.equal(ctx.posted[1].corrected_verdict, 'SUPPORTED');
   assert.equal(ctx.posted[1].check_id, 'a7f3k2q9');
+});
+
+// A confirmation the editor never sees is the same as no confirmation. The
+// single status line used to sit below the correction chips, so a thumbs-up —
+// which does not open the chips at all — reported "Thanks" further down the
+// panel than the button that was clicked.
+test('each confirmation sits with the control that produced it', async () => {
+  const ctx = makeHarness();
+  const el = ctx.harness.buildFeedbackControls(RESULT);
+  const correction = el.querySelector('.verifier-feedback-correction');
+  const ratingStatus = [...el.children].find(c => c.classList.contains('verifier-feedback-status'));
+  const chipStatus = correction.querySelector('.verifier-feedback-status');
+
+  assert.ok(ratingStatus, 'the rating has no status line of its own');
+  assert.ok(chipStatus, 'the correction chips have no status line of their own');
+  assert.equal(
+    ratingStatus.compareDocumentPosition(correction) & 4 /* DOCUMENT_POSITION_FOLLOWING */,
+    4,
+    'the rating confirmation must come before the correction block, not after it'
+  );
+
+  await ctx.byTitle('This verdict looks wrong').click();
+  assert.match(ratingStatus.textContent, /Thanks/);
+  assert.equal(chipStatus.textContent, '');
+
+  await ctx.byLabel('SUPPORTED').click();
+  assert.match(chipStatus.textContent, /Thanks/);
+});
+
+test('a recorded confirmation is marked as such, not left as plain caption text', async () => {
+  const ctx = makeHarness();
+  const el = ctx.harness.buildFeedbackControls(RESULT);
+  await ctx.byTitle('This verdict looks right').click();
+  const status = el.querySelector('.verifier-feedback-status');
+  assert.equal(status.classList.contains('is-done'), true);
+  assert.equal(status.classList.contains('is-error'), false);
 });
 
 test('a failed rating tells the user instead of silently doing nothing', async () => {

--- a/tests/feedback_controls.test.js
+++ b/tests/feedback_controls.test.js
@@ -185,31 +185,39 @@ test('thumbs-down reveals the corrected-verdict chips; thumbs-up does not', asyn
   assert.equal(upEl.querySelector('.verifier-feedback-correction').hidden, true);
 });
 
-test('the chosen thumb is marked and the other one fades', async () => {
+test('Yes, No and Comment are built as one set of buttons', () => {
+  const ctx = makeHarness();
+  ctx.harness.buildFeedbackControls(RESULT);
+  const yes = ctx.byTitle('This verdict looks right');
+  const no = ctx.byTitle('This verdict looks wrong');
+  const comment = ctx.byLabel('Comment');
+
+  // Two bare emoji beside an icon-and-label button read as decoration rather
+  // than as part of the same set. All three are the same widget with the same
+  // trimmings, which is what keeps them looking like one row of controls.
+  for (const [name, button] of [['Yes', yes], ['No', no], ['Comment', comment]]) {
+    assert.ok(button, `${name} is missing from the row`);
+    assert.ok(button.cfg.icon, `${name} has no icon`);
+    assert.ok(button.cfg.label, `${name} has no label`);
+    assert.equal(button.cfg.framed, false, `${name} is framed but the others are not`);
+  }
+  // `check` and `close` ship in oojs-ui.styles.icons-interactions, which the
+  // script already loads; anything else would need a new module.
+  assert.equal(yes.cfg.icon, 'check');
+  assert.equal(no.cfg.icon, 'close');
+});
+
+test('the chosen answer is marked and the other one fades', async () => {
   const ctx = makeHarness();
   ctx.harness.buildFeedbackControls(RESULT);
   const up = ctx.byTitle('This verdict looks right');
   const down = ctx.byTitle('This verdict looks wrong');
-  // Both thumbs disable on the first click, so OOUI dims them equally. Without
+  // Both answers disable on the first click, so OOUI dims them equally. Without
   // a chosen/dimmed distinction the editor cannot tell which way they voted.
   await down.click();
   assert.equal(down.$element[0].classList.contains('is-chosen'), true);
   assert.equal(up.$element[0].classList.contains('is-dimmed'), true);
   assert.equal(down.$element[0].classList.contains('is-dimmed'), false);
-});
-
-test('the thumbs are styled as feedback-row buttons, not bare emoji', () => {
-  const ctx = makeHarness();
-  ctx.harness.buildFeedbackControls(RESULT);
-  // The hook the stylesheet sizes them through — without it they render at the
-  // 11px caption size beside a full-height Comment button.
-  for (const title of ['This verdict looks right', 'This verdict looks wrong']) {
-    assert.equal(
-      ctx.byTitle(title).$element[0].classList.contains('verifier-feedback-thumb'),
-      true,
-      `${title} is missing the thumb class`
-    );
-  }
 });
 
 test('every canonical verdict is offered as a correction chip', () => {

--- a/tests/styles.test.js
+++ b/tests/styles.test.js
@@ -215,6 +215,19 @@ test('the dark-mode button background only targets framed buttons', () => {
   );
 });
 
+// The corrected-verdict chips are revealed by clearing `hidden` on their
+// container. That container is a flex row, and an author `display: flex`
+// outranks the user-agent's `[hidden] { display: none }` — which is how the
+// chips came to show under every verdict, thumbs-up included.
+test('the corrected-verdict chips stay collapsed while [hidden] is set', () => {
+  const css = generateCss();
+  assert.match(
+    css,
+    /\.verifier-feedback-correction\[hidden\]\s*\{[^}]*display:\s*none/,
+    'the correction row is display:flex, so [hidden] does nothing without an explicit reset'
+  );
+});
+
 test('token values stay in sync with the selected provider accent', () => {
   const css = generateCss('#123456');
   assert.ok(css.includes('--sv-accent: #123456;'), 'accent token does not track getCurrentColor()');

--- a/tests/styles.test.js
+++ b/tests/styles.test.js
@@ -246,6 +246,23 @@ test('the full-width CTA rule cannot reach the feedback controls', () => {
   );
 });
 
+// OOUI renders the icon span on every button whether or not an icon was set,
+// so `.oo-ui-iconElement-icon + .oo-ui-labelElement-label` also matches labels
+// with nothing beside them. Unqualified, it offset the text of every icon-less
+// button — visible as the correction chips' labels sitting right of centre.
+test('the icon-to-label gap only applies where an icon was actually set', () => {
+  const css = generateCss();
+  const selectors = [...css.matchAll(/([^{}]*\.oo-ui-iconElement-icon \+ \.oo-ui-labelElement-label[^{}]*)\{/g)]
+    .map((m) => m[1].trim());
+  assert.ok(selectors.length, 'the icon-to-label gap rule has gone missing');
+
+  const unqualified = selectors.filter((selector) => !/\.oo-ui-iconElement[\s>]/.test(selector));
+  assert.deepEqual(
+    unqualified, [],
+    `these rules gap every label, including buttons with no icon:\n${unqualified.join('\n')}`
+  );
+});
+
 test('token values stay in sync with the selected provider accent', () => {
   const css = generateCss('#123456');
   assert.ok(css.includes('--sv-accent: #123456;'), 'accent token does not track getCurrentColor()');

--- a/tests/styles.test.js
+++ b/tests/styles.test.js
@@ -228,6 +228,24 @@ test('the corrected-verdict chips stay collapsed while [hidden] is set', () => {
   );
 });
 
+// #verifier-action-container holds two unrelated things: the full-width
+// "Edit Section" call to action, appended straight to it, and the feedback
+// controls, which live in a .verifier-feedback wrapper inside it. An unscoped
+// width rule stretched every feedback button too, so Yes / No / Comment and the
+// correction chips shrank to unrelated widths instead of sitting as a row.
+test('the full-width CTA rule cannot reach the feedback controls', () => {
+  const css = generateCss();
+  const leaking = [...css.matchAll(/([^{}]*#verifier-action-container[^{}]*)\{([^}]*)\}/g)]
+    .filter((m) => /width:\s*100%/.test(m[2]))
+    .map((m) => m[1].trim())
+    .filter((selector) => !selector.includes('>'));
+
+  assert.deepEqual(
+    leaking, [],
+    `these rules stretch every button in the action container, not just the CTA:\n${leaking.join('\n')}`
+  );
+});
+
 test('token values stay in sync with the selected provider accent', () => {
   const css = generateCss('#123456');
   assert.ok(css.includes('--sv-accent: #123456;'), 'accent token does not track getCurrentColor()');


### PR DESCRIPTION
## Summary

Redesigns the feedback controls (Yes/No/Comment row and corrected-verdict chips) to improve visual consistency, clarity, and layout stability. Replaces bare emoji buttons with icon+label buttons matching the Comment button style, adds visual feedback for chosen answers, and splits the single status line into two so confirmations appear immediately below the control that produced them.

## Key Changes

- **Button redesign:** Replace thumbs emoji (👍/👎) with icon+label buttons using `check` and `close` icons from OOUI's built-in icon set, making all three controls (Yes/No/Comment) visually consistent
- **Visual feedback:** Add `is-chosen` ring (inset box-shadow) and `is-dimmed` opacity class to show which answer was selected and fade the unchosen option
- **Dual status lines:** Create separate status elements for the rating row and correction chips so confirmations appear immediately below the control that triggered them, not displaced further down the panel
- **CSS selector fixes:** 
  - Scope full-width button rule to direct children (`> .oo-ui-buttonElement`) so it doesn't stretch feedback buttons
  - Qualify icon-to-label gap rule to `.oo-ui-iconElement .oo-ui-iconElement-icon` so it only applies where an icon actually exists
  - Add explicit `[hidden] { display: none }` to correction container to override flex layout
- **Layout improvements:**
  - Increase gap from 4px to 6px for better breathing room
  - Use `inline-flex` on button labels to vertically center text without affecting icon positioning
  - Add `flex-basis: 100%` to correction prompt and status so they take full rows
- **Translations:** Add French translations for "Yes" and "No"
- **Tests:** Add comprehensive test coverage for button consistency, chosen/dimmed states, dual status placement, and CSS selector scoping

## Implementation Details

The feedback controls now use the same OOUI button widget pattern throughout (icon + label, frameless), eliminating the visual inconsistency of emoji buttons beside an icon-and-label button. The chosen answer is marked with an inset ring rather than a background change, preserving the disabled state styling while making the selection clear. Splitting the status line into two (one for rating, one for correction) ensures feedback appears in context rather than floating below unrelated controls.

CSS changes are carefully scoped to avoid unintended side effects: the full-width CTA rule now uses `>` to target only direct children, and the icon-to-label gap is qualified to `.oo-ui-iconElement` so it doesn't offset labels on icon-less buttons.

https://claude.ai/code/session_01K4s9LChPmM6H5sCniNUVSK