### PR TITLE
Keyless HF benchmarking follow-ups: Sonnet 5, thinking-block crash, results-wipe fix

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -180,6 +180,28 @@ The same flags apply for v3 (`extract:v3`, `benchmark:v3`, `analyze:v3`).
 Working with the expanded v1 + v2 + v3 set is the default — just run `npm run
 extract`, `npm run benchmark`, and `npm run analyze` with no flags.
 
+### Re-baselining: max_tokens 1000 → 16384 (2026-08-16)
+
+`BENCHMARK_MAX_TOKENS` was raised from 1000 to 16384 to match
+`core/providers.js`, so the benchmark measures the same output budget the
+userscript and CLI actually run under.
+
+Reasoning models (gpt-oss in particular) spend output tokens on hidden
+reasoning *before* writing the answer — roughly 1.5k–4k on this task. At 1000
+they ran out mid-reasoning and returned `finish_reason: "length"` with empty
+content, which the runner recorded as an error. Those rows were measuring the
+cap, not the model.
+
+**What this does and doesn't affect.** Raising a ceiling cannot change a
+response that already fit under it — sampling is unchanged and the model never
+sees the limit — so results for rows that did not truncate stay comparable
+across the boundary. Only previously-truncated rows change, and those were
+already failures. The real cost is that reasoning models now generate their
+full reasoning, so their latency and token spend rise to production levels.
+
+Runs recorded before this date carry the old cap. `results.json`'s `run_at`
+metadata is the marker.
+
 ## Reproducibility metadata
 
 `dataset.json` and `results.json` (plus any new frozen `*_vN.json` snapshots

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -475,10 +475,18 @@ matrices, quote fidelity — with no `entry_id`, no per-row predicted verdict,
 no comments, no quotes. It cannot be merged back into `results.json`, fed to
 `inspect_results.js`, or diffed with `npm run compare` (both need row-level
 data). It exists purely so the headline numbers from that run aren't lost
-too: Qwen3-32B 61.5% exact / 75.3% lenient / 77.5% binary; gpt-oss-20b 60.2%
-exact / 69.6% lenient / 69.6% binary. Re-running the panel (keyless, no
-account needed) would reproduce comparable numbers with full row-level
-data, but was not redone for this snapshot.
+too: Qwen3-32B 61.5% exact / 75.3% lenient / 77.5% binary / 74.2% supported-vs-rest;
+gpt-oss-20b 60.2% exact / 69.6% lenient / 69.6% binary / 76.8% supported-vs-rest.
+Re-running the panel (keyless, no account needed) would reproduce comparable
+numbers with full row-level data, but was not redone for this snapshot.
+
+`supportedVsRestAccuracy` was added to `analyze_results.js` (`equalSupportedVsRest`
+in `core/verdicts.js`) after this snapshot was generated, so it isn't in the
+original recovered file's per-provider `metrics` — it was back-filled by
+replaying `equalSupportedVsRest` against each cell of the already-present
+confusion matrix, which is sufficient to derive it exactly (verified: the
+matrix cell totals match the recorded `valid` count for both providers, 182
+and 181). No re-run or row-level data was needed for this one field.
 
 #### Benchmarking any HF-hosted model
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -458,6 +458,28 @@ Alibaba model, gpt-oss-20b is an OpenAI MoE, DeepSeek-V3 is a DeepSeek
 MLA-attention MoE. The vote benefits from disagreement across training
 stacks rather than redundant signal from same-lineage models.
 
+#### Frozen snapshot: keyless hf-qwen3-32b / hf-gpt-oss-20b, 2026-08-17
+
+`analysis_hf_keyless_2026-08-17.json` is a manually-recovered `analyze_results.js`
+snapshot from a full 182-row keyless run of `hf-qwen3-32b` and `hf-gpt-oss-20b`
+(0 and 1 errors respectively). The underlying `results.json` — the raw,
+per-row data — was lost to a bug in `run_benchmark.js`: a plain run with no
+`--resume` set `results = []` unconditionally, so a later 10-row
+`claude-sonnet-5` pilot run silently discarded these 364 rows. That bug is
+fixed (`loadInitialResults` now always preserves rows for any provider not
+in the current run, resume or not — see the commit for the full incident
+writeup), so this can't recur, but the raw rows themselves are gone.
+
+This file is **aggregate metrics only** — accuracy percentages, confusion
+matrices, quote fidelity — with no `entry_id`, no per-row predicted verdict,
+no comments, no quotes. It cannot be merged back into `results.json`, fed to
+`inspect_results.js`, or diffed with `npm run compare` (both need row-level
+data). It exists purely so the headline numbers from that run aren't lost
+too: Qwen3-32B 61.5% exact / 75.3% lenient / 77.5% binary; gpt-oss-20b 60.2%
+exact / 69.6% lenient / 69.6% binary. Re-running the panel (keyless, no
+account needed) would reproduce comparable numbers with full row-level
+data, but was not redone for this snapshot.
+
 #### Benchmarking any HF-hosted model
 
 Any model hosted on HF Inference Providers can be benchmarked without

--- a/benchmark/analysis_hf_keyless_2026-08-17.json
+++ b/benchmark/analysis_hf_keyless_2026-08-17.json
@@ -1,0 +1,142 @@
+{
+  "generated": "2026-08-17T20:47:52.609Z",
+  "overview": {
+    "datasetVersion": "all",
+    "totalEntries": 182,
+    "totalCalls": 364,
+    "providers": [
+      "hf-qwen3-32b",
+      "hf-gpt-oss-20b"
+    ]
+  },
+  "providers": {
+    "hf-qwen3-32b": {
+      "name": "Hf-qwen3-32b",
+      "model": "Qwen/Qwen3-32B",
+      "sampleCount": 182,
+      "metrics": {
+        "total": 182,
+        "valid": 182,
+        "errors": 0,
+        "quotes": {
+          "eligible": 109,
+          "offered": 109,
+          "verified": 86,
+          "offerRate": 1,
+          "fidelity": 0.7889908256880734,
+          "accuracyWhenQuoteVerified": 0.7441860465116279,
+          "accuracyWhenQuoteUnverified": 0.5652173913043478,
+          "verifiedRows": 86,
+          "unverifiedRows": 23,
+          "gap": 0.17896865520728011
+        },
+        "exactMatches": 112,
+        "partialMatches": 25,
+        "exactAccuracy": 0.6153846153846154,
+        "lenientAccuracy": 0.7527472527472527,
+        "binaryAccuracy": 0.7747252747252747,
+        "confusionMatrix": {
+          "Supported": {
+            "Supported": 53,
+            "Partially supported": 15,
+            "Not supported": 11,
+            "Source unavailable": 1
+          },
+          "Partially supported": {
+            "Supported": 10,
+            "Partially supported": 24,
+            "Not supported": 19,
+            "Source unavailable": 3
+          },
+          "Not supported": {
+            "Supported": 3,
+            "Partially supported": 4,
+            "Not supported": 35,
+            "Source unavailable": 4
+          },
+          "Source unavailable": {
+            "Supported": 0,
+            "Partially supported": 0,
+            "Not supported": 0,
+            "Source unavailable": 0
+          }
+        },
+        "latency": {
+          "avg": 10317.895604395604,
+          "min": 5064,
+          "max": 24405
+        },
+        "confidence": {
+          "avg": 56.3448275862069,
+          "avgWhenCorrect": 61.419642857142854,
+          "avgWhenWrong": 41.785714285714285,
+          "calibration": 19.63392857142857
+        }
+      }
+    },
+    "hf-gpt-oss-20b": {
+      "name": "Hf-gpt-oss-20b",
+      "model": "openai/gpt-oss-20b",
+      "sampleCount": 182,
+      "metrics": {
+        "total": 182,
+        "valid": 181,
+        "errors": 1,
+        "quotes": {
+          "eligible": 87,
+          "offered": 87,
+          "verified": 75,
+          "offerRate": 1,
+          "fidelity": 0.8620689655172413,
+          "accuracyWhenQuoteVerified": 0.7866666666666666,
+          "accuracyWhenQuoteUnverified": 0.6666666666666666,
+          "verifiedRows": 75,
+          "unverifiedRows": 12,
+          "gap": 0.12
+        },
+        "exactMatches": 109,
+        "partialMatches": 17,
+        "exactAccuracy": 0.6022099447513812,
+        "lenientAccuracy": 0.6961325966850829,
+        "binaryAccuracy": 0.6961325966850829,
+        "confusionMatrix": {
+          "Supported": {
+            "Supported": 47,
+            "Partially supported": 11,
+            "Not supported": 21,
+            "Source unavailable": 1
+          },
+          "Partially supported": {
+            "Supported": 6,
+            "Partially supported": 20,
+            "Not supported": 28,
+            "Source unavailable": 2
+          },
+          "Not supported": {
+            "Supported": 1,
+            "Partially supported": 2,
+            "Not supported": 42,
+            "Source unavailable": 0
+          },
+          "Source unavailable": {
+            "Supported": 0,
+            "Partially supported": 0,
+            "Not supported": 0,
+            "Source unavailable": 0
+          }
+        },
+        "latency": {
+          "avg": 1785.2747252747254,
+          "min": 694,
+          "max": 18690
+        },
+        "confidence": {
+          "avg": 61.17977528089887,
+          "avgWhenCorrect": 64.1743119266055,
+          "avgWhenWrong": 54.09722222222222,
+          "calibration": 10.077089704383276
+        }
+      }
+    }
+  }
+}

--- a/benchmark/analysis_hf_keyless_2026-08-17.json
+++ b/benchmark/analysis_hf_keyless_2026-08-17.json
@@ -35,6 +35,8 @@
         "exactAccuracy": 0.6153846153846154,
         "lenientAccuracy": 0.7527472527472527,
         "binaryAccuracy": 0.7747252747252747,
+        "supportedVsRestCorrect": 135,
+        "supportedVsRestAccuracy": 0.7417582417582418,
         "confusionMatrix": {
           "Supported": {
             "Supported": 53,
@@ -99,6 +101,8 @@
         "exactAccuracy": 0.6022099447513812,
         "lenientAccuracy": 0.6961325966850829,
         "binaryAccuracy": 0.6961325966850829,
+        "supportedVsRestCorrect": 139,
+        "supportedVsRestAccuracy": 0.7679558011049724,
         "confusionMatrix": {
           "Supported": {
             "Supported": 47,

--- a/benchmark/inspect_results.js
+++ b/benchmark/inspect_results.js
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+// Inspect individual result rows by outcome — the per-row detail behind the
+// counts run_benchmark.js's printSummary (or analyze_results.js) prints.
+// Joins results.json rows back to dataset.json by entry_id so you can see the
+// claim, ground truth, and what the model actually said, side by side.
+//
+// Usage:
+//   node inspect_results.js [--provider=<key>] [--status=wrong|partial|exact|error|all] [--limit=N] [--full]
+//
+// Examples:
+//   node inspect_results.js --provider=hf-qwen3-32b
+//   node inspect_results.js --provider=hf-qwen3-32b --status=partial --full
+//   node inspect_results.js --status=error --limit=50
+
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+import { loadRows } from './io.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const args = process.argv.slice(2);
+function argVal(name, def) {
+    const hit = args.find(a => a.startsWith(`--${name}=`));
+    return hit ? hit.slice(name.length + 3) : def;
+}
+const PROVIDER = argVal('provider', null);
+const STATUS = argVal('status', 'wrong'); // exact | partial | wrong | error | all
+const LIMIT = parseInt(argVal('limit', '20'), 10);
+const FULL = args.includes('--full');
+
+const DATASET_PATH = path.join(__dirname, 'dataset.json');
+const RESULTS_PATH = path.join(__dirname, 'results.json');
+
+const dataset = loadRows(DATASET_PATH);
+const datasetById = new Map(dataset.map(e => [e.id, e]));
+const results = loadRows(RESULTS_PATH);
+
+let rows = results;
+if (PROVIDER) rows = rows.filter(r => r.provider === PROVIDER);
+if (STATUS === 'error') {
+    rows = rows.filter(r => r.error);
+} else if (STATUS !== 'all') {
+    rows = rows.filter(r => r.correct === STATUS);
+}
+
+const truncate = (s, n = 220) => (!s ? s : (s.length > n ? s.slice(0, n) + '…' : s));
+
+console.log(`${rows.length} row(s) matching provider=${PROVIDER ?? 'any'} status=${STATUS}\n`);
+
+for (const r of rows.slice(0, LIMIT)) {
+    const entry = datasetById.get(r.entry_id);
+    const claim = entry?.claim_text ?? '(claim not found — dataset/results.json may be out of sync; see CLAUDE.md "row_id fragility")';
+
+    console.log('─'.repeat(72));
+    console.log(`${r.entry_id}  ·  ${r.provider}`);
+    console.log(`  ground truth : ${r.ground_truth}`);
+    console.log(`  predicted    : ${r.predicted_verdict}  (confidence ${r.confidence ?? 'n/a'})`);
+    if (r.error) console.log(`  error        : ${r.error}`);
+    console.log(`  claim        : ${FULL ? claim : truncate(claim)}`);
+    if (r.comments) console.log(`  model says   : ${FULL ? r.comments : truncate(r.comments)}`);
+    if (r.source_quote) console.log(`  quote (${r.quote_status ?? '?'})  : ${FULL ? r.source_quote : truncate(r.source_quote)}`);
+    if (entry?.source_url) console.log(`  source       : ${entry.source_url}`);
+}
+console.log('─'.repeat(72));
+if (rows.length > LIMIT) {
+    console.log(`\n(${rows.length - LIMIT} more not shown — raise --limit or narrow with --provider)`);
+}

--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -29,7 +29,8 @@
     "analyze:v3": "node analyze_results.js --version v3",
     "analyze:v3-snapshot": "node analyze_results.js --results results_v3.json --dataset dataset_v3.json --analysis analysis_v3_recomputed.json",
     "report": "node analyze_results.js --output report.md",
-    "compare": "node ../bin/ccs compare"
+    "compare": "node ../bin/ccs compare",
+    "inspect": "node inspect_results.js"
   },
   "dependencies": {
     "jsdom": "^24.0.0"

--- a/benchmark/run_benchmark.js
+++ b/benchmark/run_benchmark.js
@@ -344,7 +344,23 @@ export function shapeResult({ text, usage }) {
 // core/providers.js has its own defaults tuned for userscript/CLI use; the
 // runner overrides them here so that benchmark numbers stay comparable to
 // past runs until a deliberate re-baselining experiment changes them.
-const BENCHMARK_MAX_TOKENS = 1000;
+//
+// max_tokens was that deliberate change, on 2026-08-16: it was 1000, while
+// core/providers.js (and therefore the userscript and CLI) uses 16384. The gap
+// meant the benchmark was not measuring what production runs. Reasoning models
+// spend output tokens on hidden reasoning *before* writing the answer — gpt-oss
+// was measured at ~1.5k-4k reasoning tokens on this task — so at 1000 they
+// exhausted the budget mid-reasoning and returned finish_reason "length" with
+// empty content. Those rows scored as errors, not as verdicts: an artifact of
+// the cap, not a property of the model.
+//
+// Raising a ceiling cannot change a response that already fit under it —
+// sampling is identical and the model never sees the limit — so this only
+// affects rows that previously truncated, which were already failures. Past
+// non-truncated rows stay comparable. The cost is real but narrow: reasoning
+// models now generate their full reasoning, so their latency and token spend
+// rise to what production already pays.
+const BENCHMARK_MAX_TOKENS = 16384;
 const BENCHMARK_TEMPERATURE = 0.1;
 // The pre-consolidation runner concatenated `${systemPrompt}\n\n${userPrompt}`
 // into a single Gemini user turn rather than using the proper systemInstruction

--- a/benchmark/run_benchmark.js
+++ b/benchmark/run_benchmark.js
@@ -103,7 +103,14 @@ export const PROVIDERS = {
         endpoint: 'https://api.anthropic.com/v1/messages',
         requiresKey: true,
         keyEnv: 'ANTHROPIC_API_KEY',
-        type: 'claude'
+        type: 'claude',
+        // Sonnet 5 defaults to effort "high" on the Claude API when unset. Verdict
+        // classification on a fixed claim+source pair is a bounded task, not the
+        // intelligence-sensitive work "high" is meant for — "medium" trims thinking
+        // depth (and cost) as a middle ground against the "low" the skill would
+        // otherwise recommend for a task this simple. Sonnet 4.5 has no `effort`
+        // field: sending it there 400s, so this only applies where set explicitly.
+        effort: 'medium'
     },
     // Gemini
     'gemini-2.5-flash': {
@@ -401,6 +408,7 @@ async function callClaude(config, systemPrompt, userPrompt) {
         systemPrompt,
         userContent: userPrompt,
         maxTokens: BENCHMARK_MAX_TOKENS,
+        effort: config.effort,
         // Claude's body has historically not set temperature; preserved unchanged.
     }));
 }

--- a/benchmark/run_benchmark.js
+++ b/benchmark/run_benchmark.js
@@ -477,6 +477,24 @@ export function hostForProvider(provider, providers = PROVIDERS) {
 }
 
 /**
+ * Load prior results for --resume. A row that errored (rate limit, network
+ * failure, truncation, ...) has no verdict worth keeping and always needs a
+ * fresh attempt, so it's excluded from both the returned `results`
+ * accumulator and `completedIds` — otherwise it would either be skipped
+ * forever (never retried) or, once retried, sit alongside the new row as a
+ * duplicate entry_id/provider pair in results.json.
+ */
+export function loadResumeState(resultsPath) {
+    if (!fs.existsSync(resultsPath)) {
+        return { results: [], completedIds: new Set(), retrying: 0 };
+    }
+    const loaded = loadRows(resultsPath);
+    const results = loaded.filter(r => !r.error);
+    const completedIds = new Set(results.map(r => `${r.entry_id}|${r.provider}`));
+    return { results, completedIds, retrying: loaded.length - results.length };
+}
+
+/**
  * Run `worker` over `items` with at most `concurrency` in flight at once.
  */
 export async function runPool(items, concurrency, worker) {
@@ -587,12 +605,13 @@ async function main() {
 
     // Load existing results if resuming
     let results = [];
-    const completedIds = new Set();
+    let completedIds = new Set();
 
-    if (RESUME && fs.existsSync(RESULTS_PATH)) {
-        results = loadRows(RESULTS_PATH);
-        results.forEach(r => completedIds.add(`${r.entry_id}|${r.provider}`));
-        console.log(`Resuming: ${completedIds.size} results already completed`);
+    if (RESUME) {
+        const state = loadResumeState(RESULTS_PATH);
+        results = state.results;
+        completedIds = state.completedIds;
+        console.log(`Resuming: ${completedIds.size} results already completed` + (state.retrying ? ` (${state.retrying} errored row(s) will be retried)` : ''));
     }
 
     // Generate prompts

--- a/benchmark/run_benchmark.js
+++ b/benchmark/run_benchmark.js
@@ -493,21 +493,48 @@ export function hostForProvider(provider, providers = PROVIDERS) {
 }
 
 /**
- * Load prior results for --resume. A row that errored (rate limit, network
- * failure, truncation, ...) has no verdict worth keeping and always needs a
- * fresh attempt, so it's excluded from both the returned `results`
- * accumulator and `completedIds` — otherwise it would either be skipped
- * forever (never retried) or, once retried, sit alongside the new row as a
- * duplicate entry_id/provider pair in results.json.
+ * Load results.json to seed `results` and `completedIds` for this run.
+ *
+ * Rows for providers NOT in `selectedProviders` are always kept, resume or
+ * not — a run for provider A must never destroy data already collected for
+ * provider B in the same file. Before this function existed, a plain run
+ * (no --resume) set `results = []` unconditionally: the moment it completed,
+ * every other provider's rows in results.json were gone. That's exactly what
+ * happened on 2026-08-17 — a 10-row claude-sonnet-5 pilot run silently erased
+ * 364 rows (182 each) of hf-qwen3-32b / hf-gpt-oss-20b results with no
+ * warning, because `--resume` was the only thing standing between "add to
+ * the file" and "replace the file," and it's easy to forget on a quick
+ * one-off command. Loading (and protecting) existing rows is now unconditional;
+ * only what happens to the *selected* providers' own rows depends on `resume`.
+ *
+ * Within `selectedProviders`:
+ *   - resume: true  — keep those rows too, except errored ones (a failed call
+ *                      has no verdict worth keeping and always needs a fresh
+ *                      attempt — dropping it here, not just from completedIds,
+ *                      avoids a duplicate entry_id/provider row once retried).
+ *   - resume: false — drop all of those providers' existing rows; a plain run
+ *                      starts the *selected* providers over, scoped to just
+ *                      them rather than the whole file.
  */
-export function loadResumeState(resultsPath) {
+export function loadInitialResults(resultsPath, selectedProviders, resume) {
     if (!fs.existsSync(resultsPath)) {
         return { results: [], completedIds: new Set(), retrying: 0 };
     }
     const loaded = loadRows(resultsPath);
-    const results = loaded.filter(r => !r.error);
-    const completedIds = new Set(results.map(r => `${r.entry_id}|${r.provider}`));
-    return { results, completedIds, retrying: loaded.length - results.length };
+    const selected = new Set(selectedProviders);
+    const protectedRows = loaded.filter(r => !selected.has(r.provider));
+
+    if (!resume) {
+        return { results: protectedRows, completedIds: new Set(), retrying: 0 };
+    }
+
+    const ownRows = loaded.filter(r => selected.has(r.provider) && !r.error);
+    const retrying = loaded.filter(r => selected.has(r.provider) && r.error).length;
+    return {
+        results: [...protectedRows, ...ownRows],
+        completedIds: new Set(ownRows.map(r => `${r.entry_id}|${r.provider}`)),
+        retrying,
+    };
 }
 
 /**
@@ -619,15 +646,14 @@ async function main() {
 
     console.log(`\nProviders to benchmark: ${availableProviders.join(', ')}`);
 
-    // Load existing results if resuming
-    let results = [];
-    let completedIds = new Set();
-
+    // Load existing results. Rows for providers not in this run are always
+    // kept (see loadInitialResults) — only the selected providers' own rows
+    // depend on --resume.
+    const initialState = loadInitialResults(RESULTS_PATH, availableProviders, RESUME);
+    let results = initialState.results;
+    let completedIds = initialState.completedIds;
     if (RESUME) {
-        const state = loadResumeState(RESULTS_PATH);
-        results = state.results;
-        completedIds = state.completedIds;
-        console.log(`Resuming: ${completedIds.size} results already completed` + (state.retrying ? ` (${state.retrying} errored row(s) will be retried)` : ''));
+        console.log(`Resuming: ${completedIds.size} results already completed` + (initialState.retrying ? ` (${initialState.retrying} errored row(s) will be retried)` : ''));
     }
 
     // Generate prompts

--- a/benchmark/run_benchmark.js
+++ b/benchmark/run_benchmark.js
@@ -97,6 +97,14 @@ export const PROVIDERS = {
         keyEnv: 'ANTHROPIC_API_KEY',
         type: 'claude'
     },
+    'claude-sonnet-5': {
+        name: 'Claude Sonnet 5',
+        model: 'claude-sonnet-5',
+        endpoint: 'https://api.anthropic.com/v1/messages',
+        requiresKey: true,
+        keyEnv: 'ANTHROPIC_API_KEY',
+        type: 'claude'
+    },
     // Gemini
     'gemini-2.5-flash': {
         name: 'Gemini 2.5 Flash',
@@ -697,6 +705,15 @@ async function main() {
                     latency_ms: result.latency,
                     error: result.error,
                     correct: scoreResult(result, entry.ground_truth),
+                    // input/output are raw token counts from the upstream response,
+                    // present for every provider. cost_usd is only non-null for
+                    // OpenRouter, which is the one upstream that returns per-call
+                    // cost directly — everywhere else it's null and the $ cost has
+                    // to be computed from input/output against that provider's
+                    // published rate card.
+                    tokens_in: result.usage?.input ?? null,
+                    tokens_out: result.usage?.output ?? null,
+                    cost_usd: result.usage?.cost_usd ?? null,
                     timestamp: new Date().toISOString()
                 });
 

--- a/core/providers.js
+++ b/core/providers.js
@@ -151,13 +151,19 @@ export async function callOpenRouterAPI({ apiKey, model, systemPrompt, userConte
     });
 }
 
-export async function callClaudeAPI({ apiKey, model, systemPrompt, userContent, maxTokens = 3000 }) {
+// `effort` sets output_config.effort ("low"|"medium"|"high"|"xhigh"|"max") — GA,
+// no beta header needed. Only pass it for models that support the effort ladder
+// (Sonnet 5, Opus 5/4.8/4.7, Fable 5, Opus 4.6/Sonnet 4.6); Sonnet 4.5 and Haiku
+// 4.5 don't recognize it and return 400, so it must stay opt-in per caller rather
+// than a blanket default here.
+export async function callClaudeAPI({ apiKey, model, systemPrompt, userContent, maxTokens = 3000, effort }) {
     const requestBody = {
         model: model,
         max_tokens: maxTokens,
         system: systemPrompt,
         messages: [{ role: "user", content: userContent }]
     };
+    if (effort) requestBody.output_config = { effort };
 
     const response = await fetch('https://api.anthropic.com/v1/messages', {
         method: 'POST',

--- a/core/providers.js
+++ b/core/providers.js
@@ -182,8 +182,17 @@ export async function callClaudeAPI({ apiKey, model, systemPrompt, userContent, 
     }
 
     const data = await response.json();
+    // content[0] is not necessarily the answer: a model with adaptive thinking
+    // on (Sonnet 5, Opus 5/4.7/4.8, Fable 5 — enabled by default when `thinking`
+    // is omitted, unlike Sonnet 4.6/Opus 4.6 which require it explicitly) returns
+    // a `thinking` block first, which has no `.text`. Find the actual text block
+    // instead of indexing blindly.
+    const textBlock = data.content?.find(block => block.type === 'text');
+    if (!textBlock) {
+        throw new Error(`Invalid API response format (Claude: no text block${data.stop_reason ? `, stop_reason "${data.stop_reason}"` : ''})`);
+    }
     return {
-        text: data.content[0].text,
+        text: textBlock.text,
         usage: {
             input: data.usage?.input_tokens || 0,
             output: data.usage?.output_tokens || 0,

--- a/docs/hf-keyless-and-sonnet-5-benchmark.md
+++ b/docs/hf-keyless-and-sonnet-5-benchmark.md
@@ -1,0 +1,132 @@
+# Keyless HF Inference + Claude Sonnet 5 — benchmark results (2026-08-17)
+
+## Overview
+
+Three models were benchmarked on 2026-08-17 against the current 182-row dataset
+and the current system prompt (`core/prompts.js`): **Qwen3-32B** and
+**gpt-oss-20b** via Hugging Face Inference's keyless proxy path, and
+**Claude Sonnet 5** via the direct Anthropic API. This document covers those
+three. For the original four-model benchmark (Claude Sonnet 4.5, Gemini 2.5
+Flash, Apertus-70B, Qwen-SEA-LION), see
+[`docs/llm-benchmarking-overview.md`](llm-benchmarking-overview.md) — referenced
+below for context, not reproduced here.
+
+**Raw data:**
+- Qwen3-32B / gpt-oss-20b: [`benchmark/analysis_hf_keyless_2026-08-17.json`](../benchmark/analysis_hf_keyless_2026-08-17.json)
+  — aggregate metrics only; the underlying per-row `results.json` was lost to a
+  since-fixed bug (see [Caveats](#caveats-read-before-comparing) below).
+- Claude Sonnet 5: local `results.json` only at time of writing — not yet
+  committed. Only the headline metrics below have been captured; a fuller
+  breakdown (confusion matrix, quote fidelity, confidence calibration) can be
+  added later from the same file via `node analyze_results.js`.
+
+## Headline comparison
+
+| Model | Exact | Lenient | Binary | Supported-vs-rest | Avg latency | Errors |
+|---|---|---|---|---|---|---|
+| Qwen3-32B | 61.5% | 75.3% | 77.5% | 74.2% | 10,318ms | 0/182 |
+| gpt-oss-20b | 60.2% | 69.6% | 69.6% | 76.8% | 1,785ms | 1/182 |
+| Claude Sonnet 5 | 54.4% | 64.8% | 73.6% | 70.3% | 3,444ms | 0/182 |
+
+Metric definitions: see `benchmark/README.md` § Metrics Explained. In short —
+**exact** requires an identical verdict; **lenient** additionally forgives
+Supported↔Partially-supported; **binary** collapses to
+{Supported,Partially-supported} vs {Not-supported,Source-unavailable};
+**supported-vs-rest** requires Supported and Source-unavailable to match
+exactly but forgives Partially-supported↔Not-supported as mutual near-misses
+(this is the grouping `docs/llm-benchmarking-overview.md`'s original "Lenient
+Accuracy" section describes).
+
+## Per-model detail
+
+### Qwen3-32B (`Qwen/Qwen3-32B`, via HF Inference)
+
+- 182/182 valid, 0 errors.
+- Quote fidelity: offered a quote on 109/109 eligible rows (100% offer rate);
+  86 of those 109 were actually located in the source text (78.9% fidelity).
+- Accuracy when the quote verified: 74.4%, vs. 56.5% when it didn't — an
+  18-point gap. A verified quote is a meaningfully stronger signal that the
+  verdict is trustworthy for this model.
+- Confidence: averaged 56.3 overall, 61.4 on correct rows vs. 41.8 on wrong
+  ones (19.6-point calibration gap) — confidence tracks correctness
+  reasonably well, though the average confidence is fairly low across the board.
+- By far the slowest of the three: 10.3s average latency, up to 24.4s on the
+  slowest row.
+
+### gpt-oss-20b (`openai/gpt-oss-20b`, via HF Inference)
+
+- 181/182 valid, 1 error.
+- Quote fidelity: 87/87 eligible rows offered a quote (100%), 75 of those
+  verified in-source (86.2% fidelity) — the best fidelity of the three models
+  in this run.
+- Accuracy when the quote verified: 78.7% vs. 66.7% unverified (12-point gap)
+  — a smaller gap than Qwen3-32B's, meaning its unverified-quote rows are
+  still reasonably trustworthy.
+- Fastest of the three by a wide margin: 1.8s average latency (vs. Qwen's
+  10.3s and Sonnet 5's 3.4s) — despite being architecturally a reasoning
+  model, it did not spend heavily on hidden reasoning tokens on this task
+  once given headroom (`BENCHMARK_MAX_TOKENS` raised to 16384 this same day;
+  under the old 1000-token cap this model could not complete most rows at
+  all — see [Caveats](#caveats-read-before-comparing)).
+- Notably **leads on supported-vs-rest (76.8%) despite the lowest exact
+  accuracy of the three** — 30 of its 45 non-exact-match wrong rows were a
+  Partially-supported↔Not-supported confusion, which that metric forgives
+  and the others don't (or don't as fully).
+
+### Claude Sonnet 5 (`claude-sonnet-5`, direct API)
+
+- 182/182 valid, 0 errors.
+- Ran with `output_config.effort: "medium"` (see `run_benchmark.js`'s
+  `PROVIDERS['claude-sonnet-5']`) rather than the API default of `"high"` —
+  a deliberate cost/latency tradeoff for this benchmark, not necessarily
+  Sonnet 5's ceiling on this task under maximum reasoning effort.
+- Lowest exact (54.4%) and lenient (64.8%) accuracy of the three, but a
+  binary accuracy (73.6%) reasonably close to the pack — similar to how
+  Claude Sonnet 4.5 behaved in the original four-model benchmark (see
+  [Caveats](#caveats-read-before-comparing)): a wider-than-usual gap between
+  exact/lenient and binary/supported-vs-rest, suggesting more of its misses
+  land as a confident wrong verdict rather than a Partial/Not near-miss.
+- Confusion matrix, quote fidelity, and confidence calibration not yet
+  captured for this write-up — see the note under Raw data above.
+
+## Caveats (read before comparing)
+
+**These three ran under directly comparable conditions with each other** —
+same 182-row dataset, same system prompt, same day, same
+`BENCHMARK_MAX_TOKENS` (16384). The comparisons above, among these three, are
+fair.
+
+**Comparing against the older four-model benchmark is not fair without
+adjustment**, for several independent reasons:
+
+1. **Row count differs.** The older run (`claude-sonnet-4-5`,
+   `gemini-2.5-flash`, `apertus-70b`, `qwen-sealion`) has 186 rows each in
+   `results.json`; these three ran on 182. The dataset has shifted by a few
+   rows since then (row corrections / `needs_manual_review` changes).
+2. **`BENCHMARK_MAX_TOKENS` was 1000 for the older run, 16384 for this one.**
+   This matters most for reasoning-capable models: gpt-oss-20b specifically
+   could not complete most rows under the old 1000-token cap (see
+   `benchmark/README.md` § "Re-baselining: max_tokens 1000 → 16384") — a
+   like-for-like comparison against an older reasoning-model run isn't
+   possible because the older cap made that class of model largely unusable.
+3. **The system prompt has changed** between the two runs (most recently:
+   source-quote extraction, 2026-08-04) — the older run's Claude Sonnet 4.5
+   number reflects an earlier prompt version, not today's.
+4. **Two of these three models' raw per-row data is gone.** Qwen3-32B's and
+   gpt-oss-20b's `results.json` rows were lost to a bug (a plain benchmark run
+   with no `--resume` silently discarded every other provider's rows — fixed
+   in `loadInitialResults`, see `benchmark/run_benchmark.js`). Only the
+   aggregate metrics in `analysis_hf_keyless_2026-08-17.json` survive for
+   those two; `inspect_results.js`-style row inspection and `npm run compare`
+   diffing are not possible against them. Claude Sonnet 5's raw rows are
+   intact (as of writing, only locally).
+5. **Single run, no repeated trials.** All numbers above are from one pass at
+   temperature 0.1 (except Sonnet 5's `effort: medium`, which doesn't map to
+   a temperature). No variance/confidence interval has been measured across
+   repeated runs for any of the six models discussed here (these three or the
+   original four).
+
+Given (2) and (3) especially, treat any "model X beat model Y" claim spanning
+the two benchmark rounds with real skepticism — most of the older-round
+providers would need to be re-run under the current prompt and token cap
+before that comparison means anything.

--- a/docs/llm-benchmarking-overview.md
+++ b/docs/llm-benchmarking-overview.md
@@ -1,5 +1,11 @@
 # Wikipedia Citation Verification - LLM Benchmarking
 
+> For a later round covering Qwen3-32B, gpt-oss-20b (both via keyless HF
+> Inference), and Claude Sonnet 5, see
+> [`docs/hf-keyless-and-sonnet-5-benchmark.md`](hf-keyless-and-sonnet-5-benchmark.md)
+> — that document also explains why its numbers aren't directly comparable to
+> the ones below (different dataset row count, token cap, and prompt version).
+
 ## Overview
 
 This document describes a benchmarking exercise conducted to evaluate the performance of various Large Language Models (LLMs) on the task of verifying Wikipedia citations, that is, determining whether claims in Wikipedia articles are supported by their cited sources.

--- a/main.js
+++ b/main.js
@@ -1221,13 +1221,19 @@ async function callOpenRouterAPI({ apiKey, model, systemPrompt, userContent, max
     });
 }
 
-async function callClaudeAPI({ apiKey, model, systemPrompt, userContent, maxTokens = 3000 }) {
+// `effort` sets output_config.effort ("low"|"medium"|"high"|"xhigh"|"max") — GA,
+// no beta header needed. Only pass it for models that support the effort ladder
+// (Sonnet 5, Opus 5/4.8/4.7, Fable 5, Opus 4.6/Sonnet 4.6); Sonnet 4.5 and Haiku
+// 4.5 don't recognize it and return 400, so it must stay opt-in per caller rather
+// than a blanket default here.
+async function callClaudeAPI({ apiKey, model, systemPrompt, userContent, maxTokens = 3000, effort }) {
     const requestBody = {
         model: model,
         max_tokens: maxTokens,
         system: systemPrompt,
         messages: [{ role: "user", content: userContent }]
     };
+    if (effort) requestBody.output_config = { effort };
 
     const response = await fetch('https://api.anthropic.com/v1/messages', {
         method: 'POST',

--- a/main.js
+++ b/main.js
@@ -1252,8 +1252,17 @@ async function callClaudeAPI({ apiKey, model, systemPrompt, userContent, maxToke
     }
 
     const data = await response.json();
+    // content[0] is not necessarily the answer: a model with adaptive thinking
+    // on (Sonnet 5, Opus 5/4.7/4.8, Fable 5 — enabled by default when `thinking`
+    // is omitted, unlike Sonnet 4.6/Opus 4.6 which require it explicitly) returns
+    // a `thinking` block first, which has no `.text`. Find the actual text block
+    // instead of indexing blindly.
+    const textBlock = data.content?.find(block => block.type === 'text');
+    if (!textBlock) {
+        throw new Error(`Invalid API response format (Claude: no text block${data.stop_reason ? `, stop_reason "${data.stop_reason}"` : ''})`);
+    }
     return {
-        text: data.content[0].text,
+        text: textBlock.text,
         usage: {
             input: data.usage?.input_tokens || 0,
             output: data.usage?.output_tokens || 0,

--- a/tests/benchmark_providers.test.js
+++ b/tests/benchmark_providers.test.js
@@ -89,6 +89,31 @@ test('callProvider claude returns parsed verdict and usage shape', async () => {
             assert.equal(result.usage.output, 30);
             assert.equal(result.usage.cost_usd, null);
             assert.equal(result.error, null);
+            // Sonnet 4.5 doesn't support the effort ladder (400s if sent) — the
+            // provider config carries no `effort` field, so none should be sent.
+            const sent = JSON.parse(mock.calls[0].opts.body);
+            assert.equal(sent.output_config, undefined);
+        });
+    } finally {
+        mock.restore();
+    }
+});
+
+test('callProvider claude-sonnet-5 sends effort: medium', async () => {
+    const mock = withMockFetch(async () => ({
+        ok: true, status: 200,
+        json: async () => ({
+            content: [{ text: VERDICT_JSON }],
+            usage: { input_tokens: 200, output_tokens: 30 },
+        }),
+    }));
+    try {
+        await withEnv({ ANTHROPIC_API_KEY: 'test' }, async () => {
+            const result = await callProvider('claude-sonnet-5', 'sys', 'user');
+            assert.equal(result.verdict, 'Supported');
+            assert.equal(result.error, null);
+            const sent = JSON.parse(mock.calls[0].opts.body);
+            assert.deepEqual(sent.output_config, { effort: 'medium' });
         });
     } finally {
         mock.restore();

--- a/tests/benchmark_providers.test.js
+++ b/tests/benchmark_providers.test.js
@@ -77,7 +77,7 @@ test('callProvider claude returns parsed verdict and usage shape', async () => {
     const mock = withMockFetch(async () => ({
         ok: true, status: 200,
         json: async () => ({
-            content: [{ text: VERDICT_JSON }],
+            content: [{ type: 'text', text: VERDICT_JSON }],
             usage: { input_tokens: 200, output_tokens: 30 },
         }),
     }));
@@ -103,7 +103,7 @@ test('callProvider claude-sonnet-5 sends effort: medium', async () => {
     const mock = withMockFetch(async () => ({
         ok: true, status: 200,
         json: async () => ({
-            content: [{ text: VERDICT_JSON }],
+            content: [{ type: 'text', text: VERDICT_JSON }],
             usage: { input_tokens: 200, output_tokens: 30 },
         }),
     }));

--- a/tests/benchmark_providers.test.js
+++ b/tests/benchmark_providers.test.js
@@ -42,7 +42,7 @@ function withEnv(vars, fn) {
     });
 }
 
-test('callProvider publicai returns parsed verdict and usage shape, max_tokens=1000', async () => {
+test('callProvider publicai returns parsed verdict and usage shape, max_tokens=16384', async () => {
     const mock = withMockFetch(async () => ({
         ok: true, status: 200,
         json: async () => ({
@@ -61,10 +61,12 @@ test('callProvider publicai returns parsed verdict and usage shape, max_tokens=1
             assert.equal(result.usage.cost_usd, null);
             assert.equal(result.error, null);
             assert.equal(typeof result.latency, 'number');
-            // Benchmark holds max_tokens at 1000 across providers (preserves
-            // pre-consolidation runner behavior; see BENCHMARK_MAX_TOKENS).
+            // Benchmark max_tokens matches core/providers.js (16384) so the
+            // benchmark measures what the userscript and CLI actually run.
+            // It was 1000 until 2026-08-16, which truncated reasoning models
+            // mid-reasoning and scored them as errors — see BENCHMARK_MAX_TOKENS.
             const sent = JSON.parse(mock.calls[0].opts.body);
-            assert.equal(sent.max_tokens, 1000);
+            assert.equal(sent.max_tokens, 16384);
         });
     } finally {
         mock.restore();

--- a/tests/benchmark_runner.test.js
+++ b/tests/benchmark_runner.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-import { runPool, makeSaver, hostForProvider, shapeResult, scoreResult } from '../benchmark/run_benchmark.js';
+import { runPool, makeSaver, hostForProvider, shapeResult, scoreResult, loadResumeState } from '../benchmark/run_benchmark.js';
 
 // ---- runPool ----------------------------------------------------------------
 
@@ -215,4 +215,63 @@ test('scoreResult: scores normally when the call succeeded', () => {
 test('scoreResult: a genuinely wrong (non-error) verdict still scores "wrong"', () => {
     const result = { error: null, verdict: 'Supported' };
     assert.equal(scoreResult(result, 'Not Supported'), 'wrong');
+});
+
+// ---- loadResumeState (--resume must retry errored rows, not skip them) -----
+// Regression guard: `--resume` used to mark a row "completed" as soon as it
+// existed in results.json at all, including rows that errored. That meant a
+// transient failure (rate limit, network blip) was skipped forever on every
+// future --resume — see the 2026-08-16 keyless-HF-benchmark investigation.
+
+test('loadResumeState: an error row is excluded from completedIds so it gets retried', () => {
+    const file = tmpFile('resume-errors');
+    fs.writeFileSync(file, JSON.stringify({
+        metadata: {},
+        rows: [
+            { entry_id: 'row_1', provider: 'hf-qwen3-32b', predicted_verdict: 'Supported', error: null },
+            { entry_id: 'row_2', provider: 'hf-qwen3-32b', predicted_verdict: 'ERROR', error: 'HTTP 429' },
+        ],
+    }));
+    try {
+        const state = loadResumeState(file);
+        assert.equal(state.completedIds.has('row_1|hf-qwen3-32b'), true);
+        assert.equal(state.completedIds.has('row_2|hf-qwen3-32b'), false);
+        assert.equal(state.retrying, 1);
+    } finally {
+        fs.rmSync(file, { force: true });
+    }
+});
+
+test('loadResumeState: an error row is dropped from `results` so a retry does not duplicate it', () => {
+    const file = tmpFile('resume-drop');
+    fs.writeFileSync(file, JSON.stringify({
+        metadata: {},
+        rows: [{ entry_id: 'row_2', provider: 'hf-qwen3-32b', predicted_verdict: 'ERROR', error: 'HTTP 429' }],
+    }));
+    try {
+        const state = loadResumeState(file);
+        assert.deepEqual(state.results, []);
+    } finally {
+        fs.rmSync(file, { force: true });
+    }
+});
+
+test('loadResumeState: a successful row is kept in `results` and not re-run', () => {
+    const file = tmpFile('resume-keep');
+    const row = { entry_id: 'row_1', provider: 'hf-qwen3-32b', predicted_verdict: 'Supported', error: null };
+    fs.writeFileSync(file, JSON.stringify({ metadata: {}, rows: [row] }));
+    try {
+        const state = loadResumeState(file);
+        assert.deepEqual(state.results, [row]);
+        assert.equal(state.retrying, 0);
+    } finally {
+        fs.rmSync(file, { force: true });
+    }
+});
+
+test('loadResumeState: a missing results file resumes as empty, not an error', () => {
+    const state = loadResumeState(path.join(os.tmpdir(), 'does-not-exist-' + Math.random().toString(36).slice(2) + '.json'));
+    assert.deepEqual(state.results, []);
+    assert.equal(state.completedIds.size, 0);
+    assert.equal(state.retrying, 0);
 });

--- a/tests/benchmark_runner.test.js
+++ b/tests/benchmark_runner.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-import { runPool, makeSaver, hostForProvider, shapeResult, scoreResult, loadResumeState } from '../benchmark/run_benchmark.js';
+import { runPool, makeSaver, hostForProvider, shapeResult, scoreResult, loadInitialResults } from '../benchmark/run_benchmark.js';
 
 // ---- runPool ----------------------------------------------------------------
 
@@ -217,13 +217,21 @@ test('scoreResult: a genuinely wrong (non-error) verdict still scores "wrong"', 
     assert.equal(scoreResult(result, 'Not Supported'), 'wrong');
 });
 
-// ---- loadResumeState (--resume must retry errored rows, not skip them) -----
-// Regression guard: `--resume` used to mark a row "completed" as soon as it
+// ---- loadInitialResults ------------------------------------------------------
+// Regression guard #1: `--resume` used to mark a row "completed" as soon as it
 // existed in results.json at all, including rows that errored. That meant a
 // transient failure (rate limit, network blip) was skipped forever on every
 // future --resume — see the 2026-08-16 keyless-HF-benchmark investigation.
+//
+// Regression guard #2 (the more serious one): a plain run with no --resume
+// used to set `results = []` unconditionally, discarding EVERY provider's
+// rows the moment it completed — not just the providers being run. On
+// 2026-08-17 a 10-row `--providers=claude-sonnet-5` pilot with no --resume
+// silently erased 364 rows (182 each) of hf-qwen3-32b / hf-gpt-oss-20b data.
+// Rows for a provider not in the current run must survive regardless of
+// --resume; only the selected providers' own rows depend on it.
 
-test('loadResumeState: an error row is excluded from completedIds so it gets retried', () => {
+test('loadInitialResults: resume=true excludes an error row from completedIds so it gets retried', () => {
     const file = tmpFile('resume-errors');
     fs.writeFileSync(file, JSON.stringify({
         metadata: {},
@@ -233,7 +241,7 @@ test('loadResumeState: an error row is excluded from completedIds so it gets ret
         ],
     }));
     try {
-        const state = loadResumeState(file);
+        const state = loadInitialResults(file, ['hf-qwen3-32b'], true);
         assert.equal(state.completedIds.has('row_1|hf-qwen3-32b'), true);
         assert.equal(state.completedIds.has('row_2|hf-qwen3-32b'), false);
         assert.equal(state.retrying, 1);
@@ -242,26 +250,26 @@ test('loadResumeState: an error row is excluded from completedIds so it gets ret
     }
 });
 
-test('loadResumeState: an error row is dropped from `results` so a retry does not duplicate it', () => {
+test('loadInitialResults: resume=true drops an error row from `results` so a retry does not duplicate it', () => {
     const file = tmpFile('resume-drop');
     fs.writeFileSync(file, JSON.stringify({
         metadata: {},
         rows: [{ entry_id: 'row_2', provider: 'hf-qwen3-32b', predicted_verdict: 'ERROR', error: 'HTTP 429' }],
     }));
     try {
-        const state = loadResumeState(file);
+        const state = loadInitialResults(file, ['hf-qwen3-32b'], true);
         assert.deepEqual(state.results, []);
     } finally {
         fs.rmSync(file, { force: true });
     }
 });
 
-test('loadResumeState: a successful row is kept in `results` and not re-run', () => {
+test('loadInitialResults: resume=true keeps a successful row and does not re-run it', () => {
     const file = tmpFile('resume-keep');
     const row = { entry_id: 'row_1', provider: 'hf-qwen3-32b', predicted_verdict: 'Supported', error: null };
     fs.writeFileSync(file, JSON.stringify({ metadata: {}, rows: [row] }));
     try {
-        const state = loadResumeState(file);
+        const state = loadInitialResults(file, ['hf-qwen3-32b'], true);
         assert.deepEqual(state.results, [row]);
         assert.equal(state.retrying, 0);
     } finally {
@@ -269,9 +277,57 @@ test('loadResumeState: a successful row is kept in `results` and not re-run', ()
     }
 });
 
-test('loadResumeState: a missing results file resumes as empty, not an error', () => {
-    const state = loadResumeState(path.join(os.tmpdir(), 'does-not-exist-' + Math.random().toString(36).slice(2) + '.json'));
-    assert.deepEqual(state.results, []);
-    assert.equal(state.completedIds.size, 0);
-    assert.equal(state.retrying, 0);
+test('loadInitialResults: a missing results file resumes as empty, not an error', () => {
+    const missing = path.join(os.tmpdir(), 'does-not-exist-' + Math.random().toString(36).slice(2) + '.json');
+    for (const resume of [true, false]) {
+        const state = loadInitialResults(missing, ['hf-qwen3-32b'], resume);
+        assert.deepEqual(state.results, []);
+        assert.equal(state.completedIds.size, 0);
+        assert.equal(state.retrying, 0);
+    }
+});
+
+test('loadInitialResults: resume=false still preserves rows for a provider not in this run', () => {
+    const file = tmpFile('protect-other-providers');
+    const hfRow = { entry_id: 'row_1', provider: 'hf-qwen3-32b', predicted_verdict: 'Supported', error: null };
+    fs.writeFileSync(file, JSON.stringify({ metadata: {}, rows: [hfRow] }));
+    try {
+        const state = loadInitialResults(file, ['claude-sonnet-5'], false);
+        assert.deepEqual(state.results, [hfRow]);
+    } finally {
+        fs.rmSync(file, { force: true });
+    }
+});
+
+test('loadInitialResults: resume=false drops existing rows for the providers being run', () => {
+    const file = tmpFile('restart-selected');
+    const staleRow = { entry_id: 'row_1', provider: 'claude-sonnet-5', predicted_verdict: 'Wrong', error: null };
+    fs.writeFileSync(file, JSON.stringify({ metadata: {}, rows: [staleRow] }));
+    try {
+        const state = loadInitialResults(file, ['claude-sonnet-5'], false);
+        assert.deepEqual(state.results, []);
+        assert.equal(state.completedIds.size, 0);
+    } finally {
+        fs.rmSync(file, { force: true });
+    }
+});
+
+test('loadInitialResults: a mixed-provider file survives a run for just one of them, resume or not', () => {
+    const file = tmpFile('mixed-providers');
+    const rows = [
+        { entry_id: 'row_1', provider: 'hf-qwen3-32b', predicted_verdict: 'Supported', error: null },
+        { entry_id: 'row_1', provider: 'hf-gpt-oss-20b', predicted_verdict: 'Supported', error: null },
+        { entry_id: 'row_1', provider: 'claude-sonnet-5', predicted_verdict: 'Supported', error: null },
+    ];
+    fs.writeFileSync(file, JSON.stringify({ metadata: {}, rows }));
+    try {
+        for (const resume of [true, false]) {
+            const state = loadInitialResults(file, ['claude-sonnet-5'], resume);
+            const providers = state.results.map(r => r.provider).sort();
+            assert.ok(providers.includes('hf-qwen3-32b'), `hf-qwen3-32b missing when resume=${resume}`);
+            assert.ok(providers.includes('hf-gpt-oss-20b'), `hf-gpt-oss-20b missing when resume=${resume}`);
+        }
+    } finally {
+        fs.rmSync(file, { force: true });
+    }
 });

--- a/tests/providers.test.js
+++ b/tests/providers.test.js
@@ -28,7 +28,7 @@ test('callClaudeAPI sends Anthropic headers and parses response', async () => {
     ok: true,
     status: 200,
     json: async () => ({
-      content: [{ text: 'OK' }],
+      content: [{ type: 'text', text: 'OK' }],
       usage: { input_tokens: 10, output_tokens: 5 },
     }),
   }));
@@ -332,7 +332,7 @@ test('callProviderAPI dispatches to the named provider', async () => {
   const mock = withMockFetch(async () => ({
     ok: true,
     status: 200,
-    json: async () => ({ content: [{ text: 'via-dispatcher' }], usage: {} }),
+    json: async () => ({ content: [{ type: 'text', text: 'via-dispatcher' }], usage: {} }),
   }));
   try {
     const result = await callProviderAPI('claude', {
@@ -589,7 +589,7 @@ test('callClaudeAPI honors maxTokens parameter', async () => {
     ok: true,
     status: 200,
     json: async () => ({
-      content: [{ text: 'ok' }],
+      content: [{ type: 'text', text: 'ok' }],
       usage: { input_tokens: 0, output_tokens: 0 },
     }),
   }));
@@ -613,7 +613,7 @@ test('callClaudeAPI sets output_config.effort when effort is passed', async () =
     ok: true,
     status: 200,
     json: async () => ({
-      content: [{ text: 'ok' }],
+      content: [{ type: 'text', text: 'ok' }],
       usage: { input_tokens: 0, output_tokens: 0 },
     }),
   }));
@@ -637,7 +637,7 @@ test('callClaudeAPI omits output_config when effort is not passed', async () => 
     ok: true,
     status: 200,
     json: async () => ({
-      content: [{ text: 'ok' }],
+      content: [{ type: 'text', text: 'ok' }],
       usage: { input_tokens: 0, output_tokens: 0 },
     }),
   }));
@@ -838,6 +838,61 @@ test('callClaudeAPI throws on non-ok response', async () => {
     await assert.rejects(
       () => callClaudeAPI({ apiKey: 'bad', model: 'm', systemPrompt: 's', userContent: 'u' }),
       /401/
+    );
+  } finally {
+    mock.restore();
+  }
+});
+
+// Regression guard: a model with adaptive thinking on (Sonnet 5, Opus 5/4.7/4.8,
+// Fable 5 — enabled by default when `thinking` is omitted, which this codebase
+// never sets) returns a `thinking` block before the `text` block. Indexing
+// content[0] blindly grabbed the thinking block, which has no `.text`, and
+// downstream parsing crashed on `undefined.trim()` — surfaced as
+// "Cannot read properties of undefined (reading 'trim')" with no indication
+// this was a Claude response-shape issue. Sonnet 4.6/Opus 4.6 don't hit this
+// (thinking requires opting in there), which is why it wasn't caught earlier.
+
+test('callClaudeAPI finds the text block when a thinking block precedes it', async () => {
+  const mock = withMockFetch(async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({
+      content: [
+        { type: 'thinking', thinking: 'reasoning about the claim...' },
+        { type: 'text', text: 'the actual verdict JSON' },
+      ],
+      usage: { input_tokens: 10, output_tokens: 50 },
+    }),
+  }));
+  try {
+    const result = await callClaudeAPI({
+      apiKey: 'k', model: 'claude-sonnet-5', systemPrompt: 's', userContent: 'u', effort: 'medium',
+    });
+    assert.equal(result.text, 'the actual verdict JSON');
+  } finally {
+    mock.restore();
+  }
+});
+
+test('callClaudeAPI throws a clear error when no text block is present', async () => {
+  const mock = withMockFetch(async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({
+      content: [{ type: 'thinking', thinking: 'only reasoning, no answer' }],
+      usage: { input_tokens: 10, output_tokens: 50 },
+      stop_reason: 'max_tokens',
+    }),
+  }));
+  try {
+    await assert.rejects(
+      () => callClaudeAPI({ apiKey: 'k', model: 'claude-sonnet-5', systemPrompt: 's', userContent: 'u' }),
+      (err) => {
+        assert.match(err.message, /no text block/);
+        assert.match(err.message, /max_tokens/);
+        return true;
+      }
     );
   } finally {
     mock.restore();

--- a/tests/providers.test.js
+++ b/tests/providers.test.js
@@ -608,6 +608,53 @@ test('callClaudeAPI honors maxTokens parameter', async () => {
   }
 });
 
+test('callClaudeAPI sets output_config.effort when effort is passed', async () => {
+  const mock = withMockFetch(async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({
+      content: [{ text: 'ok' }],
+      usage: { input_tokens: 0, output_tokens: 0 },
+    }),
+  }));
+  try {
+    await callClaudeAPI({
+      apiKey: 'k',
+      model: 'claude-sonnet-5',
+      systemPrompt: 's',
+      userContent: 'u',
+      effort: 'medium',
+    });
+    const sent = JSON.parse(mock.calls[0].opts.body);
+    assert.deepEqual(sent.output_config, { effort: 'medium' });
+  } finally {
+    mock.restore();
+  }
+});
+
+test('callClaudeAPI omits output_config when effort is not passed', async () => {
+  const mock = withMockFetch(async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({
+      content: [{ text: 'ok' }],
+      usage: { input_tokens: 0, output_tokens: 0 },
+    }),
+  }));
+  try {
+    await callClaudeAPI({
+      apiKey: 'k',
+      model: 'claude-sonnet-4-5-20250929',
+      systemPrompt: 's',
+      userContent: 'u',
+    });
+    const sent = JSON.parse(mock.calls[0].opts.body);
+    assert.equal(sent.output_config, undefined);
+  } finally {
+    mock.restore();
+  }
+});
+
 test('callGeminiAPI honors maxTokens parameter (maps to maxOutputTokens)', async () => {
   const mock = withMockFetch(async () => ({
     ok: true,


### PR DESCRIPTION
## Summary

Branch `claude/keyless-hf-benchmark-dtjglk` had already been merged three times (#293, #295, #297) before these 8 commits were pushed on top of it with no open PR tracking them. Rebased onto current `main` (which has since gained the WiCE benchmark suite and `supportedVsRestAccuracy`) and opening this fresh PR to track the unmerged work properly.

- **`inspect_results.js`**: per-row inspection tool for benchmark outcomes, joins `results.json` back to `dataset.json` by `entry_id`.
- **`BENCHMARK_MAX_TOKENS` 1000 → 16384**: matches `core/providers.js`'s production default; the old cap truncated reasoning models (gpt-oss) mid-reasoning and scored the truncation as an error.
- **`--resume` no longer treats errored rows as done**: a failed call (rate limit, network blip) was marked "completed" the moment it existed in `results.json`, so it was skipped forever on every future `--resume`.
- **`claude-sonnet-5` provider**, with `effort: medium` (Sonnet 5 defaults to `high` when unset — too deep for a bounded verdict-classification task) and per-row `tokens_in`/`tokens_out`/`cost_usd` now persisted so real spend is visible instead of discarded.
- **Fixed a `callClaudeAPI` crash**: it indexed `data.content[0].text` unconditionally, which broke the moment a model with thinking-on-by-default (Sonnet 5) put a `thinking` block first. Not a live incident — `main.js`/`cli/verify.js` are pinned to `claude-sonnet-4-6`, which doesn't auto-enable thinking — but it blocked every `claude-sonnet-5` benchmark call until fixed.
- **Fixed a real data-loss bug**: a plain run with no `--resume` set `results = []` unconditionally, discarding every provider's rows, not just the ones being run. A 10-row `claude-sonnet-5` pilot with no `--resume` silently erased 364 rows of `hf-qwen3-32b`/`hf-gpt-oss-20b` results this way. `loadInitialResults()` now always protects rows for providers outside the current run, resume or not.
- **`analysis_hf_keyless_2026-08-17.json`**: the recovered aggregate-only snapshot from the run above (raw per-row data was unrecoverable), committed so the headline numbers survive even though the rows don't.

## Test plan

- [x] `npm test` — 402 pass, 13 fail (same 13 pre-existing failures on `main`, unrelated to this branch — i18n, `cli`, `urls`, etc.)
- [x] `npm run build` / `node scripts/sync-main.js --check` — `main.js` in sync with `core/`
- [x] Rebase onto current `main` was clean, no conflicts
- [x] Manually reproduced and fixed the `callClaudeAPI` thinking-block crash against a real Sonnet 5 pilot run

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01NsCVdqRt1wmsSWxHJpmS1n)_