### PR TITLE
Fix double-counted errors in run_benchmark.js's printSummary

### DIFF
--- a/benchmark/run_benchmark.js
+++ b/benchmark/run_benchmark.js
@@ -651,7 +651,7 @@ async function main() {
                     quote_verified: quoteCheck.verified,
                     latency_ms: result.latency,
                     error: result.error,
-                    correct: compareVerdicts(result.verdict, entry.ground_truth),
+                    correct: scoreResult(result, entry.ground_truth),
                     timestamp: new Date().toISOString()
                 });
 
@@ -672,6 +672,17 @@ async function main() {
 
     // Print quick summary
     printSummary(results, availableProviders);
+}
+
+/**
+ * Score a single result row's `correct` field. A failed call (result.error set,
+ * result.verdict === 'ERROR') has no predicted verdict to compare — scoring it
+ * via compareVerdicts would fall through every branch to 'wrong', double-counting
+ * it in both Wrong and Errors in printSummary. null keeps error rows out of the
+ * correctness tally entirely; analyze_results.js already excludes them separately.
+ */
+export function scoreResult(result, groundTruth) {
+    return result.error ? null : compareVerdicts(result.verdict, groundTruth);
 }
 
 /**

--- a/tests/benchmark_runner.test.js
+++ b/tests/benchmark_runner.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-import { runPool, makeSaver, hostForProvider, shapeResult } from '../benchmark/run_benchmark.js';
+import { runPool, makeSaver, hostForProvider, shapeResult, scoreResult } from '../benchmark/run_benchmark.js';
 
 // ---- runPool ----------------------------------------------------------------
 
@@ -195,4 +195,24 @@ test('shapeResult: returns PARSE_ERROR sentinel on unrecoverable prose', () => {
     const out = shapeResult({ text: 'I cannot determine this.', usage: null });
     assert.equal(out.verdict, 'PARSE_ERROR');
     assert.equal(out.confidence, 0);
+});
+
+// ---- scoreResult (error rows must not be double-counted as "wrong") --------
+// Regression guard: a failed call has verdict 'ERROR', and compareVerdicts
+// falls through every branch to 'wrong' for an unrecognized predicted string
+// — printSummary counted such rows in both Wrong and Errors before this fix.
+
+test('scoreResult: returns null for a failed call, not "wrong"', () => {
+    const result = { error: 'API request failed (500)', verdict: 'ERROR' };
+    assert.equal(scoreResult(result, 'Supported'), null);
+});
+
+test('scoreResult: scores normally when the call succeeded', () => {
+    const result = { error: null, verdict: 'Supported' };
+    assert.equal(scoreResult(result, 'Supported'), 'exact');
+});
+
+test('scoreResult: a genuinely wrong (non-error) verdict still scores "wrong"', () => {
+    const result = { error: null, verdict: 'Supported' };
+    assert.equal(scoreResult(result, 'Not Supported'), 'wrong');
 });


### PR DESCRIPTION
Failed calls set result.verdict to the literal string 'ERROR', but the result row's `correct` field was still computed via compareVerdicts('ERROR', ground_truth). Every branch in compareVerdicts falls through to 'wrong' for a predicted string it doesn't recognize, so every errored row was counted in both Wrong and Errors in the quick console summary (visible e.g. as Wrong: 7/10 + Errors: 3/10 summing to more than the 10 total tasks).

Extract scoring into scoreResult(), which returns null for error rows instead of scoring them — they have no predicted verdict to judge. analyze_results.js (npm run analyze) already excluded error rows correctly via a separate filter, so this only affects run_benchmark.js's own end-of-run summary and the `correct` field persisted to results.json for errored rows.


Claude-Session: https://claude.ai/code/session_01NsCVdqRt1wmsSWxHJpmS1n