### PR TITLE
Add contract tests for tf-source-fetcher and tf-llm-router

### DIFF
--- a/cli/verify.js
+++ b/cli/verify.js
@@ -16,6 +16,19 @@ import { parseCompareArgs, COMPARE_HELP_TEXT, runCompare } from './compare.js';
 
 const KNOWN_PROVIDERS = ['publicai', 'huggingface', 'claude', 'gemini', 'openai'];
 
+// Experimental: opt-in override that routes the huggingface provider's proxy
+// call through the tf-llm-router Toolforge tool
+// (https://github.com/alex-o-748/tf-llm-router) instead of the Cloudflare
+// Worker CORS proxy, mirroring the same override in main.js
+// (useToolforgeLlmRouter). Unlike tf-source-fetcher, tf-llm-router's README
+// carries no WMCS gating caveat — it's opt-in because it's new and its
+// Toolforge rate-limit behavior is still unverified, not because it's
+// policy-blocked. Only applies to huggingface routed via the proxy (no
+// HF_API_KEY set) — with a key the call goes directly to HF's router and
+// workerBase is irrelevant; publicai isn't routed here at all, since
+// tf-llm-router doesn't implement a publicai-shaped route.
+const TOOLFORGE_LLM_ROUTER_BASE = 'https://llm-router.toolforge.org';
+
 export function parseCliArgs(argv) {
     const raw = argv.slice(2);
 
@@ -47,6 +60,7 @@ function parseVerifyArgs(args) {
         options: {
             provider: { type: 'string', default: 'huggingface' },
             'no-log': { type: 'boolean', default: false },
+            'live-llm-router': { type: 'boolean', default: false },
             help:     { type: 'boolean', short: 'h', default: false },
         },
         allowPositionals: true,
@@ -75,6 +89,7 @@ function parseVerifyArgs(args) {
         citationNumber,
         provider,
         noLog: values['no-log'],
+        liveLlmRouter: values['live-llm-router'],
     };
 }
 
@@ -197,6 +212,10 @@ Options:
                        openai      (requires OPENAI_API_KEY)
   --no-log           Do not log the verification to the worker proxy's
                      /log endpoint.
+  --live-llm-router  Route the huggingface provider through tf-llm-router
+                     (https://github.com/alex-o-748/tf-llm-router) instead
+                     of the Cloudflare Worker proxy. Experimental; no effect
+                     unless --provider huggingface and HF_API_KEY is unset.
   --help, -h         Show this help and exit.
 
 Exit codes:
@@ -216,6 +235,7 @@ Examples:
   ccs verify https://en.wikipedia.org/wiki/Great_Migration_(African_American) 14
   ccs verify https://en.wikipedia.org/wiki/Foo 3 --provider claude
   ccs verify https://en.wikipedia.org/wiki/Foo?oldid=1234567 3 --no-log
+  ccs verify https://en.wikipedia.org/wiki/Foo 3 --live-llm-router
 `;
 
 export const TOP_LEVEL_HELP_TEXT = `usage: ccs <subcommand> [...]
@@ -251,7 +271,7 @@ async function fetchWikipediaHtml(restUrl) {
 }
 
 export async function runVerify(opts, { stdout = process.stdout, stderr = process.stderr, env = process.env } = {}) {
-    const { url, citationNumber, provider, noLog } = opts;
+    const { url, citationNumber, provider, noLog, liveLlmRouter } = opts;
 
     // 1. Check API key availability up-front (exit 8).
     const envVar = PROVIDER_ENV_VARS[provider];
@@ -331,14 +351,22 @@ export async function runVerify(opts, { stdout = process.stdout, stderr = proces
     const systemPrompt = generateSystemPrompt();
     const userContent = generateUserPrompt(claim, fetchResult.content);
     const optionalEnvVar = PROVIDER_OPTIONAL_ENV_VARS[provider];
+    const apiKey = envVar
+        ? env[envVar]
+        : (optionalEnvVar ? env[optionalEnvVar] : undefined);
     const providerConfig = {
         model: PROVIDER_MODELS[provider],
         systemPrompt,
         userContent,
-        apiKey: envVar
-            ? env[envVar]
-            : (optionalEnvVar ? env[optionalEnvVar] : undefined),
+        apiKey,
     };
+
+    // See TOOLFORGE_LLM_ROUTER_BASE above: only meaningful for the proxy-routed
+    // huggingface call (no apiKey — a direct HF call ignores workerBase entirely).
+    if (liveLlmRouter && provider === 'huggingface' && !apiKey) {
+        stderr.write(`ccs: routing huggingface via ${TOOLFORGE_LLM_ROUTER_BASE}\n`);
+        providerConfig.workerBase = TOOLFORGE_LLM_ROUTER_BASE;
+    }
 
     let providerResult;
     try {

--- a/service/extract-articles.js
+++ b/service/extract-articles.js
@@ -1,17 +1,21 @@
 #!/usr/bin/env node
-// Runnable validation script for pipeline stages 1-2: selects candidate
+// Runnable validation script for pipeline stages 1-3: selects candidate
 // articles from Wiki Replicas, fetches each one's real rendered HTML from the
-// Wikipedia REST API, and extracts its citations and claims.
+// Wikipedia REST API, extracts its citations and claims, and (opt-in only)
+// fetches the cited sources via the tf-source-fetcher Toolforge tool
+// (https://github.com/alex-o-748/tf-source-fetcher).
 //
-// Stage 3 (fetching the cited sources) is deliberately stubbed here — that
-// step is blocked on the source-fetcher Toolforge tool, which does not exist
-// yet. Every citation with a URL will report "source fetching not wired up"
-// until it does. This script exists to validate everything up to that point
-// without depending on it.
+// Stage 3 defaults to a stub. tf-source-fetcher is built and deployable, but
+// per its own README, unattended fetching of third-party publisher URLs from
+// Wikimedia infrastructure has not yet been cleared with WMCS — so no batch
+// job may be pointed at it as a matter of course. Pass --live-source-fetch to
+// opt in for a one-off manual smoke test (e.g. from a Toolforge bastion,
+// after checking WMCS clearance); every other run stays stubbed.
 //
 // Usage (on a Toolforge bastion, inside the tool account):
 //   node service/extract-articles.js
 //   node service/extract-articles.js --criterion citation-needed --max 5
+//   node service/extract-articles.js --live-source-fetch --max 1
 
 import { JSDOM } from 'jsdom';
 import { parseArgs } from 'node:util';
@@ -19,15 +23,22 @@ import { openReplicaConnection, makeQueryFn } from './replicas.js';
 import { selectCandidates, CRITERIA } from './selection.js';
 import { runBatch, ARTICLE_OUTCOMES } from './pipeline.js';
 import { fetchArticleHtml } from '../core/wikipedia.js';
+import { fetchSourceContent } from '../core/worker.js';
+
+// Same contract, same query shape (?fetch=&page=), same Google-Books-skip and
+// Wayback-fallback behavior as the reference Cloudflare Worker proxy — see
+// that repo's README ("Behavior carried over from the reference Worker").
+const TOOLFORGE_SOURCE_FETCHER_BASE = 'https://source-fetcher.toolforge.org';
 
 function parseCliArgs(argv) {
     const { values } = parseArgs({
         args: argv.slice(2),
         options: {
-            criterion: { type: 'string', default: 'failed-verification' },
-            wiki:      { type: 'string', default: 'enwiki' },
-            max:       { type: 'string', default: '3' },
-            help:      { type: 'boolean', short: 'h', default: false },
+            criterion:        { type: 'string', default: 'failed-verification' },
+            wiki:             { type: 'string', default: 'enwiki' },
+            max:              { type: 'string', default: '3' },
+            'live-source-fetch': { type: 'boolean', default: false },
+            help:             { type: 'boolean', short: 'h', default: false },
         },
         strict: true,
     });
@@ -37,6 +48,7 @@ function parseCliArgs(argv) {
         criterion: values.criterion,
         wiki: values.wiki,
         max: Number(values.max),
+        liveSourceFetch: values['live-source-fetch'],
     };
 }
 
@@ -44,13 +56,18 @@ const HELP_TEXT = `usage: node service/extract-articles.js [options]
 
 Selects candidate articles from Wiki Replicas, fetches each one's real
 rendered HTML, and extracts its citations and claims. Source fetching (stage
-3) is stubbed — this validates selection and extraction only.
+3) is stubbed by default — pass --live-source-fetch to fetch real sources via
+tf-source-fetcher for a one-off manual smoke test. Per that service's own
+README, it is not yet cleared by WMCS for unattended production traffic, so
+--live-source-fetch is opt-in only and should not be used in a scheduled job.
 
 Options:
   --criterion <name>  Selection criterion. One of: ${Object.keys(CRITERIA).join(', ')}
                        (default: failed-verification)
   --wiki <db>          Wiki database name, e.g. enwiki, frwiki (default: enwiki)
   --max <n>            Maximum articles to process (default: 3)
+  --live-source-fetch  Fetch real sources via tf-source-fetcher instead of the
+                        stub. Manual smoke-test use only (see above).
   --help, -h           Show this help and exit.
 `;
 
@@ -63,8 +80,20 @@ async function stubFetchSource() {
     return {
         content: null,
         status: null,
-        error: 'source fetching not wired up yet — waiting on the source-fetcher Toolforge tool',
+        error: 'source fetching not wired up — pass --live-source-fetch to fetch via tf-source-fetcher',
     };
+}
+
+async function liveFetchSource(url, pageNum) {
+    return fetchSourceContent(url, pageNum, { workerBase: TOOLFORGE_SOURCE_FETCHER_BASE });
+}
+
+function describeSource(source) {
+    if (source.content) {
+        const cached = source.cached ? ', cached' : '';
+        return `fetched, ${source.content.length} chars (status ${source.status}${cached})`;
+    }
+    return `unavailable (${source.unavailableReason}, status ${source.status}): ${source.error}`;
 }
 
 function printArticle(result) {
@@ -87,6 +116,9 @@ function printArticle(result) {
         const claim = c.claimText.length > 100 ? `${c.claimText.slice(0, 100)}…` : c.claimText;
         process.stdout.write(`  [${c.citationNumber}] ${claim}\n`);
         process.stdout.write(`      url: ${c.url || '(none)'}\n`);
+        if (c.url) {
+            process.stdout.write(`      source: ${describeSource(c.source)}\n`);
+        }
     }
     process.stdout.write('\n');
 
@@ -127,6 +159,13 @@ async function main(argv) {
         await connection.end();
     }
 
+    if (opts.liveSourceFetch) {
+        process.stderr.write(
+            `WARNING: --live-source-fetch is on — fetching real sources via ${TOOLFORGE_SOURCE_FETCHER_BASE}. ` +
+            `Confirm WMCS has cleared unattended fetching before using this outside a manual smoke test.\n`
+        );
+    }
+
     process.stderr.write(`selected ${candidates.length} article(s); fetching and extracting...\n\n`);
 
     let totalCitations = 0;
@@ -145,7 +184,7 @@ async function main(argv) {
         for await (const result of runBatch(candidates, {
             parseHtml,
             fetchArticle: fetchArticleHtml,
-            fetchSource: stubFetchSource,
+            fetchSource: opts.liveSourceFetch ? liveFetchSource : stubFetchSource,
         })) {
             const { citations, withUrl } = printArticle(result);
             totalCitations += citations;

--- a/tests/llm_router_contract.test.js
+++ b/tests/llm_router_contract.test.js
@@ -1,0 +1,246 @@
+// Contract test for tf-llm-router (https://github.com/alex-o-748/tf-llm-router).
+//
+// Unlike tests/providers.test.js, which mocks globalThis.fetch with
+// hand-shaped response objects to exercise callHuggingFaceAPI() /
+// callLiftwingAPI()'s own parsing logic, this file spins up a *real* local
+// HTTP server that implements tf-llm-router's documented API verbatim
+// (routes, request/response shapes, and the error-status table — all copied
+// from that repo's README as of 2026-08-10) and points the client at it over
+// real HTTP. The point is to catch drift between what that service's README
+// promises and what this client actually sends/parses, independent of
+// either repo's own unit tests. If tf-llm-router's contract changes, update
+// the fixture responses here to match its new README before assuming this
+// client still works against it.
+//
+// ccs verify's --live-llm-router flag is the only caller of this contract in
+// this repo today.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { callHuggingFaceAPI, callLiftwingAPI } from '../core/providers.js';
+
+// Routes a request by a marker in the request body's `model` field, mirroring
+// the exact shapes and status codes documented in tf-llm-router's README.
+function startFixtureServer() {
+    const requests = [];
+
+    const server = http.createServer((req, res) => {
+        let body = '';
+        req.on('data', (c) => { body += c; });
+        req.on('end', () => {
+            requests.push({ method: req.method, path: req.url, headers: req.headers, body });
+
+            const send = (httpStatus, json) => {
+                const payload = JSON.stringify(json);
+                res.writeHead(httpStatus, { 'Content-Type': 'application/json' });
+                res.end(payload);
+            };
+
+            if (req.method !== 'POST') {
+                return send(405, { error: { message: 'Method not allowed' } });
+            }
+            if (req.url !== '/hf' && req.url !== '/liftwing') {
+                return send(404, { error: { message: 'Unknown route' } });
+            }
+
+            let parsed;
+            try {
+                parsed = JSON.parse(body);
+            } catch {
+                return send(400, { error: { message: 'Malformed JSON' } });
+            }
+
+            // README: "Response" — a normal completion.
+            if (parsed.model === 'llm-ok') {
+                return send(200, {
+                    choices: [{ message: { content: 'verdict text' }, finish_reason: 'stop' }],
+                    usage: { prompt_tokens: 120, completion_tokens: 30 },
+                });
+            }
+
+            // README: "finish_reason: 'length' with empty content is passed
+            // through faithfully" — the model ran out of budget reasoning.
+            if (parsed.model === 'llm-truncated') {
+                return send(200, {
+                    choices: [{ message: { content: '' }, finish_reason: 'length' }],
+                    usage: { prompt_tokens: 120, completion_tokens: parsed.max_tokens },
+                });
+            }
+
+            // README error table: "Malformed JSON / model not allowlisted" -> 400.
+            if (parsed.model === 'llm-not-allowlisted') {
+                return send(400, { error: { message: 'model not in allowlist' } });
+            }
+
+            // README error table: "Local rate limit (if enabled)" -> 429.
+            if (parsed.model === 'llm-rate-limited') {
+                res.setHeader('Retry-After', '5');
+                return send(429, { error: { message: 'rate limit exceeded' } });
+            }
+
+            // README error table: "Upstream 401/403" -> mapped to 502, upstream
+            // detail preserved in the message (never passed through as-is,
+            // since it's our credential that was rejected, not the caller's).
+            if (parsed.model === 'llm-upstream-auth-fail') {
+                return send(502, { error: { message: 'upstream rejected credentials (401): invalid token' } });
+            }
+
+            // README error table: "Any other upstream status" -> passed
+            // through verbatim.
+            if (parsed.model === 'llm-upstream-503') {
+                return send(503, { error: { message: 'upstream temporarily unavailable' } });
+            }
+
+            // README error table: "Body over the size cap" -> 413.
+            if (parsed.model === 'llm-body-too-large') {
+                return send(413, { error: { message: 'request body too large' } });
+            }
+
+            return send(400, { error: { message: `fixture has no route for model ${parsed.model}` } });
+        });
+    });
+
+    return new Promise((resolve) => {
+        server.listen(0, '127.0.0.1', () => {
+            const { port } = server.address();
+            resolve({
+                workerBase: `http://127.0.0.1:${port}`,
+                requests,
+                close: () => new Promise((r) => server.close(r)),
+            });
+        });
+    });
+}
+
+test('callHuggingFaceAPI posts the documented request shape to /hf', async () => {
+    const fixture = await startFixtureServer();
+    try {
+        await callHuggingFaceAPI({
+            model: 'llm-ok',
+            systemPrompt: 'sys',
+            userContent: 'user',
+            workerBase: fixture.workerBase,
+        });
+        assert.equal(fixture.requests.length, 1);
+        const req = fixture.requests[0];
+        assert.equal(req.method, 'POST');
+        assert.equal(req.path, '/hf');
+        assert.equal(req.headers['content-type'], 'application/json');
+        // README: "No Authorization header — the service injects any
+        // credential the upstream needs" when the client has no apiKey.
+        assert.equal(req.headers['authorization'], undefined);
+        const sent = JSON.parse(req.body);
+        assert.equal(sent.model, 'llm-ok');
+        assert.deepEqual(sent.messages, [
+            { role: 'system', content: 'sys' },
+            { role: 'user', content: 'user' },
+        ]);
+        assert.equal(typeof sent.max_tokens, 'number');
+    } finally {
+        await fixture.close();
+    }
+});
+
+test('callLiftwingAPI posts the documented request shape to /liftwing', async () => {
+    const fixture = await startFixtureServer();
+    try {
+        const result = await callLiftwingAPI({
+            model: 'llm-ok',
+            systemPrompt: 'sys',
+            userContent: 'user',
+            workerBase: fixture.workerBase,
+        });
+        assert.equal(result.text, 'verdict text');
+        assert.equal(result.usage.input, 120);
+        assert.equal(result.usage.output, 30);
+        assert.equal(fixture.requests[0].path, '/liftwing');
+    } finally {
+        await fixture.close();
+    }
+});
+
+test('callHuggingFaceAPI reports the "ran out of output budget" case for finish_reason length', async () => {
+    const fixture = await startFixtureServer();
+    try {
+        await assert.rejects(
+            () => callHuggingFaceAPI({
+                model: 'llm-truncated',
+                systemPrompt: 'sys',
+                userContent: 'user',
+                workerBase: fixture.workerBase,
+                maxTokens: 999,
+            }),
+            /ran out of output budget/
+        );
+    } finally {
+        await fixture.close();
+    }
+});
+
+test('callHuggingFaceAPI surfaces a 400 model-not-allowlisted error', async () => {
+    const fixture = await startFixtureServer();
+    try {
+        await assert.rejects(
+            () => callHuggingFaceAPI({ model: 'llm-not-allowlisted', systemPrompt: 'sys', userContent: 'user', workerBase: fixture.workerBase }),
+            /HuggingFace API request failed \(400\).*not in allowlist/
+        );
+    } finally {
+        await fixture.close();
+    }
+});
+
+test('callHuggingFaceAPI surfaces the local 429 rate limit', async () => {
+    const fixture = await startFixtureServer();
+    try {
+        await assert.rejects(
+            () => callHuggingFaceAPI({ model: 'llm-rate-limited', systemPrompt: 'sys', userContent: 'user', workerBase: fixture.workerBase }),
+            /API request failed \(429\)/
+        );
+    } finally {
+        await fixture.close();
+    }
+});
+
+// README: upstream 401/403 is deliberately remapped to 502 by tf-llm-router
+// itself (never passed through as 401/403), because that status describes
+// its own rejected credential, not the caller's. The client doesn't need to
+// know that remapping happened — it just needs to handle 502 like any other
+// 5xx — but pinning it here means a future change that accidentally passes
+// 401/403 straight through would show up as a client-side test failure too,
+// not just a server-side one.
+test('callHuggingFaceAPI surfaces tf-llm-router\'s 502-remapped upstream auth failure', async () => {
+    const fixture = await startFixtureServer();
+    try {
+        await assert.rejects(
+            () => callHuggingFaceAPI({ model: 'llm-upstream-auth-fail', systemPrompt: 'sys', userContent: 'user', workerBase: fixture.workerBase }),
+            /API request failed \(502\)/
+        );
+    } finally {
+        await fixture.close();
+    }
+});
+
+test('callHuggingFaceAPI passes through an unrelated upstream 503 verbatim', async () => {
+    const fixture = await startFixtureServer();
+    try {
+        await assert.rejects(
+            () => callHuggingFaceAPI({ model: 'llm-upstream-503', systemPrompt: 'sys', userContent: 'user', workerBase: fixture.workerBase }),
+            /API request failed \(503\)/
+        );
+    } finally {
+        await fixture.close();
+    }
+});
+
+test('callHuggingFaceAPI gives the size-cap-specific message on a 413', async () => {
+    const fixture = await startFixtureServer();
+    try {
+        await assert.rejects(
+            () => callHuggingFaceAPI({ model: 'llm-body-too-large', systemPrompt: 'sys', userContent: 'user', workerBase: fixture.workerBase }),
+            /the source is too large to send/
+        );
+    } finally {
+        await fixture.close();
+    }
+});

--- a/tests/source_fetcher_contract.test.js
+++ b/tests/source_fetcher_contract.test.js
@@ -1,0 +1,256 @@
+// Contract test for tf-source-fetcher (https://github.com/alex-o-748/tf-source-fetcher).
+//
+// Unlike tests/worker.test.js, which mocks globalThis.fetch with hand-shaped
+// response objects to exercise fetchSourceContent()'s own parsing logic, this
+// file spins up a *real* local HTTP server that implements tf-source-fetcher's
+// documented API verbatim (query shape, response shapes, and the
+// "Distinguishing refused from dead" status table — all copied from that
+// repo's README as of 2026-08-11) and points fetchSourceContent() at it over
+// real HTTP. The point is to catch drift between what that service's README
+// promises and what this client actually parses, independent of either
+// repo's own unit tests. If tf-source-fetcher's contract changes, update the
+// fixture responses here to match its new README before assuming this client
+// still works against it.
+//
+// service/extract-articles.js's --live-source-fetch flag is the only caller
+// of this contract in this repo today.
+
+import { test, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { fetchSourceContent } from '../core/worker.js';
+
+// Every failure case below makes fetchSourceContent() take its real Wayback
+// fallback path (core/worker.js calls out to archive.org's availability API
+// whenever the primary fetch returns no content). Left alone that would fire
+// real network requests to archive.org on every test in this file — slow,
+// flaky, and dependent on this sandbox's network policy for a test that has
+// nothing to do with Wayback. Intercept only that one endpoint and report "no
+// snapshot", exactly like tests/worker.test.js's
+// "skips Wayback fallback when no snapshot exists" case; every other request
+// (to the local fixture server below) goes over the real network stack
+// unmodified, since real HTTP round-tripping to the fixture is the point of
+// this file.
+let realFetch;
+beforeEach(() => {
+    realFetch = globalThis.fetch;
+    globalThis.fetch = (input, init) => {
+        const url = typeof input === 'string' ? input : input.url;
+        if (url.includes('archive.org/wayback/available')) {
+            return Promise.resolve({
+                ok: true,
+                status: 200,
+                json: async () => ({ archived_snapshots: {} }),
+            });
+        }
+        return realFetch(input, init);
+    };
+});
+afterEach(() => {
+    globalThis.fetch = realFetch;
+});
+
+// Routes a request to a fixture response by a marker in the target URL
+// (?fetch=...&page=...), mirroring the exact JSON shapes documented in
+// tf-source-fetcher's README.
+function startFixtureServer() {
+    const server = http.createServer((req, res) => {
+        const url = new URL(req.url, 'http://localhost');
+        const target = url.searchParams.get('fetch') || '';
+        const page = url.searchParams.get('page');
+
+        const send = (httpStatus, body) => {
+            const payload = JSON.stringify(body);
+            res.writeHead(httpStatus, {
+                'Content-Type': 'application/json; charset=utf-8',
+                'Content-Length': Buffer.byteLength(payload),
+                'Access-Control-Allow-Origin': '*',
+            });
+            res.end(payload);
+        };
+
+        // README: "Response — success"
+        if (target.includes('ok-page')) {
+            return send(200, {
+                content: 'y'.repeat(500),
+                error: null,
+                status: 200,
+                pdf: false,
+                totalPages: null,
+                page: null,
+                truncated: false,
+                fetched_at: '2026-08-11T06:00:00.000Z',
+                cached: false,
+            });
+        }
+
+        // README: "Response — success" for a paginated PDF.
+        if (target.includes('some.pdf')) {
+            return send(200, {
+                content: 'z'.repeat(500),
+                error: null,
+                status: 200,
+                pdf: true,
+                totalPages: 40,
+                page: page ? Number(page) : null,
+                truncated: false,
+                fetched_at: '2026-08-11T06:00:00.000Z',
+                cached: false,
+            });
+        }
+
+        // README: "Response — no usable content" (JS-only shell / login wall;
+        // fetched fine, extracted text was under 101 characters).
+        if (target.includes('empty-shell')) {
+            return send(200, {
+                content: null,
+                error: 'Source content was empty or too short to verify',
+                status: 200,
+            });
+        }
+
+        // README table: "Upstream returned a real HTTP status" — passed
+        // through unchanged, both in the body and as this service's own
+        // outer HTTP status.
+        if (target.includes('404-page')) {
+            return send(404, { content: null, error: 'Not Found', status: 404 });
+        }
+
+        // README table: "Blocked by the target host's robots.txt" — we never
+        // contacted the host; status is our own considered 403.
+        if (target.includes('robots-blocked')) {
+            return send(403, { content: null, error: 'Blocked by robots.txt', status: 403 });
+        }
+
+        // README table: "Throttled by our own per-host rate limiter" — 429,
+        // we never contacted the host this time.
+        if (target.includes('rate-limited')) {
+            return send(429, { content: null, error: 'Rate limited, try again shortly', status: 429 });
+        }
+
+        // README table: "Upstream unreachable (DNS failure, connection
+        // refused, timeout)" — status: null in the body is the documented
+        // signal for "we never got a response at all"; this service's own
+        // outer HTTP status is 502.
+        if (target.includes('unreachable-host')) {
+            return send(502, { content: null, error: 'DNS lookup failed', status: null });
+        }
+
+        return send(400, { content: null, error: `fixture has no route for ${target}`, status: 400 });
+    });
+
+    return new Promise((resolve) => {
+        server.listen(0, '127.0.0.1', () => {
+            const { port } = server.address();
+            resolve({
+                workerBase: `http://127.0.0.1:${port}`,
+                close: () => new Promise((r) => server.close(r)),
+            });
+        });
+    });
+}
+
+test('fetchSourceContent parses a successful tf-source-fetcher response', async () => {
+    const fixture = await startFixtureServer();
+    try {
+        const result = await fetchSourceContent('https://example.com/ok-page', null, { workerBase: fixture.workerBase });
+        assert.equal(result.error, null);
+        assert.equal(result.status, 200);
+        assert.ok(result.content.includes('Source URL: https://example.com/ok-page'));
+        assert.ok(result.content.includes('y'.repeat(500)));
+    } finally {
+        await fixture.close();
+    }
+});
+
+test('fetchSourceContent surfaces PDF metadata from tf-source-fetcher', async () => {
+    const fixture = await startFixtureServer();
+    try {
+        const result = await fetchSourceContent('https://example.com/some.pdf', 7, { workerBase: fixture.workerBase });
+        assert.equal(result.status, 200);
+        assert.ok(result.content.includes('PDF: 40 pages'));
+        assert.ok(result.content.includes('(extracted page 7)'));
+    } finally {
+        await fixture.close();
+    }
+});
+
+test('fetchSourceContent treats "no usable content" as unavailable, not an error state', async () => {
+    const fixture = await startFixtureServer();
+    try {
+        const result = await fetchSourceContent('https://example.com/empty-shell', null, { workerBase: fixture.workerBase });
+        assert.equal(result.content, null);
+        assert.equal(result.status, 200);
+        assert.match(result.error, /empty or too short/);
+    } finally {
+        await fixture.close();
+    }
+});
+
+test('fetchSourceContent passes through a real upstream 404 unchanged', async () => {
+    const fixture = await startFixtureServer();
+    try {
+        const result = await fetchSourceContent('https://example.com/404-page', null, { workerBase: fixture.workerBase });
+        assert.equal(result.content, null);
+        assert.equal(result.status, 404);
+        assert.equal(result.error, 'Not Found');
+    } finally {
+        await fixture.close();
+    }
+});
+
+test('fetchSourceContent reports a robots.txt block as status 403', async () => {
+    const fixture = await startFixtureServer();
+    try {
+        const result = await fetchSourceContent('https://example.com/robots-blocked', null, { workerBase: fixture.workerBase });
+        assert.equal(result.content, null);
+        assert.equal(result.status, 403);
+        assert.match(result.error, /robots\.txt/);
+    } finally {
+        await fixture.close();
+    }
+});
+
+test('fetchSourceContent reports the service\'s own rate limit as status 429', async () => {
+    const fixture = await startFixtureServer();
+    try {
+        const result = await fetchSourceContent('https://example.com/rate-limited', null, { workerBase: fixture.workerBase });
+        assert.equal(result.content, null);
+        assert.equal(result.status, 429);
+    } finally {
+        await fixture.close();
+    }
+});
+
+// Documents a real subtlety in the contract: the README says body `status:
+// null` means "we never got a response at all", and that this service's own
+// outer HTTP status is 502 in that case. fetchSourceContent() only reads
+// `data.status` and falls back to the proxy's own HTTP status when that
+// field isn't a number (core/worker.js: `typeof data.status === 'number'`) —
+// so an "unreachable host" from tf-source-fetcher surfaces to this client as
+// status 502, not status null. null status is reserved for when this
+// client's own request to tf-source-fetcher never got a response at all
+// (see tests/worker.test.js's "network failures" case). Pinning this here so
+// a future reader doesn't "fix" fetchSourceContent to pass through a literal
+// null and silently change what every caller sees for this case.
+test('fetchSourceContent surfaces tf-source-fetcher\'s "unreachable host" as status 502, not null', async () => {
+    const fixture = await startFixtureServer();
+    try {
+        const result = await fetchSourceContent('https://example.com/unreachable-host', null, { workerBase: fixture.workerBase });
+        assert.equal(result.content, null);
+        assert.equal(result.status, 502);
+    } finally {
+        await fixture.close();
+    }
+});
+
+test('fetchSourceContent never sends Google Books URLs to the fetcher at all', async () => {
+    const fixture = await startFixtureServer();
+    try {
+        const result = await fetchSourceContent('https://books.google.com/books?id=abc', null, { workerBase: fixture.workerBase });
+        assert.equal(result.content, null);
+        assert.match(result.error, /google books/i);
+    } finally {
+        await fixture.close();
+    }
+});


### PR DESCRIPTION
## Summary

Adds two new contract test suites that validate this client's integration with external Toolforge services by spinning up real local HTTP servers that implement their documented APIs verbatim. These tests catch drift between what those services' READMEs promise and what this client actually sends/parses, independent of either repo's own unit tests.

Also wires up opt-in live fetching of cited sources via tf-source-fetcher and experimental routing of LLM calls through tf-llm-router, with corresponding CLI flags for manual smoke testing.

## Key Changes

**New test files:**
- `tests/source_fetcher_contract.test.js` — Contract tests for tf-source-fetcher (https://github.com/alex-o-748/tf-source-fetcher)
  - Validates successful content fetching, PDF metadata handling, error cases (404, robots.txt blocks, rate limits, unreachable hosts)
  - Confirms Google Books URLs are rejected client-side without hitting the fetcher
  - Intercepts archive.org Wayback API calls to avoid real network requests while allowing real HTTP to the fixture server

- `tests/llm_router_contract.test.js` — Contract tests for tf-llm-router (https://github.com/alex-o-748/tf-llm-router)
  - Validates request shape (POST to /hf or /liftwing, correct message format, no Authorization header when no API key)
  - Tests success cases, truncation (finish_reason: 'length'), and error handling (400 model-not-allowlisted, 429 rate limit, 502 upstream auth failure, 413 body-too-large)
  - Documents the 502-remapping of upstream 401/403 to prevent accidental regressions

**Service integration updates:**
- `service/extract-articles.js` — Added `--live-source-fetch` flag to opt into real source fetching via tf-source-fetcher (defaults to stub)
  - Defines `TOOLFORGE_SOURCE_FETCHER_BASE` constant pointing to the Toolforge deployment
  - Implements `liveFetchSource()` and `describeSource()` helper functions
  - Updated help text to clarify that source fetching is opt-in pending WMCS clearance

- `cli/verify.js` — Added `--live-llm-router` flag for experimental routing through tf-llm-router
  - Defines `TOOLFORGE_LLM_ROUTER_BASE` constant
  - Passes `workerBase` to provider calls when the flag is set
  - Updated help text and examples

## Implementation Details

- Both test suites use `node:http` to start ephemeral local servers on random ports, avoiding port conflicts and cleanup issues
- Fixture servers route requests by markers in query parameters (`?fetch=...&page=...`) or request body (`model` field), mirroring the exact JSON shapes from each service's README
- The source-fetcher tests intercept only the archive.org Wayback API to prevent real network calls while allowing real HTTP to the fixture; all other requests use the real fetch stack
- Both flags are opt-in only: tf-source-fetcher because it's not yet WMCS-cleared for unattended production traffic; tf-llm-router because it's new and its Toolforge rate-limit behavior is still unverified
- No changes to the core fetching/provider logic itself — the contract tests validate the existing `fetchSourceContent()` and `callHuggingFaceAPI()`/`callLiftwingAPI()` implementations against real HTTP servers

https://claude.ai/code/session_01FcXoP4C4PVq8oLXeKBLbgA