### PR TITLE
Record the checked revision in the log and the talk-page comment

### DIFF
--- a/core/feedback.js
+++ b/core/feedback.js
@@ -39,6 +39,20 @@ export function truncateForLog(value, max = MAX_LOGGED_TEXT) {
     return s.length > max ? s.slice(0, max - 1) + '…' : s;
 }
 
+// MediaWiki revision ids are positive integers. Normalising to a number (or
+// null) rather than passing whatever the caller had keeps the log column
+// numeric, and — because every consumer stringifies the result of this — makes
+// the id inert wikitext by construction, with no separate escaping step to
+// forget. `wgRevisionId` is 0 on a page that has no revision (a preview, a
+// special page), which is not a revision and must not be recorded as one.
+export function normalizeRevisionId(value) {
+    if (value == null) return null;
+    const s = String(value).trim();
+    if (!/^\d+$/.test(s)) return null;
+    const n = Number(s);
+    return Number.isSafeInteger(n) && n > 0 ? n : null;
+}
+
 // 8 hex characters. `source` is injectable so tests can pin the output;
 // production passes nothing and picks up the ambient Web Crypto.
 export function newCheckId(source) {
@@ -67,6 +81,12 @@ export function buildLogPayload(fields = {}) {
         kind:            fields.kind ?? 'source',
         article_url:     fields.articleUrl ?? null,
         article_title:   fields.articleTitle ?? null,
+        // The article revision the check ran against. Without it a logged
+        // verdict is not reproducible: the page it describes is a moving
+        // target, so a disagreement about the verdict can't be separated from
+        // an edit to the claim, and two model versions can't be compared
+        // because they were never shown the same text.
+        revision_id:     normalizeRevisionId(fields.revisionId),
         citation_number: fields.citationNumber ?? null,
         source_url:      fields.sourceUrl ?? null,
         provider:        fields.provider ?? null,
@@ -168,6 +188,7 @@ export function buildTalkSectionBody(fields = {}) {
     const {
         articleUrl, articleTitle, citationNumber, claimText, sourceUrl,
         verdict, comments, providerName, model, correctedVerdict, checkId,
+        revisionId, revisionUrl,
     } = fields;
 
     const clean = v => String(v ?? '').replace(/\s+/g, ' ').trim();
@@ -176,7 +197,18 @@ export function buildTalkSectionBody(fields = {}) {
 
     if (articleUrl && label) {
         const cite = clean(citationNumber);
-        toolLines.push(`* '''Article:''' [${encodeURI(String(articleUrl))} ${label}]${cite ? `, citation [${cite}]` : ''}`);
+        // The revision is what makes the report reproducible, and it belongs
+        // on the Article line because it is a property of the article, not of
+        // the check: the plain link goes to whatever the page says today, so
+        // without the permalink a reader arriving at this section a month
+        // later cannot tell whether they are looking at the text the tool
+        // read. Linked when the caller supplied a permalink, bare otherwise —
+        // the number alone still identifies the revision.
+        const rev = normalizeRevisionId(revisionId);
+        const revText = rev === null ? '' : (revisionUrl
+            ? `[${encodeURI(String(revisionUrl))} ${rev}]`
+            : String(rev));
+        toolLines.push(`* '''Article:''' [${encodeURI(String(articleUrl))} ${label}]${cite ? `, citation [${cite}]` : ''}${revText ? `, revision ${revText}` : ''}`);
     }
     if (sourceUrl) {
         // encodeURI neutralises {{ }} (the one wikitext construct a citation

--- a/docs/worker-logging-reference.md
+++ b/docs/worker-logging-reference.md
@@ -10,6 +10,7 @@ CREATE TABLE verification_logs (
   kind TEXT DEFAULT 'source',  -- 'source' | 'group'
   article_url TEXT,
   article_title TEXT,
+  revision_id BIGINT,          -- the article revision the check ran against
   citation_number TEXT,        -- comma-joined for kind='group'
   source_url TEXT,             -- null for kind='group' (several sources)
   provider TEXT,
@@ -30,11 +31,26 @@ ALTER TABLE verification_logs
   ADD COLUMN kind TEXT DEFAULT 'source',
   ADD COLUMN model TEXT,
   ADD COLUMN claim_text TEXT,
-  ADD COLUMN llm_comments TEXT;
+  ADD COLUMN llm_comments TEXT,
+  ADD COLUMN revision_id BIGINT;
 ```
 
 (`reason_type` is already sent by the client; add it too if the deployed table
 is older than that change.)
+
+### Why the revision id is recorded
+
+Without it a logged verdict describes a page that has since moved on. A
+disagreement about a verdict can't be separated from an edit to the claim, and
+two prompt or model versions can't be compared, because they were never shown
+the same text — the fixed page is the whole point. `normalizeRevisionId()` in
+`core/feedback.js` is the gate: a positive integer or null, never `wgRevisionId`'s
+0 (a preview or special page, which is not a revision).
+
+The client sends `wgRevisionId` — the revision actually on screen, and so the
+one that was read — falling back to `wgCurRevisionId`. The two differ only when
+an old revision is being viewed, which is exactly the case where naming the
+current one would be wrong.
 
 ### Why `check_id` is minted in the browser
 
@@ -232,8 +248,13 @@ the `<!-- source-verifier check: … -->` marker in each section.
 
 ### The section is split by who wrote what
 
-Everything the tool produced — article, source, verdict, claim, rationale —
-goes inside a `{{hidden begin|title=Check details}}` … `{{hidden end}}` box.
+Everything the tool produced — article, revision, source, verdict, claim,
+rationale — goes inside a `{{hidden begin|title=Check details}}` … `{{hidden end}}` box.
+The **Article** line carries the revision as a permalink
+(`…, citation [12], revision [<permalink> 1234567]`) for the same reason the log
+column exists: the plain article link points at whatever the page says today, so
+without it a reader arriving at the section a month later can't tell whether
+they are looking at the text the tool read.
 Everything the editor supplies stays visible above the signature: the
 corrected verdict, and their prose under an **`Editor's explanation:`** label.
 A reader scanning the talk page sees the human argument, not five bullets of

--- a/main.js
+++ b/main.js
@@ -1183,6 +1183,20 @@ function truncateForLog(value, max = MAX_LOGGED_TEXT) {
     return s.length > max ? s.slice(0, max - 1) + '…' : s;
 }
 
+// MediaWiki revision ids are positive integers. Normalising to a number (or
+// null) rather than passing whatever the caller had keeps the log column
+// numeric, and — because every consumer stringifies the result of this — makes
+// the id inert wikitext by construction, with no separate escaping step to
+// forget. `wgRevisionId` is 0 on a page that has no revision (a preview, a
+// special page), which is not a revision and must not be recorded as one.
+function normalizeRevisionId(value) {
+    if (value == null) return null;
+    const s = String(value).trim();
+    if (!/^\d+$/.test(s)) return null;
+    const n = Number(s);
+    return Number.isSafeInteger(n) && n > 0 ? n : null;
+}
+
 // 8 hex characters. `source` is injectable so tests can pin the output;
 // production passes nothing and picks up the ambient Web Crypto.
 function newCheckId(source) {
@@ -1211,6 +1225,12 @@ function buildLogPayload(fields = {}) {
         kind:            fields.kind ?? 'source',
         article_url:     fields.articleUrl ?? null,
         article_title:   fields.articleTitle ?? null,
+        // The article revision the check ran against. Without it a logged
+        // verdict is not reproducible: the page it describes is a moving
+        // target, so a disagreement about the verdict can't be separated from
+        // an edit to the claim, and two model versions can't be compared
+        // because they were never shown the same text.
+        revision_id:     normalizeRevisionId(fields.revisionId),
         citation_number: fields.citationNumber ?? null,
         source_url:      fields.sourceUrl ?? null,
         provider:        fields.provider ?? null,
@@ -1312,6 +1332,7 @@ function buildTalkSectionBody(fields = {}) {
     const {
         articleUrl, articleTitle, citationNumber, claimText, sourceUrl,
         verdict, comments, providerName, model, correctedVerdict, checkId,
+        revisionId, revisionUrl,
     } = fields;
 
     const clean = v => String(v ?? '').replace(/\s+/g, ' ').trim();
@@ -1320,7 +1341,18 @@ function buildTalkSectionBody(fields = {}) {
 
     if (articleUrl && label) {
         const cite = clean(citationNumber);
-        toolLines.push(`* '''Article:''' [${encodeURI(String(articleUrl))} ${label}]${cite ? `, citation [${cite}]` : ''}`);
+        // The revision is what makes the report reproducible, and it belongs
+        // on the Article line because it is a property of the article, not of
+        // the check: the plain link goes to whatever the page says today, so
+        // without the permalink a reader arriving at this section a month
+        // later cannot tell whether they are looking at the text the tool
+        // read. Linked when the caller supplied a permalink, bare otherwise —
+        // the number alone still identifies the revision.
+        const rev = normalizeRevisionId(revisionId);
+        const revText = rev === null ? '' : (revisionUrl
+            ? `[${encodeURI(String(revisionUrl))} ${rev}]`
+            : String(rev));
+        toolLines.push(`* '''Article:''' [${encodeURI(String(articleUrl))} ${label}]${cite ? `, citation [${cite}]` : ''}${revText ? `, revision ${revText}` : ''}`);
     }
     if (sourceUrl) {
         // encodeURI neutralises {{ }} (the one wikitext construct a citation
@@ -1404,15 +1436,6 @@ function buildCommentUrl(fields = {}, {
 //      `entry.<numeric-id>` from the pre-filled link.
 //   4. Run `npm run build` so the constants are re-inlined into main.js.
 
-// Cap for manually-pasted source text. Unlike fetched sources — which the
-// Cloudflare Worker proxy truncates server-side before they reach us — a manual
-// paste goes straight into the request body, so an oversized paste hits the
-// proxy's request-body limit (HTTP 413 "Request body too large"). We trim here
-// to stay comfortably under that limit (currently ~100 KB): budget = 100 KB
-// minus the ~6.5 KB system prompt, the claim/user-prompt boilerplate, and
-// JSON-escaping + UTF-8 overhead on the source itself. 80 000 chars leaves room.
-const MAX_MANUAL_SOURCE_CHARS = 80000;
-
 // Sentinel substring that marks scaffolded values as not-yet-configured.
 // isDatasetSubmissionConfigured() looks for this exact token; don't reuse it
 // anywhere else in this file.
@@ -1463,6 +1486,19 @@ function buildDatasetSubmissionUrl(
     return `${formUrl}?${params.toString()}`;
 }
 // </core-injected>
+
+// Cap for manually-pasted source text. Unlike fetched sources — which the
+// Cloudflare Worker proxy truncates server-side before they reach us — a manual
+// paste goes straight into the request body, so an oversized paste hits the
+// proxy's request-body limit (HTTP 413 "Request body too large"). We trim here
+// to stay comfortably under that limit (currently ~100 KB): budget = 100 KB
+// minus the ~6.5 KB system prompt, the claim/user-prompt boilerplate, and
+// JSON-escaping + UTF-8 overhead on the source itself. 80 000 chars leaves room.
+//
+// Deliberately *below* the </core-injected> marker: it has no counterpart in
+// core/, so while it sat inside the injected region the next `npm run build`
+// silently deleted it, taking loadManualSourceText() with it.
+const MAX_MANUAL_SOURCE_CHARS = 80000;
 
     // ========================================
     // UI LOCALIZATION (i18n)
@@ -4220,6 +4256,7 @@ function buildDatasetSubmissionUrl(
                 kind: context.kind,
                 articleUrl: window.location.href,
                 articleTitle: typeof mw !== 'undefined' ? mw.config.get('wgTitle') : document.title,
+                revisionId: this.getArticleRevisionId(),
                 citationNumber: fromContext('citationNumber', this.activeCitationNumber),
                 sourceUrl: fromContext('sourceUrl', this.activeSourceUrl),
                 provider: this.currentProvider,
@@ -4858,6 +4895,22 @@ function buildDatasetSubmissionUrl(
             actionsEl.appendChild(copyTextBtn.$element[0]);
         }
 
+        // The revision the check ran against, recorded so a logged verdict or
+        // a talk-page report stays reproducible after the article moves on.
+        // `wgRevisionId` is the revision actually on screen and so the one that
+        // was read; it differs from `wgCurRevisionId` only when an old revision
+        // is being viewed, which is exactly the case where naming the current
+        // revision would be a lie.
+        getArticleRevisionId() {
+            if (typeof mw === 'undefined') return null;
+            try {
+                return normalizeRevisionId(mw.config.get('wgRevisionId'))
+                    ?? normalizeRevisionId(mw.config.get('wgCurRevisionId'));
+            } catch (e) {
+                return null;
+            }
+        }
+
         getRevisionPermalinkUrl(revId) {
             if (!revId || typeof mw === 'undefined') return null;
             try {
@@ -5242,7 +5295,7 @@ function buildDatasetSubmissionUrl(
             this.sourceCache = new Map();
             this.reportTokenUsage = { input: 0, output: 0 };
             this.hasReport = true;
-            this.reportRevisionId = mw.config.get('wgCurRevisionId') || null;
+            this.reportRevisionId = this.getArticleRevisionId();
 
             this.showReportView();
             document.getElementById('verifier-report-results').innerHTML = '';
@@ -5580,12 +5633,15 @@ function buildDatasetSubmissionUrl(
         // from either a report result object or the sidebar's active state.
         feedbackContextFor(result) {
             const provider = this.providers[this.currentProvider] || {};
+            const revisionId = this.getArticleRevisionId();
             return {
                 checkId: result?.checkId ?? null,
                 articleUrl: (typeof window !== 'undefined' && window.location)
                     ? `${window.location.origin}${window.location.pathname}`
                     : '',
                 articleTitle: typeof mw !== 'undefined' ? mw.config.get('wgTitle') : document.title,
+                revisionId,
+                revisionUrl: this.getRevisionPermalinkUrl(revisionId),
                 citationNumber: result?.citationNumber ?? '',
                 claimText: result?.claimText ?? '',
                 sourceUrl: result?.url ?? '',

--- a/tests/feedback.test.js
+++ b/tests/feedback.test.js
@@ -7,6 +7,7 @@ import {
   buildLogPayload,
   buildFeedbackPayload,
   nowikiWrap,
+  normalizeRevisionId,
   buildTalkSectionTitle,
   buildTalkSectionBody,
   buildCommentUrl,
@@ -92,6 +93,7 @@ test('buildLogPayload maps camelCase fields onto the snake_case columns', () => 
     checkId: 'a7f3k2q9',
     articleUrl: 'https://en.wikipedia.org/wiki/Test',
     articleTitle: 'Test',
+    revisionId: 1234567,
     citationNumber: '12',
     sourceUrl: 'https://example.com/s',
     provider: 'claude',
@@ -107,6 +109,7 @@ test('buildLogPayload maps camelCase fields onto the snake_case columns', () => 
     kind: 'source',
     article_url: 'https://en.wikipedia.org/wiki/Test',
     article_title: 'Test',
+    revision_id: 1234567,
     citation_number: '12',
     source_url: 'https://example.com/s',
     provider: 'claude',
@@ -117,6 +120,26 @@ test('buildLogPayload maps camelCase fields onto the snake_case columns', () => 
     claim_text: 'The sky is blue.',
     llm_comments: 'Source never mentions the sky.',
   });
+});
+
+test('normalizeRevisionId accepts a revision id as a number or a string', () => {
+  assert.equal(normalizeRevisionId(1234567), 1234567);
+  assert.equal(normalizeRevisionId('1234567'), 1234567);
+  assert.equal(normalizeRevisionId(' 1234567 '), 1234567);
+});
+
+// wgRevisionId is 0 on a page with no revision — a preview, a special page.
+// That is not a revision and must not be logged as one.
+test('normalizeRevisionId rejects anything that is not a positive integer', () => {
+  for (const bad of [0, '0', -1, '-1', 1.5, '1.5', '', '  ', null, undefined, NaN,
+                     'abc', '12 34', '1e6', '{{delete}}', Number.MAX_SAFE_INTEGER + 2]) {
+    assert.equal(normalizeRevisionId(bad), null, `accepted ${JSON.stringify(String(bad))}`);
+  }
+});
+
+test('buildLogPayload records the revision so a logged verdict stays reproducible', () => {
+  assert.equal(buildLogPayload({ revisionId: '1234567' }).revision_id, 1234567);
+  assert.equal(buildLogPayload({}).revision_id, null);
 });
 
 test('buildLogPayload carries claim text and rationale — the fields that make a rating interpretable', () => {
@@ -268,6 +291,47 @@ test('buildTalkSectionBody records article, source, verdict, claim and reasoning
   assert.match(body, /\* '''Tool's verdict:''' NOT SUPPORTED \(Claude, claude-sonnet-4-6\)/);
   assert.match(body, /\* '''Claim checked:''' <nowiki>He was born in Honolulu\.<\/nowiki>/);
   assert.match(body, /\* '''Tool's reasoning:''' <nowiki>The source never mentions Honolulu\.<\/nowiki>/);
+});
+
+// The revision is what makes a report reproducible: the plain article link
+// points at whatever the page says today, so without it a reader arriving at
+// the section later cannot tell whether they are looking at the text the tool
+// read, and two model versions cannot be compared on a fixed page.
+test('buildTalkSectionBody names the revision the check ran against', () => {
+  const body = buildTalkSectionBody({
+    ...CONTEXT,
+    revisionId: 1234567,
+    revisionUrl: 'https://en.wikipedia.org/w/index.php?title=Barack_Obama&oldid=1234567',
+  });
+  assert.match(
+    body,
+    /\* '''Article:''' \[https:\/\/en\.wikipedia\.org\/wiki\/Barack_Obama Barack Obama\], citation \[12\], revision \[https:\/\/en\.wikipedia\.org\/w\/index\.php\?title=Barack_Obama&oldid=1234567 1234567\]/,
+  );
+});
+
+test('buildTalkSectionBody keeps the revision inside the collapsed tool box', () => {
+  const body = buildTalkSectionBody({ ...CONTEXT, revisionId: 1234567 });
+  const boxed = body.slice(body.indexOf('{{hidden begin'), body.indexOf('{{hidden end}}'));
+  assert.ok(boxed.includes('revision 1234567'));
+});
+
+test('buildTalkSectionBody falls back to a bare revision number without a permalink', () => {
+  const body = buildTalkSectionBody({ ...CONTEXT, revisionId: 1234567 });
+  assert.match(body, /, citation \[12\], revision 1234567$/m);
+});
+
+test('buildTalkSectionBody omits the revision when none is known', () => {
+  const body = buildTalkSectionBody(CONTEXT);
+  assert.equal(body.includes('revision'), false);
+});
+
+// The revision reaches the wikitext as a number, so a caller passing something
+// else must not be able to open a link or a template through it.
+test('buildTalkSectionBody ignores a revision id that is not a plain number', () => {
+  for (const bad of ['{{delete}}', '12 34', '1234567e0', '-5', '', 'null']) {
+    const body = buildTalkSectionBody({ ...CONTEXT, revisionId: bad });
+    assert.equal(body.includes('revision'), false, `leaked ${JSON.stringify(bad)}`);
+  }
 });
 
 test('buildTalkSectionBody tells the editor where to write and to sign', () => {

--- a/tests/feedback_controls.test.js
+++ b/tests/feedback_controls.test.js
@@ -12,6 +12,7 @@ import {
   buildFeedbackPayload,
   buildTalkSectionBody,
   buildCommentUrl,
+  normalizeRevisionId,
   FEEDBACK_TALK_PAGE,
 } from '../core/feedback.js';
 
@@ -33,6 +34,19 @@ function feedbackMethods() {
   return src.slice(start, end + END_MARKER.length);
 }
 
+// The revision helpers live elsewhere in the class, so they are lifted
+// separately rather than stubbed — the point of the revision tests is that the
+// id the real reader produces is the one that reaches the comment link.
+function classMethod(name) {
+  const src = fs.readFileSync(MAIN_JS, 'utf8');
+  const open = `\n        ${name}(`;
+  const start = src.indexOf(open);
+  assert.ok(start !== -1, `${name}() not found in main.js — did the method get renamed?`);
+  const end = src.indexOf('\n        }\n', start);
+  assert.ok(end !== -1, `${name}() has no closing brace at class indentation`);
+  return src.slice(start + 1, end + '\n        }'.length);
+}
+
 // --- stubs --------------------------------------------------------------
 
 function jq(el) {
@@ -43,7 +57,7 @@ function jq(el) {
   };
 }
 
-function makeHarness({ postFeedback } = {}) {
+function makeHarness({ postFeedback, config } = {}) {
   const dom = new JSDOM('<!doctype html><body></body>');
   const { document } = dom.window;
   const widgets = [];
@@ -66,15 +80,25 @@ function makeHarness({ postFeedback } = {}) {
     click() { return Promise.all((this.handlers.click || []).map(fn => fn())); }
   }
 
-  // Only wgTitle is consulted now that nothing is posted through the API.
-  const mw = { config: { get: key => ({ wgTitle: 'Barack Obama' }[key] ?? null) } };
+  // wgTitle for the heading, and the revision/site keys the permalink is built
+  // from. Nothing is posted through the API, so no other config is consulted.
+  const defaultConfig = {
+    wgTitle: 'Barack Obama',
+    wgPageName: 'Barack_Obama',
+    wgServer: '//en.wikipedia.org',
+    wgScript: '/w/index.php',
+    wgRevisionId: 1234567,
+    wgCurRevisionId: 1234567,
+  };
+  const values = { ...defaultConfig, ...config };
+  const mw = { config: { get: key => values[key] ?? null } };
 
   const posted = [];
   const postFeedbackStub = postFeedback || (payload => { posted.push(payload); return Promise.resolve(true); });
 
   const Harness = new Function(
     'document', 'window', 'localStorage', 'OO', 'mw', 'VERDICT_LIST', 'newCheckId',
-    'buildFeedbackPayload', 'postFeedback', 'buildCommentUrl',
+    'buildFeedbackPayload', 'postFeedback', 'buildCommentUrl', 'normalizeRevisionId',
     `
     class Harness {
       constructor() {
@@ -86,6 +110,8 @@ function makeHarness({ postFeedback } = {}) {
         if (params) for (const k of Object.keys(params)) s = s.split('{' + k + '}').join(String(params[k]));
         return s;
       }
+${classMethod('getArticleRevisionId')}
+${classMethod('getRevisionPermalinkUrl')}
 ${feedbackMethods()}
     }
     return Harness;
@@ -104,6 +130,7 @@ ${feedbackMethods()}
     buildFeedbackPayload,
     payload => postFeedbackStub(payload),
     buildCommentUrl,
+    normalizeRevisionId,
   );
 
   return {
@@ -331,6 +358,37 @@ test('choosing a correction updates the comment link to carry it', async () => {
   assert.match(after, /Editor says it should be:''' SUPPORTED/);
 });
 
+// Reproducibility: the preloaded section has to name the revision that was
+// checked, and link it, or a reader coming to the talk page later has no fixed
+// page to compare a second run against.
+test('the comment link carries the revision the check ran against', () => {
+  const ctx = makeHarness();
+  ctx.harness.buildFeedbackControls(RESULT);
+  const body = new URL(ctx.byLabel('Comment').cfg.href).searchParams.get('preloadparams[]');
+  assert.match(
+    body,
+    /revision \[https:\/\/en\.wikipedia\.org\/w\/index\.php\?title=Barack_Obama&oldid=1234567 1234567\]/,
+  );
+});
+
+// wgRevisionId is the revision on screen, which is the one that was read.
+// Naming wgCurRevisionId while an old revision is displayed would record a
+// page the tool never saw.
+test('viewing an old revision records that revision, not the current one', () => {
+  const ctx = makeHarness({ config: { wgRevisionId: 111, wgCurRevisionId: 999 } });
+  ctx.harness.buildFeedbackControls(RESULT);
+  const body = new URL(ctx.byLabel('Comment').cfg.href).searchParams.get('preloadparams[]');
+  assert.match(body, /revision \[\S+oldid=111 111\]/);
+  assert.equal(body.includes('999'), false);
+});
+
+test('a page with no revision of its own contributes no revision line', () => {
+  const ctx = makeHarness({ config: { wgRevisionId: 0, wgCurRevisionId: 0 } });
+  ctx.harness.buildFeedbackControls(RESULT);
+  const body = new URL(ctx.byLabel('Comment').cfg.href).searchParams.get('preloadparams[]');
+  assert.equal(body.includes('revision'), false);
+});
+
 test('the preloaded text matches what the pure builder produces', () => {
   const ctx = makeHarness();
   ctx.harness.buildFeedbackControls(RESULT);
@@ -339,6 +397,8 @@ test('the preloaded text matches what the pure builder produces', () => {
     checkId: 'a7f3k2q9',
     articleUrl: 'https://en.wikipedia.org/wiki/Barack_Obama',
     articleTitle: 'Barack Obama',
+    revisionId: 1234567,
+    revisionUrl: 'https://en.wikipedia.org/w/index.php?title=Barack_Obama&oldid=1234567',
     citationNumber: '12',
     claimText: 'He was born in Honolulu.',
     sourceUrl: 'https://example.com/source',


### PR DESCRIPTION
Johnjbarton's point on the talk page: a feedback report that names only the article is not reproducible. The plain link points at whatever the page says today, so a disagreement about a verdict can't be separated from a later edit to the claim, and two prompt or model versions can't be compared because they were never shown the same text.

So the revision travels with the check on both paths. `revision_id` goes into the /log payload alongside the article, and the Article line of the Check details box gains `, revision [<permalink> 1234567]` — inside the collapsed box, since it is tool output, and linked so the fixed page is one click away.

The id read is `wgRevisionId`, the revision actually on screen and so the one that was read, falling back to `wgCurRevisionId`. They differ only when an old revision is being viewed, which is exactly the case where naming the current one would record a page the tool never saw. `normalizeRevisionId()` is the single gate: a positive integer or null, which both keeps the log column numeric and makes the value inert wikitext by construction. It rejects `wgRevisionId`'s 0 — a preview or a special page, which is not a revision. `verifyAllCitations()` now takes its report revision from the same helper.

Also moves `MAX_MANUAL_SOURCE_CHARS` below the </core-injected> marker. It had no counterpart in core/, so it was living on borrowed time inside the injected region: the first `npm run build` after this change deleted it, taking loadManualSourceText() with it.


Claude-Session: https://claude.ai/code/session_011U1ujzs6sWsh6PsEVSiQ3j