### PR TITLE
Add Gemini 3.7 Flash provider to benchmark suite

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -10,6 +10,7 @@
     "extract:v3": "node extract_dataset.js --version v3",
     "benchmark": "node run_benchmark.js",
     "benchmark:publicai": "node run_benchmark.js --providers=publicai",
+    "benchmark:gemini-3.7-flash": "node run_benchmark.js --providers=gemini-3.7-flash",
     "benchmark:liftwing": "node run_benchmark.js --providers=liftwing-qwen3.6-27b",
     "benchmark:v1": "node run_benchmark.js --version v1",
     "benchmark:v3": "node run_benchmark.js --version v3",

--- a/benchmark/run_benchmark.js
+++ b/benchmark/run_benchmark.js
@@ -121,10 +121,24 @@ export const PROVIDERS = {
         effort: 'medium'
     },
     // Gemini
+    // gemini-2.5-flash is kept (not replaced) for frozen-snapshot reproducibility —
+    // analysis.json / results.json / the v1 and v3 snapshots all reference this
+    // provider key by name. Gemini 2.5 Flash is slated to shut down 2026-10-16.
     'gemini-2.5-flash': {
         name: 'Gemini 2.5 Flash',
         model: 'gemini-2.5-flash',
         endpoint: 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent',
+        requiresKey: true,
+        keyEnv: 'GEMINI_API_KEY',
+        type: 'gemini'
+    },
+    // Gemini 3.7 Flash is the current GA/stable Gemini Flash model (verified
+    // 2026-08-20 against ai.google.dev's model docs), pinned to a fixed
+    // dated model id rather than the `gemini-flash-latest` alias main.js uses.
+    'gemini-3.7-flash': {
+        name: 'Gemini 3.7 Flash',
+        model: 'gemini-3.7-flash',
+        endpoint: 'https://generativelanguage.googleapis.com/v1beta/models/gemini-3.7-flash:generateContent',
         requiresKey: true,
         keyEnv: 'GEMINI_API_KEY',
         type: 'gemini'


### PR DESCRIPTION
## Summary

Adds support for Gemini 3.7 Flash (the current GA/stable Gemini Flash model) to the benchmark suite while preserving the existing Gemini 2.5 Flash configuration for frozen-snapshot reproducibility.

## Changes

- **Added `gemini-3.7-flash` provider configuration** in `benchmark/run_benchmark.js`:
  - Pinned to the fixed dated model ID `gemini-3.7-flash` (verified 2026-08-20 against ai.google.dev docs)
  - Uses the same API endpoint pattern and authentication as other Gemini providers
  - Includes documentation explaining why 2.5 Flash is retained (referenced by name in frozen analysis.json / results.json / v1 and v3 snapshots)
  - Notes that Gemini 2.5 Flash is scheduled for shutdown on 2026-10-16

- **Added convenience npm script** in `benchmark/package.json`:
  - `npm run benchmark:gemini-3.7-flash` for running benchmarks against the new provider

## Implementation Details

The new provider follows the established pattern for Gemini models in the benchmark suite, with explicit documentation of the model's GA status and the rationale for keeping the older 2.5 Flash configuration intact (to avoid breaking reproducibility of historical benchmark snapshots).

https://claude.ai/code/session_01YRS5cgUVvxo5m6hfmcuwXf