### PR TITLE
Support keyless HF Inference and ad-hoc hf:<model-id> providers

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -417,9 +417,13 @@ or when a WMF-funded inference path becomes available through the proxy.
 | `hf-gpt-oss-20b` | `openai/gpt-oss-20b` | Apache 2.0 |
 | `hf-deepseek-v3` | `deepseek-ai/DeepSeek-V3` | MIT |
 
-Set `HF_TOKEN` (Hugging Face access token with serverless-inference
-permissions, plus the relevant backend providers enabled in your account
-settings at https://huggingface.co/settings/inference-providers) and run:
+`HF_TOKEN` is optional. If set (a Hugging Face access token with
+serverless-inference permissions, plus the relevant backend providers
+enabled in your account settings at
+https://huggingface.co/settings/inference-providers), calls go straight to
+`router.huggingface.co` on your own quota. If unset, calls fall back to the
+publicai-proxy worker's keyless `/hf` path, which injects an upstream token
+on your behalf — no account or token needed, but shared quota. Run:
 
 ```bash
 npm run benchmark:hf-panel    # 3-model sweep, ~2-4s per call
@@ -431,6 +435,19 @@ npm run analyze
 Alibaba model, gpt-oss-20b is an OpenAI MoE, DeepSeek-V3 is a DeepSeek
 MLA-attention MoE. The vote benefits from disagreement across training
 stacks rather than redundant signal from same-lineage models.
+
+#### Benchmarking any HF-hosted model
+
+Any model hosted on HF Inference Providers can be benchmarked without
+adding a `PROVIDERS` entry, by passing it inline as `hf:<model-id>`:
+
+```bash
+node run_benchmark.js --providers=hf:meta-llama/Llama-3.3-70B-Instruct --limit 10
+```
+
+This works the same keyless-or-`HF_TOKEN` way as the panel above, and can be
+mixed with predefined provider keys in the same `--providers` list
+(`--providers=claude-sonnet-4-5,hf:mistralai/Mistral-Small-24B-Instruct-2501`).
 
 DeepSeek-V3 (the original December 2024 release) is the panel choice
 rather than the newer V3.1 or V3.2-Exp because both newer variants emit

--- a/benchmark/run_benchmark.js
+++ b/benchmark/run_benchmark.js
@@ -11,6 +11,17 @@
  *   OPENAI_API_KEY - OpenAI API key
  *   GEMINI_API_KEY - Google Gemini API key
  *
+ * Hugging Face Inference models (providers of type 'huggingface', including
+ * any hf:<model-id> ad-hoc provider — see below) do not require HF_TOKEN.
+ * Without it, calls route through the publicai-proxy worker's keyless /hf
+ * path, which injects an upstream token on the caller's behalf and shares
+ * that proxy's quota. Set HF_TOKEN to call router.huggingface.co directly
+ * on your own quota instead.
+ *
+ * Any model hosted on HF Inference Providers can be benchmarked without a
+ * predefined PROVIDERS entry by passing it as `hf:<model-id>`, e.g.:
+ *   node run_benchmark.js --providers=hf:meta-llama/Llama-3.3-70B-Instruct
+ *
  * Output:
  *   - results.json: Complete benchmark results
  */
@@ -41,7 +52,7 @@ const DATASET_PATH = path.join(__dirname, 'dataset.json');
 const RESULTS_PATH = path.join(__dirname, 'results.json');
 
 // Provider configurations
-const PROVIDERS = {
+export const PROVIDERS = {
     // Open-source models via PublicAI (direct API)
     'apertus-70b': {
         name: 'Apertus 70B',
@@ -147,7 +158,9 @@ const PROVIDERS = {
         keyEnv: 'OPENROUTER_API_KEY',
         type: 'openrouter'
     },
-    // Hugging Face Inference Providers — routed through router.huggingface.co.
+    // Hugging Face Inference Providers — routed through router.huggingface.co
+    // when HF_TOKEN is set, or through the publicai-proxy worker's keyless
+    // /hf path otherwise (see callHuggingFaceAPI in core/providers.js).
     // Same OpenAI-compatible request shape as OpenRouter; the per-provider
     // backend (Groq, Together, Fireworks, PublicAI, etc.) is auto-selected
     // by HF based on which providers the token has enabled. HF's response
@@ -157,7 +170,7 @@ const PROVIDERS = {
         name: 'Qwen3-32B (HF Inference)',
         model: 'Qwen/Qwen3-32B',
         endpoint: 'https://router.huggingface.co/v1/chat/completions',
-        requiresKey: true,
+        requiresKey: false,
         keyEnv: 'HF_TOKEN',
         type: 'huggingface'
     },
@@ -165,7 +178,7 @@ const PROVIDERS = {
         name: 'gpt-oss-20b (HF Inference)',
         model: 'openai/gpt-oss-20b',
         endpoint: 'https://router.huggingface.co/v1/chat/completions',
-        requiresKey: true,
+        requiresKey: false,
         keyEnv: 'HF_TOKEN',
         type: 'huggingface'
     },
@@ -173,17 +186,41 @@ const PROVIDERS = {
         name: 'DeepSeek-V3 (HF Inference)',
         model: 'deepseek-ai/DeepSeek-V3',
         endpoint: 'https://router.huggingface.co/v1/chat/completions',
-        requiresKey: true,
+        requiresKey: false,
         keyEnv: 'HF_TOKEN',
         type: 'huggingface'
     }
 };
 
+// Ad-hoc HF providers registered at runtime via `--providers=hf:<model-id>`
+// (see registerAdHocHfProvider below), so any model hosted on HF Inference
+// Providers can be benchmarked without adding a PROVIDERS entry for it.
+const HF_ADHOC_PREFIX = 'hf:';
+const HF_ADHOC_ENDPOINT = 'https://router.huggingface.co/v1/chat/completions';
+
+export function registerAdHocHfProvider(spec) {
+    const model = spec.slice(HF_ADHOC_PREFIX.length);
+    if (!model) {
+        throw new Error(`Invalid --providers entry "${spec}": expected hf:<model-id>, e.g. hf:meta-llama/Llama-3.3-70B-Instruct`);
+    }
+    if (!PROVIDERS[spec]) {
+        PROVIDERS[spec] = {
+            name: `${model} (HF Inference)`,
+            model,
+            endpoint: HF_ADHOC_ENDPOINT,
+            requiresKey: false,
+            keyEnv: 'HF_TOKEN',
+            type: 'huggingface'
+        };
+    }
+    return spec;
+}
+
 // Parse command line arguments
 const args = process.argv.slice(2);
 const providerArg = args.find(a => a.startsWith('--providers='));
 const selectedProviders = providerArg
-    ? providerArg.split('=')[1].split(',')
+    ? providerArg.split('=')[1].split(',').map(p => p.startsWith(HF_ADHOC_PREFIX) ? registerAdHocHfProvider(p) : p)
     : Object.keys(PROVIDERS);
 const limitIndex = args.indexOf('--limit');
 const LIMIT = limitIndex !== -1 ? parseInt(args[limitIndex + 1], 10) : null;
@@ -379,8 +416,10 @@ async function callOpenRouter(config, systemPrompt, userPrompt) {
 }
 
 async function callHuggingFace(config, systemPrompt, userPrompt) {
-    const apiKey = process.env[config.keyEnv];
-    if (!apiKey) throw new Error(`Missing ${config.keyEnv}`);
+    // Unlike other provider types, HF_TOKEN is optional: without it,
+    // callHuggingFaceAPI falls back to the publicai-proxy worker's keyless
+    // /hf path instead of throwing (see PROVIDERS' hf-* requiresKey: false).
+    const apiKey = process.env[config.keyEnv] || undefined;
     return shapeResult(await callHuggingFaceAPI({
         apiKey,
         model: config.model,

--- a/tests/benchmark_providers.test.js
+++ b/tests/benchmark_providers.test.js
@@ -10,7 +10,7 @@
 // cost_usd: null where the upstream API doesn't expose per-call cost.
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { callProvider } from '../benchmark/run_benchmark.js';
+import { callProvider, PROVIDERS, registerAdHocHfProvider, hostForProvider } from '../benchmark/run_benchmark.js';
 
 function withMockFetch(handler) {
     const original = globalThis.fetch;
@@ -122,4 +122,98 @@ test('callProvider returns ERROR shape when env var is missing', async () => {
         assert.match(result.error, /PUBLICAI_API_KEY/);
         assert.equal(typeof result.latency, 'number');
     });
+});
+
+// ---- Hugging Face: keyless mode ---------------------------------------------
+
+test('callProvider hf-* without HF_TOKEN routes through the keyless proxy /hf path', async () => {
+    const mock = withMockFetch(async () => ({
+        ok: true, status: 200,
+        json: async () => ({
+            choices: [{ message: { content: VERDICT_JSON } }],
+            usage: { prompt_tokens: 40, completion_tokens: 8 },
+        }),
+    }));
+    try {
+        await withEnv({ HF_TOKEN: undefined }, async () => {
+            const result = await callProvider('hf-qwen3-32b', 'sys', 'user');
+            assert.equal(result.error, null);
+            assert.equal(result.verdict, 'Supported');
+            assert.equal(mock.calls[0].url, 'https://publicai-proxy.alaexis.workers.dev/hf');
+            assert.equal(mock.calls[0].opts.headers['Authorization'], undefined);
+        });
+    } finally {
+        mock.restore();
+    }
+});
+
+test('callProvider hf-* with HF_TOKEN calls the HF router directly', async () => {
+    const mock = withMockFetch(async () => ({
+        ok: true, status: 200,
+        json: async () => ({
+            choices: [{ message: { content: VERDICT_JSON } }],
+            usage: { prompt_tokens: 40, completion_tokens: 8 },
+        }),
+    }));
+    try {
+        await withEnv({ HF_TOKEN: 'hf_test' }, async () => {
+            const result = await callProvider('hf-qwen3-32b', 'sys', 'user');
+            assert.equal(result.error, null);
+            assert.equal(mock.calls[0].url, 'https://router.huggingface.co/v1/chat/completions');
+            assert.equal(mock.calls[0].opts.headers['Authorization'], 'Bearer hf_test');
+        });
+    } finally {
+        mock.restore();
+    }
+});
+
+// ---- Hugging Face: ad-hoc hf:<model-id> providers ---------------------------
+
+test('registerAdHocHfProvider registers a keyless huggingface provider for the given model', () => {
+    const key = registerAdHocHfProvider('hf:meta-llama/Llama-3.3-70B-Instruct');
+    assert.equal(key, 'hf:meta-llama/Llama-3.3-70B-Instruct');
+    assert.deepEqual(PROVIDERS[key], {
+        name: 'meta-llama/Llama-3.3-70B-Instruct (HF Inference)',
+        model: 'meta-llama/Llama-3.3-70B-Instruct',
+        endpoint: 'https://router.huggingface.co/v1/chat/completions',
+        requiresKey: false,
+        keyEnv: 'HF_TOKEN',
+        type: 'huggingface',
+    });
+    // hostForProvider works the same as any predefined provider.
+    assert.equal(hostForProvider(key), 'router.huggingface.co');
+});
+
+test('registerAdHocHfProvider rejects a spec with no model id', () => {
+    assert.throws(() => registerAdHocHfProvider('hf:'), /expected hf:<model-id>/);
+});
+
+test('registerAdHocHfProvider is idempotent for the same model id', () => {
+    const first = registerAdHocHfProvider('hf:idempotent/test-model');
+    const second = registerAdHocHfProvider('hf:idempotent/test-model');
+    assert.equal(first, second);
+    assert.equal(Object.keys(PROVIDERS).filter(k => k === first).length, 1);
+});
+
+test('callProvider works end-to-end for an ad-hoc hf:<model-id> provider, keyless', async () => {
+    const mock = withMockFetch(async () => ({
+        ok: true, status: 200,
+        json: async () => ({
+            choices: [{ message: { content: VERDICT_JSON } }],
+            usage: { prompt_tokens: 25, completion_tokens: 6 },
+        }),
+    }));
+    try {
+        await withEnv({ HF_TOKEN: undefined }, async () => {
+            const key = registerAdHocHfProvider('hf:mistralai/Mistral-Small-24B-Instruct-2501');
+            const result = await callProvider(key, 'sys', 'user');
+            assert.equal(result.error, null);
+            assert.equal(result.verdict, 'Supported');
+            assert.equal(mock.calls[0].url, 'https://publicai-proxy.alaexis.workers.dev/hf');
+            const sent = JSON.parse(mock.calls[0].opts.body);
+            assert.equal(sent.model, 'mistralai/Mistral-Small-24B-Instruct-2501');
+        });
+    } finally {
+        mock.restore();
+    }
 });


### PR DESCRIPTION
## Summary

Enable benchmarking of any Hugging Face Inference model without requiring `HF_TOKEN`, and support ad-hoc provider registration via `hf:<model-id>` syntax on the command line.

## Changes

- **Keyless HF Inference:** Changed `requiresKey: true` to `requiresKey: false` for all predefined `hf-*` providers (`hf-qwen3-32b`, `hf-gpt-oss-20b`, `hf-deepseek-v3`). When `HF_TOKEN` is unset, calls now route through the publicai-proxy worker's keyless `/hf` path instead of throwing an error.

- **Ad-hoc provider registration:** Added `registerAdHocHfProvider(spec)` function to dynamically register any HF-hosted model at runtime. Users can now pass `--providers=hf:meta-llama/Llama-3.3-70B-Instruct` on the command line to benchmark models without adding them to the `PROVIDERS` object.

- **Command-line parsing:** Updated provider argument parsing to detect `hf:` prefix and call `registerAdHocHfProvider()` for matching entries.

- **Exports:** Exported `PROVIDERS`, `registerAdHocHfProvider`, and `hostForProvider` from `run_benchmark.js` to support testing and external use.

- **HF API call logic:** Updated `callHuggingFace()` to treat `HF_TOKEN` as optional (falls back to `undefined` instead of throwing), allowing the underlying `callHuggingFaceAPI()` to select the keyless proxy path.

- **Documentation:** Updated `run_benchmark.js` module docstring and `README.md` to explain keyless mode, quota sharing via the proxy, and the new ad-hoc syntax.

## Testing

Added comprehensive test coverage:
- Keyless routing (without `HF_TOKEN`) to publicai-proxy `/hf` path
- Direct routing (with `HF_TOKEN`) to `router.huggingface.co`
- Ad-hoc provider registration, validation, and idempotency
- End-to-end verification with ad-hoc providers

https://claude.ai/code/session_01NsCVdqRt1wmsSWxHJpmS1n